### PR TITLE
:sparkles: support int8 and uint8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "argminmax"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Jeroen Van Der Donckt"]
 edition = "2021"
 readme = "README.md"
@@ -48,6 +48,10 @@ harness = false
 
 [[bench]]
 name = "bench_i64"
+harness = false
+
+[[bench]]
+name = "bench_u8"
 harness = false
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,10 @@ name = "bench_f64"
 harness = false
 
 [[bench]]
+name = "bench_i8"
+harness = false
+
+[[bench]]
 name = "bench_i16"
 harness = false
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # ArgMinMax
-> Efficient argmin &amp; argmax (in 1 function) with SIMD (SSE, AVX(2), AVX512, NEON) for `f16`, `f32`, `f64`, `i16`, `i32`, `i64`, `u16`, `u32`, `u64` on `ndarray::ArrayView1`
+> Efficient argmin &amp; argmax (in 1 function) with SIMD (SSE, AVX(2), AVX512, NEON) for `f16`, `f32`, `f64`, `i8`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64` on `ndarray::ArrayView1`
 
 <!-- This project uses [SIMD](https://en.wikipedia.org/wiki/Single_instruction,_multiple_data) to compute argmin and argmax in a single function.   -->
 
-🚀 The function is generic over the type of the array, so it can be used on an `ndarray::ArrayView1<T>` where `T` can be `f16`*, `f32`, `f64`, `i16`, `i32`, `i64`, `u16`, `u32`, `u64`.
+🚀 The function is generic over the type of the array, so it can be used on an `ndarray::ArrayView1<T>` where `T` can be `f16`*, `f32`, `f64`, `i8`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64`.
 
 ⚡ **Runtime CPU feature detection** is used to select the most efficient implementation for the current CPU. This means that the same binary can be used on different CPUs without recompilation. 
 
@@ -19,7 +19,7 @@ Add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-argminmax = "0.2"
+argminmax = "0.3"
 ```
 
 ## Example usage

--- a/benches/bench_i8.rs
+++ b/benches/bench_i8.rs
@@ -1,0 +1,188 @@
+#![feature(stdsimd)]
+
+#[macro_use]
+extern crate criterion;
+extern crate dev_utils;
+
+use argminmax::ArgMinMax;
+use criterion::{black_box, Criterion};
+use dev_utils::{config, utils};
+
+use argminmax::{ScalarArgMinMax, SCALAR};
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+use argminmax::{AVX2, AVX512, SIMD, SSE};
+#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+use argminmax::{NEON, SIMD};
+
+fn minmax_i8_random_array_long(c: &mut Criterion) {
+    let n = config::ARRAY_LENGTH_LONG;
+    let data = utils::get_random_array::<i8>(n, i8::MIN, i8::MAX);
+    c.bench_function("scalar_random_long_i8", |b| {
+        b.iter(|| SCALAR::argminmax(black_box(data.view())))
+    });
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    if is_x86_feature_detected!("sse4.1") {
+        c.bench_function("sse_random_long_i8", |b| {
+            b.iter(|| unsafe { SSE::argminmax(black_box(data.view())) })
+        });
+    }
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    if is_x86_feature_detected!("avx2") {
+        c.bench_function("avx2_random_long_i8", |b| {
+            b.iter(|| unsafe { AVX2::argminmax(black_box(data.view())) })
+        });
+    }
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    if is_x86_feature_detected!("avx512bw") {
+        c.bench_function("avx512_random_long_i8", |b| {
+            b.iter(|| unsafe { AVX512::argminmax(black_box(data.view())) })
+        });
+    }
+    #[cfg(target_arch = "arm")]
+    if std::arch::is_arm_feature_detected!("neon") {
+        c.bench_function("neon_random_long_i8", |b| {
+            b.iter(|| unsafe { NEON::argminmax(black_box(data.view())) })
+        });
+    }
+    #[cfg(target_arch = "aarch64")]
+    if std::arch::is_aarch64_feature_detected!("neon") {
+        c.bench_function("neon_random_long_i8", |b| {
+            b.iter(|| unsafe { NEON::argminmax(black_box(data.view())) })
+        });
+    }
+    c.bench_function("impl_random_long_i8", |b| {
+        b.iter(|| black_box(data.view().argminmax()))
+    });
+}
+
+fn minmax_i8_random_array_short(c: &mut Criterion) {
+    let n = config::ARRAY_LENGTH_SHORT;
+    let data = utils::get_random_array::<i8>(n, i8::MIN, i8::MAX);
+    c.bench_function("scalar_random_short_i8", |b| {
+        b.iter(|| SCALAR::argminmax(black_box(data.view())))
+    });
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    if is_x86_feature_detected!("sse4.1") {
+        c.bench_function("sse_random_short_i8", |b| {
+            b.iter(|| unsafe { SSE::argminmax(black_box(data.view())) })
+        });
+    }
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    if is_x86_feature_detected!("avx2") {
+        c.bench_function("avx2_random_short_i8", |b| {
+            b.iter(|| unsafe { AVX2::argminmax(black_box(data.view())) })
+        });
+    }
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    if is_x86_feature_detected!("avx512bw") {
+        c.bench_function("avx512_random_short_i8", |b| {
+            b.iter(|| unsafe { AVX512::argminmax(black_box(data.view())) })
+        });
+    }
+    #[cfg(target_arch = "arm")]
+    if std::arch::is_arm_feature_detected!("neon") {
+        c.bench_function("neon_random_short_i8", |b| {
+            b.iter(|| unsafe { NEON::argminmax(black_box(data.view())) })
+        });
+    }
+    #[cfg(target_arch = "aarch64")]
+    if std::arch::is_aarch64_feature_detected!("neon") {
+        c.bench_function("neon_random_short_i8", |b| {
+            b.iter(|| unsafe { NEON::argminmax(black_box(data.view())) })
+        });
+    }
+    c.bench_function("impl_random_short_i8", |b| {
+        b.iter(|| black_box(data.view().argminmax()))
+    });
+}
+
+fn minmax_i8_worst_case_array_long(c: &mut Criterion) {
+    let n = config::ARRAY_LENGTH_LONG;
+    let data = utils::get_worst_case_array::<i8>(n, 1);
+    c.bench_function("scalar_worst_long_i8", |b| {
+        b.iter(|| SCALAR::argminmax(black_box(data.view())))
+    });
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    if is_x86_feature_detected!("sse4.1") {
+        c.bench_function("sse_worst_long_i8", |b| {
+            b.iter(|| unsafe { SSE::argminmax(black_box(data.view())) })
+        });
+    }
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    if is_x86_feature_detected!("avx2") {
+        c.bench_function("avx2_worst_long_i8", |b| {
+            b.iter(|| unsafe { AVX2::argminmax(black_box(data.view())) })
+        });
+    }
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    if is_x86_feature_detected!("avx512bw") {
+        c.bench_function("avx512_worst_long_i8", |b| {
+            b.iter(|| unsafe { AVX512::argminmax(black_box(data.view())) })
+        });
+    }
+    #[cfg(target_arch = "arm")]
+    if std::arch::is_arm_feature_detected!("neon") {
+        c.bench_function("neon_worst_long_i8", |b| {
+            b.iter(|| unsafe { NEON::argminmax(black_box(data.view())) })
+        });
+    }
+    #[cfg(target_arch = "aarch64")]
+    if std::arch::is_aarch64_feature_detected!("neon") {
+        c.bench_function("neon_worst_long_i8", |b| {
+            b.iter(|| unsafe { NEON::argminmax(black_box(data.view())) })
+        });
+    }
+    c.bench_function("impl_worst_long_i8", |b| {
+        b.iter(|| black_box(data.view().argminmax()))
+    });
+}
+
+fn minmax_i8_worst_case_array_short(c: &mut Criterion) {
+    let n = config::ARRAY_LENGTH_SHORT;
+    let data = utils::get_worst_case_array::<i8>(n, 1);
+    c.bench_function("scalar_worst_short_i8", |b| {
+        b.iter(|| SCALAR::argminmax(black_box(data.view())))
+    });
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    if is_x86_feature_detected!("sse4.1") {
+        c.bench_function("sse_worst_short_i8", |b| {
+            b.iter(|| unsafe { SSE::argminmax(black_box(data.view())) })
+        });
+    }
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    if is_x86_feature_detected!("avx2") {
+        c.bench_function("avx2_worst_short_i8", |b| {
+            b.iter(|| unsafe { AVX2::argminmax(black_box(data.view())) })
+        });
+    }
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    if is_x86_feature_detected!("avx512bw") {
+        c.bench_function("avx512_worst_short_i8", |b| {
+            b.iter(|| unsafe { AVX512::argminmax(black_box(data.view())) })
+        });
+    }
+    #[cfg(target_arch = "arm")]
+    if std::arch::is_arm_feature_detected!("neon") {
+        c.bench_function("neon_worst_short_i8", |b| {
+            b.iter(|| unsafe { NEON::argminmax(black_box(data.view())) })
+        });
+    }
+    #[cfg(target_arch = "aarch64")]
+    if std::arch::is_aarch64_feature_detected!("neon") {
+        c.bench_function("neon_worst_short_i8", |b| {
+            b.iter(|| unsafe { NEON::argminmax(black_box(data.view())) })
+        });
+    }
+    c.bench_function("impl_worst_short_i8", |b| {
+        b.iter(|| black_box(data.view().argminmax()))
+    });
+}
+
+criterion_group!(
+    benches,
+    minmax_i8_random_array_long,
+    // minmax_i8_random_array_short,
+    // minmax_i8_worst_case_array_long,
+    // minmax_i8_worst_case_array_short
+);
+criterion_main!(benches);

--- a/benches/bench_u8.rs
+++ b/benches/bench_u8.rs
@@ -1,0 +1,188 @@
+#![feature(stdsimd)]
+
+#[macro_use]
+extern crate criterion;
+extern crate dev_utils;
+
+use argminmax::ArgMinMax;
+use criterion::{black_box, Criterion};
+use dev_utils::{config, utils};
+
+use argminmax::{ScalarArgMinMax, SCALAR};
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+use argminmax::{AVX2, AVX512, SIMD, SSE};
+#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+use argminmax::{NEON, SIMD};
+
+fn minmax_u8_random_array_long(c: &mut Criterion) {
+    let n = config::ARRAY_LENGTH_LONG;
+    let data = utils::get_random_array::<u8>(n, u8::MIN, u8::MAX);
+    c.bench_function("scalar_random_long_u8", |b| {
+        b.iter(|| SCALAR::argminmax(black_box(data.view())))
+    });
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    if is_x86_feature_detected!("sse4.1") {
+        c.bench_function("sse_random_long_u8", |b| {
+            b.iter(|| unsafe { SSE::argminmax(black_box(data.view())) })
+        });
+    }
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    if is_x86_feature_detected!("avx2") {
+        c.bench_function("avx2_random_long_u8", |b| {
+            b.iter(|| unsafe { AVX2::argminmax(black_box(data.view())) })
+        });
+    }
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    if is_x86_feature_detected!("avx512bw") {
+        c.bench_function("avx512_random_long_u8", |b| {
+            b.iter(|| unsafe { AVX512::argminmax(black_box(data.view())) })
+        });
+    }
+    #[cfg(target_arch = "arm")]
+    if std::arch::is_arm_feature_detected!("neon") {
+        c.bench_function("neon_random_long_u8", |b| {
+            b.iter(|| unsafe { NEON::argminmax(black_box(data.view())) })
+        });
+    }
+    #[cfg(target_arch = "aarch64")]
+    if std::arch::is_aarch64_feature_detected!("neon") {
+        c.bench_function("neon_random_long_u8", |b| {
+            b.iter(|| unsafe { NEON::argminmax(black_box(data.view())) })
+        });
+    }
+    c.bench_function("impl_random_long_u8", |b| {
+        b.iter(|| black_box(data.view().argminmax()))
+    });
+}
+
+fn minmax_u8_random_array_short(c: &mut Criterion) {
+    let n = config::ARRAY_LENGTH_SHORT;
+    let data = utils::get_random_array::<u8>(n, u8::MIN, u8::MAX);
+    c.bench_function("scalar_random_short_u8", |b| {
+        b.iter(|| SCALAR::argminmax(black_box(data.view())))
+    });
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    if is_x86_feature_detected!("sse4.1") {
+        c.bench_function("sse_random_short_u8", |b| {
+            b.iter(|| unsafe { SSE::argminmax(black_box(data.view())) })
+        });
+    }
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    if is_x86_feature_detected!("avx2") {
+        c.bench_function("avx2_random_short_u8", |b| {
+            b.iter(|| unsafe { AVX2::argminmax(black_box(data.view())) })
+        });
+    }
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    if is_x86_feature_detected!("avx512bw") {
+        c.bench_function("avx512_random_short_u8", |b| {
+            b.iter(|| unsafe { AVX512::argminmax(black_box(data.view())) })
+        });
+    }
+    #[cfg(target_arch = "arm")]
+    if std::arch::is_arm_feature_detected!("neon") {
+        c.bench_function("neon_random_short_u8", |b| {
+            b.iter(|| unsafe { NEON::argminmax(black_box(data.view())) })
+        });
+    }
+    #[cfg(target_arch = "aarch64")]
+    if std::arch::is_aarch64_feature_detected!("neon") {
+        c.bench_function("neon_random_short_u8", |b| {
+            b.iter(|| unsafe { NEON::argminmax(black_box(data.view())) })
+        });
+    }
+    c.bench_function("impl_random_short_u8", |b| {
+        b.iter(|| black_box(data.view().argminmax()))
+    });
+}
+
+fn minmax_u8_worst_case_array_long(c: &mut Criterion) {
+    let n = config::ARRAY_LENGTH_LONG;
+    let data = utils::get_worst_case_array::<u8>(n, 1);
+    c.bench_function("scalar_worst_long_u8", |b| {
+        b.iter(|| SCALAR::argminmax(black_box(data.view())))
+    });
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    if is_x86_feature_detected!("sse4.1") {
+        c.bench_function("sse_worst_long_u8", |b| {
+            b.iter(|| unsafe { SSE::argminmax(black_box(data.view())) })
+        });
+    }
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    if is_x86_feature_detected!("avx2") {
+        c.bench_function("avx2_worst_long_u8", |b| {
+            b.iter(|| unsafe { AVX2::argminmax(black_box(data.view())) })
+        });
+    }
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    if is_x86_feature_detected!("avx512bw") {
+        c.bench_function("avx512_worst_long_u8", |b| {
+            b.iter(|| unsafe { AVX512::argminmax(black_box(data.view())) })
+        });
+    }
+    #[cfg(target_arch = "arm")]
+    if std::arch::is_arm_feature_detected!("neon") {
+        c.bench_function("neon_worst_long_u8", |b| {
+            b.iter(|| unsafe { NEON::argminmax(black_box(data.view())) })
+        });
+    }
+    #[cfg(target_arch = "aarch64")]
+    if std::arch::is_aarch64_feature_detected!("neon") {
+        c.bench_function("neon_worst_long_u8", |b| {
+            b.iter(|| unsafe { NEON::argminmax(black_box(data.view())) })
+        });
+    }
+    c.bench_function("impl_worst_long_u8", |b| {
+        b.iter(|| black_box(data.view().argminmax()))
+    });
+}
+
+fn minmax_u8_worst_case_array_short(c: &mut Criterion) {
+    let n = config::ARRAY_LENGTH_SHORT;
+    let data = utils::get_worst_case_array::<u8>(n, 1);
+    c.bench_function("scalar_worst_short_u8", |b| {
+        b.iter(|| SCALAR::argminmax(black_box(data.view())))
+    });
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    if is_x86_feature_detected!("sse4.1") {
+        c.bench_function("sse_worst_short_u8", |b| {
+            b.iter(|| unsafe { SSE::argminmax(black_box(data.view())) })
+        });
+    }
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    if is_x86_feature_detected!("avx2") {
+        c.bench_function("avx2_worst_short_u8", |b| {
+            b.iter(|| unsafe { AVX2::argminmax(black_box(data.view())) })
+        });
+    }
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    if is_x86_feature_detected!("avx512bw") {
+        c.bench_function("avx512_worst_short_u8", |b| {
+            b.iter(|| unsafe { AVX512::argminmax(black_box(data.view())) })
+        });
+    }
+    #[cfg(target_arch = "arm")]
+    if std::arch::is_arm_feature_detected!("neon") {
+        c.bench_function("neon_worst_short_u8", |b| {
+            b.iter(|| unsafe { NEON::argminmax(black_box(data.view())) })
+        });
+    }
+    #[cfg(target_arch = "aarch64")]
+    if std::arch::is_aarch64_feature_detected!("neon") {
+        c.bench_function("neon_worst_short_u8", |b| {
+            b.iter(|| unsafe { NEON::argminmax(black_box(data.view())) })
+        });
+    }
+    c.bench_function("impl_worst_short_u8", |b| {
+        b.iter(|| black_box(data.view().argminmax()))
+    });
+}
+
+criterion_group!(
+    benches,
+    minmax_u8_random_array_long,
+    // minmax_u8_random_array_short,
+    // minmax_u8_worst_case_array_long,
+    // minmax_u8_worst_case_array_short
+);
+criterion_main!(benches);

--- a/benches/results
+++ b/benches/results
@@ -2,101 +2,121 @@
 
 ### Laptop: 11th Gen Intel i7-1185G7 (8) @ 4.800GHz
 
-scalar_random_long_f16  time:   [69.320 µs 69.351 µs 69.381 µs]
-sse_random_long_f16     time:   [11.450 µs 11.455 µs 11.460 µs]
-avx2_random_long_f16    time:   [7.4110 µs 7.4142 µs 7.4180 µs]
-avx512_random_long_f16  time:   [3.7895 µs 3.7990 µs 3.8110 µs]
-impl_random_long_f16    time:   [3.7037 µs 3.7060 µs 3.7086 µs]
+scalar_random_long_f16  time:   [67.045 µs 67.090 µs 67.143 µs]
+sse_random_long_f16     time:   [10.120 µs 10.126 µs 10.134 µs]
+avx2_random_long_f16    time:   [7.3271 µs 7.3303 µs 7.3339 µs]
+avx512_random_long_f16  time:   [4.0125 µs 4.0166 µs 4.0206 µs]
+impl_random_long_f16    time:   [3.9800 µs 3.9820 µs 3.9842 µs]
 
-scalar_random_long_f32  time:   [57.765 µs 57.799 µs 57.838 µs]
-sse_random_long_f32     time:   [37.059 µs 37.080 µs 37.107 µs]
-avx_random_long_f32     time:   [24.739 µs 24.746 µs 24.753 µs]
-avx512_random_long_f32  time:   [7.9029 µs 7.9086 µs 7.9165 µs]
-impl_random_long_f32    time:   [7.7441 µs 7.7604 µs 7.7828 µs]
+scalar_random_long_f32  time:   [57.434 µs 57.514 µs 57.616 µs]
+sse_random_long_f32     time:   [38.284 µs 38.312 µs 38.351 µs]
+avx_random_long_f32     time:   [24.109 µs 24.131 µs 24.159 µs]
+avx512_random_long_f32  time:   [7.8858 µs 7.8868 µs 7.8879 µs]
+impl_random_long_f32    time:   [7.5747 µs 7.5769 µs 7.5794 µs]
 
-scalar_random_long_f64  time:   [58.070 µs 58.095 µs 58.124 µs]
-sse_random_long_f64     time:   [74.636 µs 74.692 µs 74.765 µs]
-avx_random_long_f64     time:   [49.225 µs 49.251 µs 49.279 µs]
-avx512_random_long_f64  time:   [15.302 µs 15.305 µs 15.309 µs]
-impl_random_long_f64    time:   [15.135 µs 15.141 µs 15.147 µs]
+scalar_random_long_f64  time:   [57.431 µs 57.452 µs 57.476 µs]
+sse_random_long_f64     time:   [74.618 µs 74.639 µs 74.663 µs]
+avx_random_long_f64     time:   [48.175 µs 48.215 µs 48.265 µs]
+avx512_random_long_f64  time:   [14.721 µs 14.734 µs 14.752 µs]
+impl_random_long_f64    time:   [15.004 µs 15.007 µs 15.010 µs]
 
-scalar_random_long_i16  time:   [67.512 µs 67.751 µs 68.037 µs]
-sse_random_long_i16     time:   [8.6018 µs 8.6045 µs 8.6077 µs]
-avx2_random_long_i16    time:   [5.2666 µs 5.2898 µs 5.3187 µs]
-avx512_random_long_i16  time:   [3.1433 µs 3.1445 µs 3.1460 µs]
-impl_random_long_i16    time:   [3.1463 µs 3.1519 µs 3.1595 µs]
+scalar_random_long_i8   time:   [54.877 µs 54.895 µs 54.916 µs]
+sse_random_long_i8      time:   [11.854 µs 11.864 µs 11.875 µs]
+avx2_random_long_i8     time:   [14.008 µs 14.013 µs 14.019 µs]
+avx512_random_long_i8   time:   [15.079 µs 15.084 µs 15.091 µs]
+impl_random_long_i8     time:   [11.835 µs 11.846 µs 11.857 µs]
 
-scalar_random_long_i32  time:   [46.614 µs 46.690 µs 46.798 µs]
-sse_random_long_i32     time:   [16.443 µs 16.506 µs 16.585 µs]
-avx2_random_long_i32    time:   [10.645 µs 10.654 µs 10.665 µs]
-avx512_random_long_i32  time:   [5.7806 µs 5.7987 µs 5.8211 µs]
-impl_random_long_i32    time:   [5.9866 µs 5.9921 µs 5.9984 µs]
+scalar_random_long_i16  time:   [67.520 µs 67.663 µs 67.831 µs]
+sse_random_long_i16     time:   [8.1634 µs 8.1769 µs 8.1903 µs]
+avx2_random_long_i16    time:   [5.5039 µs 5.5078 µs 5.5122 µs]
+avx512_random_long_i16  time:   [3.1286 µs 3.1298 µs 3.1312 µs]
+impl_random_long_i16    time:   [3.1944 µs 3.1957 µs 3.1972 µs]
 
-scalar_random_long_i64  time:   [47.034 µs 47.062 µs 47.093 µs]
-sse_random_long_i64     time:   [57.309 µs 57.667 µs 57.989 µs]
-avx2_random_long_i64    time:   [39.665 µs 39.924 µs 40.384 µs]
-avx512_random_long_i64  time:   [14.814 µs 14.829 µs 14.851 µs]
-impl_random_long_i64    time:   [14.802 µs 14.809 µs 14.815 µs]
+scalar_random_long_i32  time:   [43.811 µs 43.834 µs 43.865 µs]
+sse_random_long_i32     time:   [15.945 µs 16.023 µs 16.102 µs]
+avx2_random_long_i32    time:   [10.510 µs 10.514 µs 10.517 µs]
+avx512_random_long_i32  time:   [5.8947 µs 5.8974 µs 5.9005 µs]
+impl_random_long_i32    time:   [5.5592 µs 5.5627 µs 5.5686 µs]
 
-scalar_random_long_u16  time:   [98.308 µs 98.410 µs 98.529 µs]  -> sneller?
-sse_random_long_u16     time:   [9.6338 µs 9.6389 µs 9.6462 µs]
-avx2_random_long_u16    time:   [5.8723 µs 5.8992 µs 5.9329 µs]
-avx512_random_long_u16  time:   [3.3129 µs 3.3231 µs 3.3356 µs]
-impl_random_long_u16    time:   [3.4282 µs 3.4300 µs 3.4322 µs]
+scalar_random_long_i64  time:   [46.211 µs 46.252 µs 46.301 µs]
+sse_random_long_i64     time:   [54.677 µs 54.706 µs 54.746 µs]
+avx2_random_long_i64    time:   [38.602 µs 38.618 µs 38.639 µs]
+avx512_random_long_i64  time:   [14.926 µs 14.930 µs 14.934 µs]
+impl_random_long_i64    time:   [14.297 µs 14.308 µs 14.322 µs]
 
-scalar_random_long_u32  time:   [67.529 µs 67.582 µs 67.640 µs]
-sse_random_long_u32     time:   [19.222 µs 19.236 µs 19.252 µs]
-avx2_random_long_u32    time:   [12.061 µs 12.066 µs 12.071 µs]
-avx512_random_long_u32  time:   [6.5644 µs 6.5681 µs 6.5726 µs]
-impl_random_long_u32    time:   [6.5856 µs 6.5879 µs 6.5904 µs]
+scalar_random_long_u8   time:   [80.157 µs 80.265 µs 80.376 µs]
+sse_random_long_u8      time:   [12.081 µs 12.090 µs 12.101 µs]
+avx2_random_long_u8     time:   [14.453 µs 14.463 µs 14.473 µs]
+avx512_random_long_u8   time:   [15.489 µs 15.496 µs 15.503 µs]
+impl_random_long_u8     time:   [12.678 µs 12.685 µs 12.693 µs]
 
-scalar_random_long_u64  time:   [67.260 µs 67.332 µs 67.413 µs]
-sse_random_long_u64     time:   [55.768 µs 55.830 µs 55.905 µs]
-avx2_random_long_u64    time:   [40.109 µs 40.141 µs 40.178 µs]
-avx512_random_long_u64  time:   [15.352 µs 15.367 µs 15.387 µs]
-impl_random_long_u64    time:   [15.363 µs 15.371 µs 15.381 µs]
+scalar_random_long_u16  time:   [90.227 µs 90.249 µs 90.275 µs] -> sneller?
+sse_random_long_u16     time:   [8.2780 µs 8.2808 µs 8.2839 µs]
+avx2_random_long_u16    time:   [5.7641 µs 5.7665 µs 5.7686 µs]
+avx512_random_long_u16  time:   [3.4283 µs 3.4302 µs 3.4323 µs]
+impl_random_long_u16    time:   [3.3348 µs 3.3375 µs 3.3416 µs]
+
+scalar_random_long_u32  time:   [66.721 µs 66.752 µs 66.788 µs]
+sse_random_long_u32     time:   [16.437 µs 16.454 µs 16.475 µs]
+avx2_random_long_u32    time:   [11.280 µs 11.283 µs 11.286 µs]
+avx512_random_long_u32  time:   [6.1891 µs 6.1939 µs 6.2013 µs]
+impl_random_long_u32    time:   [6.5594 µs 6.5636 µs 6.5683 µs]
+
+scalar_random_long_u64  time:   [66.776 µs 66.900 µs 67.052 µs]
+sse_random_long_u64     time:   [54.894 µs 54.916 µs 54.943 µs]
+avx2_random_long_u64    time:   [37.903 µs 37.940 µs 37.991 µs]
+avx512_random_long_u64  time:   [14.702 µs 14.709 µs 14.717 µs]
+impl_random_long_u64    time:   [15.040 µs 15.046 µs 15.054 µs]
 
 ----
 
 ### Server: Intel Xeon E5-2650 v2 (32) @ 3.400GHz
 
-scalar_random_long_f16  time:   [124.96 µs 125.02 µs 125.10 µs]
-sse_random_long_f16     time:   [21.346 µs 21.367 µs 21.397 µs]
-impl_random_long_f16    time:   [21.361 µs 21.380 µs 21.402 µs]
+scalar_random_long_f16  time:   [124.98 µs 125.05 µs 125.13 µs]
+sse_random_long_f16     time:   [21.559 µs 21.565 µs 21.571 µs]
+impl_random_long_f16    time:   [21.572 µs 21.578 µs 21.585 µs]
 
-scalar_random_long_f32  time:   [91.359 µs 91.410 µs 91.467 µs]
-sse_random_long_f32     time:   [53.526 µs 53.542 µs 53.558 µs]
-avx_random_long_f32     time:   [27.533 µs 27.542 µs 27.552 µs]
-impl_random_long_f32    time:   [27.603 µs 27.613 µs 27.625 µs]
+scalar_random_long_f32  time:   [98.079 µs 98.143 µs 98.221 µs]
+sse_random_long_f32     time:   [54.766 µs 54.788 µs 54.812 µs]
+avx_random_long_f32     time:   [27.565 µs 27.575 µs 27.586 µs]
+impl_random_long_f32    time:   [27.567 µs 27.578 µs 27.591 µs]
 
-scalar_random_long_f64  time:   [98.929 µs 98.977 µs 99.047 µs]
-sse_random_long_f64     time:   [112.39 µs 112.43 µs 112.47 µs]
-avx_random_long_f64     time:   [55.176 µs 55.201 µs 55.228 µs]
-impl_random_long_f64    time:   [55.142 µs 55.162 µs 55.187 µs]
+scalar_random_long_f64  time:   [93.482 µs 93.608 µs 93.753 µs]
+sse_random_long_f64     time:   [112.40 µs 112.44 µs 112.48 µs]
+avx_random_long_f64     time:   [55.188 µs 55.205 µs 55.225 µs]
+impl_random_long_f64    time:   [55.193 µs 55.220 µs 55.249 µs]
 
-scalar_random_long_i16  time:   [114.29 µs 114.32 µs 114.35 µs]
-sse_random_long_i16     time:   [18.933 µs 18.940 µs 18.947 µs]
-impl_random_long_i16    time:   [18.935 µs 18.944 µs 18.953 µs]
+scalar_random_long_i8   time:   [111.68 µs 111.73 µs 111.77 µs]
+sse_random_long_i8      time:   [23.394 µs 23.398 µs 23.403 µs]
+impl_random_long_i8     time:   [23.301 µs 23.305 µs 23.309 µs]
 
-scalar_random_long_i32  time:   [106.56 µs 106.61 µs 106.66 µs]
-sse_random_long_i32     time:   [35.754 µs 35.769 µs 35.788 µs]
-impl_random_long_i32    time:   [35.740 µs 35.752 µs 35.764 µs]
+scalar_random_long_i16  time:   [114.27 µs 114.31 µs 114.36 µs]
+sse_random_long_i16     time:   [19.041 µs 19.047 µs 19.052 µs]
+impl_random_long_i16    time:   [19.050 µs 19.057 µs 19.064 µs]
 
-scalar_random_long_i64  time:   [106.60 µs 106.63 µs 106.67 µs]
-sse_random_long_i64     time:   [165.96 µs 166.03 µs 166.12 µs]
-impl_random_long_i64    time:   [106.48 µs 106.53 µs 106.60 µs]
+scalar_random_long_i32  time:   [106.54 µs 106.58 µs 106.62 µs]
+sse_random_long_i32     time:   [33.426 µs 33.443 µs 33.460 µs]
+impl_random_long_i32    time:   [33.423 µs 33.438 µs 33.457 µs]
 
-scalar_random_long_u16  time:   [137.29 µs 137.38 µs 137.50 µs]
-sse_random_long_u16     time:   [18.941 µs 18.950 µs 18.961 µs]
-impl_random_long_u16    time:   [18.930 µs 18.935 µs 18.940 µs]
+scalar_random_long_i64  time:   [106.66 µs 106.70 µs 106.74 µs]
+sse_random_long_i64     time:   [166.21 µs 166.27 µs 166.33 µs]
+impl_random_long_i64    time:   [106.67 µs 106.71 µs 106.77 µs]
 
-scalar_random_long_u32  time:   [135.93 µs 135.97 µs 136.00 µs]
-sse_random_long_u32     time:   [35.453 µs 35.475 µs 35.505 µs]
-impl_random_long_u32    time:   [35.370 µs 35.387 µs 35.407 µs]
+scalar_random_long_u8   time:   [139.28 µs 139.31 µs 139.35 µs]
+sse_random_long_u8      time:   [24.055 µs 24.061 µs 24.067 µs]
+impl_random_long_u8     time:   [24.049 µs 24.053 µs 24.058 µs]
 
-scalar_random_long_u64  time:   [135.98 µs 136.03 µs 136.09 µs]
-sse_random_long_u64     time:   [189.44 µs 189.51 µs 189.59 µs]
-impl_random_long_u64    time:   [136.01 µs 136.07 µs 136.14 µs]
+scalar_random_long_u16  time:   [137.21 µs 137.25 µs 137.29 µs]
+sse_random_long_u16     time:   [19.037 µs 19.045 µs 19.054 µs]
+impl_random_long_u16    time:   [19.040 µs 19.046 µs 19.053 µs]
+
+scalar_random_long_u32  time:   [135.97 µs 136.06 µs 136.17 µs]
+sse_random_long_u32     time:   [36.288 µs 36.299 µs 36.311 µs]
+impl_random_long_u32    time:   [36.265 µs 36.280 µs 36.295 µs]
+
+scalar_random_long_u64  time:   [135.94 µs 135.98 µs 136.02 µs]
+sse_random_long_u64     time:   [189.34 µs 189.42 µs 189.49 µs]
+impl_random_long_u64    time:   [135.96 µs 136.02 µs 136.09 µs]
 
 
 
@@ -106,38 +126,46 @@ impl_random_long_u64    time:   [136.01 µs 136.07 µs 136.14 µs]
 
 ### Raspberry Pi 3B v1.2 (ARMv7 Processor rev 4 (v7l))
 
-scalar_random_long_f16  time:   [856.07 µs 856.20 µs 856.39 µs]
-neon_random_long_f16    time:   [550.08 µs 550.34 µs 550.65 µs]
-impl_random_long_f16    time:   [528.85 µs 529.29 µs 529.83 µs]
+scalar_random_long_f16  time:   [855.10 µs 855.38 µs 855.93 µs]
+neon_random_long_f16    time:   [528.80 µs 529.19 µs 529.93 µs]
+impl_random_long_f16    time:   [548.74 µs 548.79 µs 548.84 µs]
 
-scalar_random_long_f32  time:   [775.65 µs 776.50 µs 777.64 µs]
-neon_random_long_f32    time:   [1.0195 ms 1.0209 ms 1.0231 ms]
-impl_random_long_f32    time:   [776.35 µs 777.46 µs 778.87 µs]
+scalar_random_long_f32  time:   [777.12 µs 777.32 µs 777.54 µs]
+neon_random_long_f32    time:   [1.0013 ms 1.0016 ms 1.0020 ms]
+impl_random_long_f32    time:   [776.10 µs 777.05 µs 778.29 µs]
 
-scalar_random_long_f64  time:   [730.05 µs 731.05 µs 732.29 µs]
-impl_random_long_f64    time:   [735.02 µs 735.87 µs 736.84 µs]
+scalar_random_long_f64  time:   [737.34 µs 739.08 µs 740.88 µs]
+impl_random_long_f64    time:   [731.59 µs 732.29 µs 733.00 µs]
 
-scalar_random_long_i16  time:   [688.45 µs 688.75 µs 689.06 µs]
-neon_random_long_i16    time:   [533.24 µs 533.48 µs 533.73 µs]
-impl_random_long_i16    time:   [510.81 µs 511.47 µs 512.28 µs]
+scalar_random_long_i8   time:   [687.17 µs 688.10 µs 689.08 µs]
+neon_random_long_i8     time:   [450.31 µs 450.40 µs 450.50 µs]
+impl_random_long_i8     time:   [437.06 µs 437.14 µs 437.24 µs]
 
-scalar_random_long_i32  time:   [518.58 µs 518.98 µs 519.39 µs]
-neon_random_long_i32    time:   [1.0591 ms 1.0594 ms 1.0596 ms]
-impl_random_long_i32    time:   [518.30 µs 519.03 µs 519.93 µs]
+scalar_random_long_i16  time:   [684.97 µs 685.39 µs 686.16 µs]
+neon_random_long_i16    time:   [518.03 µs 518.07 µs 518.11 µs]
+impl_random_long_i16    time:   [500.61 µs 500.69 µs 500.77 µs]
 
-scalar_random_long_i64  time:   [1.1611 ms 1.1620 ms 1.1630 ms]
-impl_random_long_i64    time:   [1.1616 ms 1.1624 ms 1.1632 ms]
+scalar_random_long_i32  time:   [519.78 µs 520.71 µs 521.66 µs]
+neon_random_long_i32    time:   [1.0207 ms 1.0210 ms 1.0213 ms]
+impl_random_long_i32    time:   [519.82 µs 520.82 µs 521.82 µs]
 
-scalar_random_long_u16  time:   [688.35 µs 688.61 µs 688.87 µs]
-neon_random_long_u16    time:   [529.17 µs 529.24 µs 529.31 µs]
-impl_random_long_u16    time:   [511.75 µs 512.01 µs 512.29 µs]
+scalar_random_long_i64  time:   [1.1529 ms 1.1533 ms 1.1536 ms]
+impl_random_long_i64    time:   [1.1591 ms 1.1595 ms 1.1600 ms]
 
-scalar_random_long_u32  time:   [517.05 µs 517.40 µs 517.80 µs]
-neon_random_long_u32    time:   [1.0579 ms 1.0582 ms 1.0584 ms]
-impl_random_long_u32    time:   [517.63 µs 517.74 µs 517.84 µs]
+scalar_random_long_u8   time:   [687.11 µs 687.21 µs 687.31 µs]
+neon_random_long_u8     time:   [354.93 µs 354.98 µs 355.04 µs] -> veel sneller dan i8
+impl_random_long_u8     time:   [343.60 µs 344.13 µs 344.66 µs]
 
-scalar_random_long_u64  time:   [1.1607 ms 1.1632 ms 1.1675 ms]
-impl_random_long_u64    time:   [1.1592 ms 1.1619 ms 1.1652 ms]
+scalar_random_long_u16  time:   [684.65 µs 684.69 µs 684.74 µs]
+neon_random_long_u16    time:   [516.20 µs 516.29 µs 516.38 µs]
+impl_random_long_u16    time:   [496.21 µs 496.28 µs 496.36 µs]
+
+scalar_random_long_u32  time:   [518.33 µs 519.35 µs 520.45 µs]
+neon_random_long_u32    time:   [1.0232 ms 1.0253 ms 1.0274 ms]
+impl_random_long_u32    time:   [518.50 µs 518.96 µs 519.49 µs]
+
+scalar_random_long_u64  time:   [1.1652 ms 1.1678 ms 1.1703 ms]
+impl_random_long_u64    time:   [1.1641 ms 1.1665 ms 1.1689 ms]
 
 
 Remarks:
@@ -152,38 +180,46 @@ Remarks:
 
 ### Raspberry Pi 4B v1.1 (AArch64 Processor rev 4 (aarch64))
 
-scalar_random_long_f16  time:   [343.87 µs 343.90 µs 343.95 µs]
-neon_random_long_f16    time:   [96.913 µs 96.927 µs 96.945 µs]
-impl_random_long_f16    time:   [96.939 µs 96.963 µs 96.992 µs]
+scalar_random_long_f16  time:   [343.74 µs 343.75 µs 343.77 µs]
+neon_random_long_f16    time:   [96.912 µs 96.935 µs 96.970 µs]
+impl_random_long_f16    time:   [96.941 µs 96.963 µs 96.994 µs]
 
-scalar_random_long_f32  time:   [209.96 µs 210.03 µs 210.10 µs]
-neon_random_long_f32    time:   [149.40 µs 149.60 µs 149.86 µs]
-impl_random_long_f32    time:   [149.68 µs 149.80 µs 149.93 µs]
+scalar_random_long_f32  time:   [209.76 µs 209.82 µs 209.91 µs]
+neon_random_long_f32    time:   [148.95 µs 149.05 µs 149.22 µs]
+impl_random_long_f32    time:   [148.94 µs 148.97 µs 148.99 µs]
 
-scalar_random_long_f64  time:   [241.56 µs 241.87 µs 242.18 µs]
-impl_random_long_f64    time:   [241.48 µs 241.78 µs 242.08 µs]
+scalar_random_long_f64  time:   [244.41 µs 244.62 µs 244.85 µs]
+impl_random_long_f64    time:   [244.76 µs 245.10 µs 245.44 µs]
 
-scalar_random_long_i16  time:   [274.92 µs 274.94 µs 274.97 µs]
-neon_random_long_i16    time:   [55.036 µs 55.055 µs 55.084 µs]
-impl_random_long_i16    time:   [54.987 µs 54.993 µs 55.001 µs]
+scalar_random_long_i8   time:   [274.41 µs 274.41 µs 274.41 µs]
+neon_random_long_i8     time:   [79.214 µs 79.219 µs 79.225 µs]
+impl_random_long_i8     time:   [79.172 µs 79.179 µs 79.191 µs]
 
-scalar_random_long_i32  time:   [242.40 µs 242.45 µs 242.50 µs]
-neon_random_long_i32    time:   [106.25 µs 106.31 µs 106.39 µs]
-impl_random_long_i32    time:   [106.32 µs 106.37 µs 106.42 µs]
+scalar_random_long_i16  time:   [274.98 µs 274.98 µs 274.99 µs]
+neon_random_long_i16    time:   [54.987 µs 54.988 µs 54.990 µs]
+impl_random_long_i16    time:   [54.990 µs 54.993 µs 54.995 µs]
 
-scalar_random_long_i64  time:   [270.37 µs 270.61 µs 270.84 µs]
-impl_random_long_i64    time:   [270.45 µs 270.72 µs 271.00 µs]
+scalar_random_long_i32  time:   [242.26 µs 242.27 µs 242.28 µs]
+neon_random_long_i32    time:   [106.21 µs 106.22 µs 106.22 µs]
+impl_random_long_i32    time:   [106.29 µs 106.30 µs 106.30 µs]
 
-scalar_random_long_u16  time:   [274.93 µs 275.00 µs 275.08 µs]
-neon_random_long_u16    time:   [54.712 µs 54.724 µs 54.740 µs]
-impl_random_long_u16    time:   [54.679 µs 54.684 µs 54.690 µs]
+scalar_random_long_i64  time:   [273.56 µs 273.89 µs 274.23 µs]
+impl_random_long_i64    time:   [272.86 µs 273.11 µs 273.37 µs]
 
-scalar_random_long_u32  time:   [242.49 µs 242.58 µs 242.70 µs]
-neon_random_long_u32    time:   [106.46 µs 106.52 µs 106.59 µs]
-impl_random_long_u32    time:   [106.50 µs 106.62 µs 106.76 µs]
+scalar_random_long_u8   time:   [274.36 µs 274.37 µs 274.38 µs]
+neon_random_long_u8     time:   [52.818 µs 52.821 µs 52.828 µs]
+impl_random_long_u8     time:   [52.972 µs 52.976 µs 52.980 µs]
 
-scalar_random_long_u64  time:   [270.92 µs 271.23 µs 271.52 µs]
-impl_random_long_u64    time:   [269.62 µs 269.88 µs 270.14 µs]
+scalar_random_long_u16  time:   [274.94 µs 274.94 µs 274.95 µs]
+neon_random_long_u16    time:   [54.615 µs 54.624 µs 54.635 µs]
+impl_random_long_u16    time:   [54.614 µs 54.618 µs 54.624 µs]
+
+scalar_random_long_u32  time:   [242.26 µs 242.27 µs 242.29 µs]
+neon_random_long_u32    time:   [106.24 µs 106.27 µs 106.30 µs]
+impl_random_long_u32    time:   [106.26 µs 106.27 µs 106.28 µs]
+
+scalar_random_long_u64  time:   [267.46 µs 267.74 µs 268.02 µs]
+impl_random_long_u64    time:   [268.66 µs 268.88 µs 269.11 µs]
 
 
 Remarks:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,9 +152,9 @@ macro_rules! impl_argminmax {
 }
 
 // Implement ArgMinMax for the rust primitive types
-impl_nb_bits!(false, i8 i16 i32 i64 u16 u32 u64);
+impl_nb_bits!(false, i8 i16 i32 i64 u8 u16 u32 u64);
 impl_nb_bits!(true, f32 f64);
-impl_argminmax!(i8, i16, i32, i64, f32, f64, u16, u32, u64);
+impl_argminmax!(i8, i16, i32, i64, f32, f64, u8, u16, u32, u64);
 
 // Implement ArgMinMax for other data types
 #[cfg(feature = "half")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,9 +149,9 @@ macro_rules! impl_argminmax {
 }
 
 // Implement ArgMinMax for the rust primitive types
-impl_nb_bits!(false, u16 u32 u64 i16 i32 i64);
+impl_nb_bits!(false, i8 i16 i32 i64 u16 u32 u64);
 impl_nb_bits!(true, f32 f64);
-impl_argminmax!(i16, i32, i64, f32, f64, u16, u32, u64);
+impl_argminmax!(i8, i16, i32, i64, f32, f64, u16, u32, u64);
 
 // Implement ArgMinMax for other data types
 #[cfg(feature = "half")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,8 +107,11 @@ macro_rules! impl_argminmax {
                 fn argminmax(self) -> (usize, usize) {
                     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
                     {
-                        if is_x86_feature_detected!("avx512bw") & (<$t>::NB_BITS <= 16) {
-                            // BW (ByteWord) instructions are needed for 16-bit avx512
+                        if is_x86_feature_detected!("sse4.1") & (<$t>::NB_BITS == 8) {
+                            // 8-bit numbers are best handled by SSE4.1
+                            return unsafe { SSE::argminmax(self) }
+                        } else if is_x86_feature_detected!("avx512bw") & (<$t>::NB_BITS <= 16) {
+                            // BW (ByteWord) instructions are needed for 8 or 16-bit avx512
                             return unsafe { AVX512::argminmax(self) }
                         } else if is_x86_feature_detected!("avx512f") {  // TODO: check if avx512bw is included in avx512f
                             return unsafe { AVX512::argminmax(self) }

--- a/src/scalar/generic.rs
+++ b/src/scalar/generic.rs
@@ -89,6 +89,6 @@ macro_rules! impl_scalar {
     };
 }
 
-impl_scalar!(scalar_argminmax, i16, i32, i64, u16, u32, u64, f32, f64);
+impl_scalar!(scalar_argminmax, i8, i16, i32, i64, u16, u32, u64, f32, f64);
 #[cfg(feature = "half")]
 impl_scalar!(scalar_argminmax_f16, f16);

--- a/src/scalar/generic.rs
+++ b/src/scalar/generic.rs
@@ -89,6 +89,18 @@ macro_rules! impl_scalar {
     };
 }
 
-impl_scalar!(scalar_argminmax, i8, i16, i32, i64, u16, u32, u64, f32, f64);
+impl_scalar!(
+    scalar_argminmax,
+    i8,
+    i16,
+    i32,
+    i64,
+    u8,
+    u16,
+    u32,
+    u64,
+    f32,
+    f64
+);
 #[cfg(feature = "half")]
 impl_scalar!(scalar_argminmax_f16, f16);

--- a/src/simd/config.rs
+++ b/src/simd/config.rs
@@ -4,6 +4,7 @@ pub trait SIMDInstructionSet {
     const REGISTER_SIZE: usize;
 
     // Set the const lanesize for each datatype
+    const LANE_SIZE_8: usize = Self::REGISTER_SIZE / (std::mem::size_of::<u8>() * 8);
     const LANE_SIZE_16: usize = Self::REGISTER_SIZE / (std::mem::size_of::<u16>() * 8);
     const LANE_SIZE_32: usize = Self::REGISTER_SIZE / (std::mem::size_of::<u32>() * 8);
     const LANE_SIZE_64: usize = Self::REGISTER_SIZE / (std::mem::size_of::<u64>() * 8);
@@ -74,6 +75,14 @@ mod tests {
     }
 
     #[test]
+    fn test_lane_size_i8() {
+        assert_eq!(AVX2::get_lane_size::<i8>(), 32);
+        assert_eq!(AVX512::get_lane_size::<i8>(), 64);
+        assert_eq!(NEON::get_lane_size::<i8>(), 16);
+        assert_eq!(SSE::get_lane_size::<i8>(), 16);
+    }
+
+    #[test]
     fn test_lane_size_i16() {
         assert_eq!(AVX2::get_lane_size::<i16>(), 16);
         assert_eq!(AVX512::get_lane_size::<i16>(), 32);
@@ -95,5 +104,37 @@ mod tests {
         assert_eq!(AVX512::get_lane_size::<i64>(), 8);
         assert_eq!(NEON::get_lane_size::<i64>(), 2);
         assert_eq!(SSE::get_lane_size::<i64>(), 2);
+    }
+
+    #[test]
+    fn test_lane_size_u8() {
+        assert_eq!(AVX2::get_lane_size::<u8>(), 32);
+        assert_eq!(AVX512::get_lane_size::<u8>(), 64);
+        assert_eq!(NEON::get_lane_size::<u8>(), 16);
+        assert_eq!(SSE::get_lane_size::<u8>(), 16);
+    }
+
+    #[test]
+    fn test_lane_size_u16() {
+        assert_eq!(AVX2::get_lane_size::<u16>(), 16);
+        assert_eq!(AVX512::get_lane_size::<u16>(), 32);
+        assert_eq!(NEON::get_lane_size::<u16>(), 8);
+        assert_eq!(SSE::get_lane_size::<u16>(), 8);
+    }
+
+    #[test]
+    fn test_lane_size_u32() {
+        assert_eq!(AVX2::get_lane_size::<u32>(), 8);
+        assert_eq!(AVX512::get_lane_size::<u32>(), 16);
+        assert_eq!(NEON::get_lane_size::<u32>(), 4);
+        assert_eq!(SSE::get_lane_size::<u32>(), 4);
+    }
+
+    #[test]
+    fn test_lane_size_u64() {
+        assert_eq!(AVX2::get_lane_size::<u64>(), 4);
+        assert_eq!(AVX512::get_lane_size::<u64>(), 8);
+        assert_eq!(NEON::get_lane_size::<u64>(), 2);
+        assert_eq!(SSE::get_lane_size::<u64>(), 2);
     }
 }

--- a/src/simd/generic.rs
+++ b/src/simd/generic.rs
@@ -6,7 +6,7 @@ use num_traits::AsPrimitive;
 use crate::scalar::{ScalarArgMinMax, SCALAR};
 
 // TODO: other potential generic SIMDIndexDtype: Copy
-#[allow(clippy::missing_safety_doc)]  // TODO: add safety docs?
+#[allow(clippy::missing_safety_doc)] // TODO: add safety docs?
 pub trait SIMD<
     ScalarDType: Copy + PartialOrd + AsPrimitive<usize>,
     SIMDVecDtype: Copy,

--- a/src/simd/generic.rs
+++ b/src/simd/generic.rs
@@ -44,6 +44,7 @@ pub trait SIMD<
         // to avoid overflow.
         // To tackle this bottleneck, we use a different approach for 8-bit data types:
         // -> we overwrite this method to perform (in SIMD) the horizontal min
+        //    see: https://stackoverflow.com/a/9798369
         // Note: this is not a bottleneck for 16-bit data types, as the termination of
         // the SIMD inner loop is 2**8 times less frequent.
         let index_arr = Self::_reg_to_arr(index);
@@ -59,6 +60,7 @@ pub trait SIMD<
         // to avoid overflow.
         // To tackle this bottleneck, we use a different approach for 8-bit data types:
         // -> we overwrite this method to perform (in SIMD) the horizontal max
+        //    see: https://stackoverflow.com/a/9798369
         // Note: this is not a bottleneck for 16-bit data types, as the termination of
         // the SIMD inner loop is 2**8 times less frequent.
         let index_arr = Self::_reg_to_arr(index);

--- a/src/simd/generic.rs
+++ b/src/simd/generic.rs
@@ -6,6 +6,7 @@ use num_traits::AsPrimitive;
 use crate::scalar::{ScalarArgMinMax, SCALAR};
 
 // TODO: other potential generic SIMDIndexDtype: Copy
+#[allow(clippy::missing_safety_doc)]  // TODO: add safety docs?
 pub trait SIMD<
     ScalarDType: Copy + PartialOrd + AsPrimitive<usize>,
     SIMDVecDtype: Copy,
@@ -37,7 +38,7 @@ pub trait SIMD<
 
     unsafe fn _mm_blendv(a: SIMDVecDtype, b: SIMDVecDtype, mask: SIMDMaskDtype) -> SIMDVecDtype;
 
-    // #[inline(always)]
+    #[inline(always)]
     unsafe fn _horiz_min(index: SIMDVecDtype, value: SIMDVecDtype) -> (usize, ScalarDType) {
         // This becomes the bottleneck when using 8-bit data types, as for  every 2**7
         // or 2**8 elements, the SIMD inner loop is executed (& thus also terminated)
@@ -53,7 +54,7 @@ pub trait SIMD<
         (min_index.as_(), min_value)
     }
 
-    // #[inline(always)]
+    #[inline(always)]
     unsafe fn _horiz_max(index: SIMDVecDtype, value: SIMDVecDtype) -> (usize, ScalarDType) {
         // This becomes the bottleneck when using 8-bit data types, as for  every 2**7
         // or 2**8 elements, the SIMD inner loop is executed (& thus also terminated)
@@ -125,7 +126,7 @@ pub trait SIMD<
         (min_index, min_value, max_index, max_value)
     }
 
-    // TODO: remove this
+    // TODO: can be cleaner (perhaps?)
     #[inline(always)]
     unsafe fn _get_min_max_index_value(
         index_low: SIMDVecDtype,
@@ -133,15 +134,6 @@ pub trait SIMD<
         index_high: SIMDVecDtype,
         values_high: SIMDVecDtype,
     ) -> (usize, ScalarDType, usize, ScalarDType) {
-        // let values_low_arr = Self::_reg_to_arr(values_low);
-        // let index_low_arr = Self::_reg_to_arr(index_low);
-        // let values_high_arr = Self::_reg_to_arr(values_high);
-        // let index_high_arr = Self::_reg_to_arr(index_high);
-        // (0, values_low_arr[0], 0, values_high_arr[0])
-        // (index_low_arr[0].as_(), values_low_arr[0], index_high_arr[0].as_(), values_high_arr[0])
-        // let (min_index, min_value) = min_index_value(&index_low_arr, &values_low_arr);
-        // let (max_index, max_value) = max_index_value(&index_high_arr, &values_high_arr);
-        // (min_index.as_(), min_value, max_index.as_(), max_value)
         let (min_index, min_value) = Self::_horiz_min(index_low, values_low);
         let (max_index, max_value) = Self::_horiz_max(index_high, values_high);
         (min_index, min_value, max_index, max_value)
@@ -182,10 +174,6 @@ pub trait SIMD<
             });
 
         Self::_get_min_max_index_value(index_low, values_low, index_high, values_high)
-        // TODO: implement this as below and remove _get_min_max_index_value
-        // let (min_index, min_value) = Self::_horiz_min(index_low, values_low);
-        // let (max_index, max_value) = Self::_horiz_max(index_high, values_high);
-        // (min_index, min_value, max_index, max_value)
     }
 }
 

--- a/src/simd/mod.rs
+++ b/src/simd/mod.rs
@@ -15,3 +15,4 @@ mod simd_i8;
 mod simd_u16;
 mod simd_u32;
 mod simd_u64;
+mod simd_u8;

--- a/src/simd/mod.rs
+++ b/src/simd/mod.rs
@@ -7,10 +7,10 @@ mod simd_f16;
 mod simd_f32;
 mod simd_f64;
 // SIGNED INT
-mod simd_i8;
 mod simd_i16;
 mod simd_i32;
 mod simd_i64;
+mod simd_i8;
 // UNSIGNED INT
 mod simd_u16;
 mod simd_u32;

--- a/src/simd/mod.rs
+++ b/src/simd/mod.rs
@@ -7,6 +7,7 @@ mod simd_f16;
 mod simd_f32;
 mod simd_f64;
 // SIGNED INT
+mod simd_i8;
 mod simd_i16;
 mod simd_i32;
 mod simd_i64;

--- a/src/simd/simd_f16.rs
+++ b/src/simd/simd_f16.rs
@@ -19,11 +19,7 @@ use std::arch::x86::*;
 use std::arch::x86_64::*;
 
 #[cfg(feature = "half")]
-use crate::utils::{max_index_value, min_index_value};
-#[cfg(feature = "half")]
 use half::f16;
-#[cfg(feature = "half")]
-use num_traits::AsPrimitive;
 
 #[cfg(feature = "half")]
 const XOR_VALUE: i16 = 0x7FFF;

--- a/src/simd/simd_f16.rs
+++ b/src/simd/simd_f16.rs
@@ -136,16 +136,12 @@ mod avx2 {
             index_high: __m256i,
             values_high: __m256i,
         ) -> (usize, f16, usize, f16) {
-            let index_low_arr = _reg_to_i16_arr(index_low);
-            let values_low_arr = _reg_to_i16_arr(values_low);
-            let index_high_arr = _reg_to_i16_arr(index_high);
-            let values_high_arr = _reg_to_i16_arr(values_high);
-            let (min_index, min_value) = min_index_value(&index_low_arr, &values_low_arr);
-            let (max_index, max_value) = max_index_value(&index_high_arr, &values_high_arr);
+            let (min_index, min_value) = Self::_horiz_min(index_low, values_low);
+            let (max_index, max_value) = Self::_horiz_max(index_high, values_high);
             (
-                min_index.as_(),
+                min_index,
                 _ord_i16_to_f16(min_value),
-                max_index.as_(),
+                max_index,
                 _ord_i16_to_f16(max_value),
             )
         }
@@ -323,16 +319,12 @@ mod sse {
             index_high: __m128i,
             values_high: __m128i,
         ) -> (usize, f16, usize, f16) {
-            let index_low_arr = _reg_to_i16_arr(index_low);
-            let values_low_arr = _reg_to_i16_arr(values_low);
-            let index_high_arr = _reg_to_i16_arr(index_high);
-            let values_high_arr = _reg_to_i16_arr(values_high);
-            let (min_index, min_value) = min_index_value(&index_low_arr, &values_low_arr);
-            let (max_index, max_value) = max_index_value(&index_high_arr, &values_high_arr);
+            let (min_index, min_value) = Self::_horiz_min(index_low, values_low);
+            let (max_index, max_value) = Self::_horiz_max(index_high, values_high);
             (
-                min_index.as_(),
+                min_index,
                 _ord_i16_to_f16(min_value),
-                max_index.as_(),
+                max_index,
                 _ord_i16_to_f16(max_value),
             )
         }
@@ -498,16 +490,12 @@ mod avx512 {
             index_high: __m512i,
             values_high: __m512i,
         ) -> (usize, f16, usize, f16) {
-            let index_low_arr = _reg_to_i16_arr(index_low);
-            let values_low_arr = _reg_to_i16_arr(values_low);
-            let index_high_arr = _reg_to_i16_arr(index_high);
-            let values_high_arr = _reg_to_i16_arr(values_high);
-            let (min_index, min_value) = min_index_value(&index_low_arr, &values_low_arr);
-            let (max_index, max_value) = max_index_value(&index_high_arr, &values_high_arr);
+            let (min_index, min_value) = Self::_horiz_min(index_low, values_low);
+            let (max_index, max_value) = Self::_horiz_max(index_high, values_high);
             (
-                min_index.as_(),
+                min_index,
                 _ord_i16_to_f16(min_value),
-                max_index.as_(),
+                max_index,
                 _ord_i16_to_f16(max_value),
             )
         }
@@ -687,16 +675,12 @@ mod neon {
             index_high: int16x8_t,
             values_high: int16x8_t,
         ) -> (usize, f16, usize, f16) {
-            let index_low_arr = _reg_to_i16_arr(index_low);
-            let values_low_arr = _reg_to_i16_arr(values_low);
-            let index_high_arr = _reg_to_i16_arr(index_high);
-            let values_high_arr = _reg_to_i16_arr(values_high);
-            let (min_index, min_value) = min_index_value(&index_low_arr, &values_low_arr);
-            let (max_index, max_value) = max_index_value(&index_high_arr, &values_high_arr);
+            let (min_index, min_value) = Self::_horiz_min(index_low, values_low);
+            let (max_index, max_value) = Self::_horiz_max(index_high, values_high);
             (
-                min_index.as_(),
+                min_index,
                 _ord_i16_to_f16(min_value),
-                max_index.as_(),
+                max_index,
                 _ord_i16_to_f16(max_value),
             )
         }

--- a/src/simd/simd_i8.rs
+++ b/src/simd/simd_i8.rs
@@ -22,9 +22,9 @@ mod avx2 {
     impl SIMD<i8, __m256i, __m256i, LANE_SIZE> for AVX2 {
         const INITIAL_INDEX: __m256i = unsafe {
             std::mem::transmute([
-                0i8, 1i8, 2i8, 3i8, 4i8, 5i8, 6i8, 7i8, 8i8, 9i8, 10i8, 11i8, 12i8, 13i8, 14i8, 15i8,
-                16i8, 17i8, 18i8, 19i8, 20i8, 21i8, 22i8, 23i8, 24i8, 25i8, 26i8, 27i8, 28i8, 29i8, 30i8,
-                31i8
+                0i8, 1i8, 2i8, 3i8, 4i8, 5i8, 6i8, 7i8, 8i8, 9i8, 10i8, 11i8, 12i8, 13i8, 14i8,
+                15i8, 16i8, 17i8, 18i8, 19i8, 20i8, 21i8, 22i8, 23i8, 24i8, 25i8, 26i8, 27i8, 28i8,
+                29i8, 30i8, 31i8,
             ])
         };
         const MAX_INDEX: usize = i8::MAX as usize;
@@ -109,17 +109,7 @@ mod avx2 {
                 return;
             }
 
-            let data = [
-                10,
-                std::i8::MIN,
-                6,
-                9,
-                9,
-                22,
-                std::i8::MAX,
-                4,
-                std::i8::MAX,
-            ];
+            let data = [10, std::i8::MIN, 6, 9, 9, 22, std::i8::MAX, 4, std::i8::MAX];
             let data: Vec<i8> = data.iter().map(|x| *x).collect();
             let data = Array1::from(data);
 
@@ -154,7 +144,7 @@ mod avx2 {
             }
 
             for _ in 0..10_000 {
-                let data = get_array_i8(8*32 + 1);
+                let data = get_array_i8(8 * 32 + 1);
                 let (argmin_index, argmax_index) = scalar_argminmax(data.view());
                 let (argmin_simd_index, argmax_simd_index) =
                     unsafe { AVX2::argminmax(data.view()) };
@@ -177,7 +167,8 @@ mod sse {
     impl SIMD<i8, __m128i, __m128i, LANE_SIZE> for SSE {
         const INITIAL_INDEX: __m128i = unsafe {
             std::mem::transmute([
-                0i8, 1i8, 2i8, 3i8, 4i8, 5i8, 6i8, 7i8, 8i8, 9i8, 10i8, 11i8, 12i8, 13i8, 14i8, 15i8,
+                0i8, 1i8, 2i8, 3i8, 4i8, 5i8, 6i8, 7i8, 8i8, 9i8, 10i8, 11i8, 12i8, 13i8, 14i8,
+                15i8,
             ])
         };
         const MAX_INDEX: usize = i8::MAX as usize;
@@ -254,17 +245,7 @@ mod sse {
 
         #[test]
         fn test_first_index_is_returned_when_identical_values_found() {
-            let data = [
-                10,
-                std::i8::MIN,
-                6,
-                9,
-                9,
-                22,
-                std::i8::MAX,
-                4,
-                std::i8::MAX,
-            ];
+            let data = [10, std::i8::MIN, 6, 9, 9, 22, std::i8::MAX, 4, std::i8::MAX];
             let data: Vec<i8> = data.iter().map(|x| *x).collect();
             let data = Array1::from(data);
 
@@ -313,11 +294,11 @@ mod avx512 {
     impl SIMD<i8, __m512i, u64, LANE_SIZE> for AVX512 {
         const INITIAL_INDEX: __m512i = unsafe {
             std::mem::transmute([
-                0i8, 1i8, 2i8, 3i8, 4i8, 5i8, 6i8, 7i8, 8i8, 9i8, 10i8, 11i8, 12i8, 13i8, 14i8, 15i8,
-                16i8, 17i8, 18i8, 19i8, 20i8, 21i8, 22i8, 23i8, 24i8, 25i8, 26i8, 27i8, 28i8, 29i8, 30i8,
-                31i8, 32i8, 33i8, 34i8, 35i8, 36i8, 37i8, 38i8, 39i8, 40i8, 41i8, 42i8, 43i8, 44i8, 45i8,
-                46i8, 47i8, 48i8, 49i8, 50i8, 51i8, 52i8, 53i8, 54i8, 55i8, 56i8, 57i8, 58i8, 59i8, 60i8,
-                61i8, 62i8, 63i8
+                0i8, 1i8, 2i8, 3i8, 4i8, 5i8, 6i8, 7i8, 8i8, 9i8, 10i8, 11i8, 12i8, 13i8, 14i8,
+                15i8, 16i8, 17i8, 18i8, 19i8, 20i8, 21i8, 22i8, 23i8, 24i8, 25i8, 26i8, 27i8, 28i8,
+                29i8, 30i8, 31i8, 32i8, 33i8, 34i8, 35i8, 36i8, 37i8, 38i8, 39i8, 40i8, 41i8, 42i8,
+                43i8, 44i8, 45i8, 46i8, 47i8, 48i8, 49i8, 50i8, 51i8, 52i8, 53i8, 54i8, 55i8, 56i8,
+                57i8, 58i8, 59i8, 60i8, 61i8, 62i8, 63i8,
             ])
         };
         const MAX_INDEX: usize = i8::MAX as usize;
@@ -402,17 +383,7 @@ mod avx512 {
                 return;
             }
 
-            let data = [
-                10,
-                std::i8::MIN,
-                6,
-                9,
-                9,
-                22,
-                std::i8::MAX,
-                4,
-                std::i8::MAX,
-            ];
+            let data = [10, std::i8::MIN, 6, 9, 9, 22, std::i8::MAX, 4, std::i8::MAX];
             let data: Vec<i8> = data.iter().map(|x| *x).collect();
             let data = Array1::from(data);
 
@@ -468,8 +439,12 @@ mod neon {
     const LANE_SIZE: usize = NEON::LANE_SIZE_16;
 
     impl SIMD<i8, int8x16_t, uint8x16_t, LANE_SIZE> for NEON {
-        const INITIAL_INDEX: int8x16_t =
-            unsafe { std::mem::transmute([0i8, 1i8, 2i8, 3i8, 4i8, 5i8, 6i8, 7i8, 8i8, 9i8, 10i8, 11i8, 12i8, 13i8, 14i8, 15i8]) };
+        const INITIAL_INDEX: int8x16_t = unsafe {
+            std::mem::transmute([
+                0i8, 1i8, 2i8, 3i8, 4i8, 5i8, 6i8, 7i8, 8i8, 9i8, 10i8, 11i8, 12i8, 13i8, 14i8,
+                15i8,
+            ])
+        };
         const MAX_INDEX: usize = i8::MAX as usize;
 
         #[inline(always)]
@@ -545,17 +520,7 @@ mod neon {
 
         #[test]
         fn test_first_index_is_returned_when_identical_values_found() {
-            let data = [
-                10,
-                std::i8::MIN,
-                6,
-                9,
-                9,
-                22,
-                std::i8::MAX,
-                4,
-                std::i8::MAX,
-            ];
+            let data = [10, std::i8::MIN, 6, 9, 9, 22, std::i8::MAX, 4, std::i8::MAX];
             let data: Vec<i8> = data.iter().map(|x| *x).collect();
             let data = Array1::from(data);
 

--- a/src/simd/simd_i8.rs
+++ b/src/simd/simd_i8.rs
@@ -1,0 +1,594 @@
+use super::config::SIMDInstructionSet;
+use super::generic::SIMD;
+use ndarray::ArrayView1;
+#[cfg(target_arch = "aarch64")]
+use std::arch::aarch64::*;
+#[cfg(target_arch = "arm")]
+use std::arch::arm::*;
+#[cfg(target_arch = "x86")]
+use std::arch::x86::*;
+#[cfg(target_arch = "x86_64")]
+use std::arch::x86_64::*;
+
+// ------------------------------------------ AVX2 ------------------------------------------
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+mod avx2 {
+    use super::super::config::AVX2;
+    use super::*;
+
+    const LANE_SIZE: usize = AVX2::LANE_SIZE_8;
+
+    impl SIMD<i8, __m256i, __m256i, LANE_SIZE> for AVX2 {
+        const INITIAL_INDEX: __m256i = unsafe {
+            std::mem::transmute([
+                0i8, 1i8, 2i8, 3i8, 4i8, 5i8, 6i8, 7i8, 8i8, 9i8, 10i8, 11i8, 12i8, 13i8, 14i8, 15i8,
+                16i8, 17i8, 18i8, 19i8, 20i8, 21i8, 22i8, 23i8, 24i8, 25i8, 26i8, 27i8, 28i8, 29i8, 30i8,
+                31i8
+            ])
+        };
+        const MAX_INDEX: usize = i8::MAX as usize;
+
+        #[inline(always)]
+        unsafe fn _reg_to_arr(reg: __m256i) -> [i8; LANE_SIZE] {
+            std::mem::transmute::<__m256i, [i8; LANE_SIZE]>(reg)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_loadu(data: *const i8) -> __m256i {
+            _mm256_loadu_si256(data as *const __m256i)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_set1(a: usize) -> __m256i {
+            _mm256_set1_epi8(a as i8)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_add(a: __m256i, b: __m256i) -> __m256i {
+            _mm256_add_epi8(a, b)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_cmpgt(a: __m256i, b: __m256i) -> __m256i {
+            _mm256_cmpgt_epi8(a, b)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_cmplt(a: __m256i, b: __m256i) -> __m256i {
+            _mm256_cmpgt_epi8(b, a)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_blendv(a: __m256i, b: __m256i, mask: __m256i) -> __m256i {
+            _mm256_blendv_epi8(a, b, mask)
+        }
+
+        // ------------------------------------ ARGMINMAX --------------------------------------
+
+        #[target_feature(enable = "avx2")]
+        unsafe fn argminmax(data: ArrayView1<i8>) -> (usize, usize) {
+            Self::_argminmax(data)
+        }
+    }
+
+    // ------------------------------------ TESTS --------------------------------------
+
+    #[cfg(test)]
+    mod tests {
+        use super::{AVX2, SIMD};
+        use crate::scalar::generic::scalar_argminmax;
+
+        use ndarray::Array1;
+
+        extern crate dev_utils;
+        use dev_utils::utils;
+
+        fn get_array_i8(n: usize) -> Array1<i8> {
+            utils::get_random_array(n, i8::MIN, i8::MAX)
+        }
+
+        #[test]
+        fn test_both_versions_return_the_same_results() {
+            if !is_x86_feature_detected!("avx2") {
+                return;
+            }
+
+            let data = get_array_i8(513);
+            assert_eq!(data.len() % 16, 1);
+
+            let (argmin_index, argmax_index) = scalar_argminmax(data.view());
+            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data.view()) };
+            assert_eq!(argmin_index, argmin_simd_index);
+            assert_eq!(argmax_index, argmax_simd_index);
+        }
+
+        #[test]
+        fn test_first_index_is_returned_when_identical_values_found() {
+            if !is_x86_feature_detected!("avx2") {
+                return;
+            }
+
+            let data = [
+                10,
+                std::i8::MIN,
+                6,
+                9,
+                9,
+                22,
+                std::i8::MAX,
+                4,
+                std::i8::MAX,
+            ];
+            let data: Vec<i8> = data.iter().map(|x| *x).collect();
+            let data = Array1::from(data);
+
+            let (argmin_index, argmax_index) = scalar_argminmax(data.view());
+            assert_eq!(argmin_index, 1);
+            assert_eq!(argmax_index, 6);
+
+            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data.view()) };
+            assert_eq!(argmin_simd_index, 1);
+            assert_eq!(argmax_simd_index, 6);
+        }
+
+        #[test]
+        fn test_no_overflow() {
+            if !is_x86_feature_detected!("avx2") {
+                return;
+            }
+
+            let n: usize = 1 << 10;
+            let data = get_array_i8(n);
+
+            let (argmin_index, argmax_index) = scalar_argminmax(data.view());
+            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data.view()) };
+            assert_eq!(argmin_index, argmin_simd_index);
+            assert_eq!(argmax_index, argmax_simd_index);
+        }
+
+        #[test]
+        fn test_many_random_runs() {
+            if !is_x86_feature_detected!("avx2") {
+                return;
+            }
+
+            for _ in 0..10_000 {
+                let data = get_array_i8(8*32 + 1);
+                let (argmin_index, argmax_index) = scalar_argminmax(data.view());
+                let (argmin_simd_index, argmax_simd_index) =
+                    unsafe { AVX2::argminmax(data.view()) };
+                assert_eq!(argmin_index, argmin_simd_index);
+                assert_eq!(argmax_index, argmax_simd_index);
+            }
+        }
+    }
+}
+
+// ----------------------------------------- SSE -----------------------------------------
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+mod sse {
+    use super::super::config::SSE;
+    use super::*;
+
+    const LANE_SIZE: usize = SSE::LANE_SIZE_8;
+
+    impl SIMD<i8, __m128i, __m128i, LANE_SIZE> for SSE {
+        const INITIAL_INDEX: __m128i = unsafe {
+            std::mem::transmute([
+                0i8, 1i8, 2i8, 3i8, 4i8, 5i8, 6i8, 7i8, 8i8, 9i8, 10i8, 11i8, 12i8, 13i8, 14i8, 15i8,
+            ])
+        };
+        const MAX_INDEX: usize = i8::MAX as usize;
+
+        #[inline(always)]
+        unsafe fn _reg_to_arr(reg: __m128i) -> [i8; LANE_SIZE] {
+            std::mem::transmute::<__m128i, [i8; LANE_SIZE]>(reg)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_loadu(data: *const i8) -> __m128i {
+            _mm_loadu_si128(data as *const __m128i)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_set1(a: usize) -> __m128i {
+            _mm_set1_epi8(a as i8)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_add(a: __m128i, b: __m128i) -> __m128i {
+            _mm_add_epi8(a, b)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_cmpgt(a: __m128i, b: __m128i) -> __m128i {
+            _mm_cmpgt_epi8(a, b)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_cmplt(a: __m128i, b: __m128i) -> __m128i {
+            _mm_cmplt_epi8(a, b)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_blendv(a: __m128i, b: __m128i, mask: __m128i) -> __m128i {
+            _mm_blendv_epi8(a, b, mask)
+        }
+
+        // ------------------------------------ ARGMINMAX --------------------------------------
+
+        #[target_feature(enable = "sse4.1")]
+        unsafe fn argminmax(data: ArrayView1<i8>) -> (usize, usize) {
+            Self::_argminmax(data)
+        }
+    }
+
+    // ------------------------------------ TESTS --------------------------------------
+
+    #[cfg(test)]
+    mod tests {
+        use super::{SIMD, SSE};
+        use crate::scalar::generic::scalar_argminmax;
+
+        use ndarray::Array1;
+
+        extern crate dev_utils;
+        use dev_utils::utils;
+
+        fn get_array_i8(n: usize) -> Array1<i8> {
+            utils::get_random_array(n, i8::MIN, i8::MAX)
+        }
+
+        #[test]
+        fn test_both_versions_return_the_same_results() {
+            let data = get_array_i8(513);
+            assert_eq!(data.len() % 8, 1);
+
+            let (argmin_index, argmax_index) = scalar_argminmax(data.view());
+            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data.view()) };
+            assert_eq!(argmin_index, argmin_simd_index);
+            assert_eq!(argmax_index, argmax_simd_index);
+        }
+
+        #[test]
+        fn test_first_index_is_returned_when_identical_values_found() {
+            let data = [
+                10,
+                std::i8::MIN,
+                6,
+                9,
+                9,
+                22,
+                std::i8::MAX,
+                4,
+                std::i8::MAX,
+            ];
+            let data: Vec<i8> = data.iter().map(|x| *x).collect();
+            let data = Array1::from(data);
+
+            let (argmin_index, argmax_index) = scalar_argminmax(data.view());
+            assert_eq!(argmin_index, 1);
+            assert_eq!(argmax_index, 6);
+
+            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data.view()) };
+            assert_eq!(argmin_simd_index, 1);
+            assert_eq!(argmax_simd_index, 6);
+        }
+
+        #[test]
+        fn test_no_overflow() {
+            let n: usize = 1 << 10;
+            let data = get_array_i8(n);
+
+            let (argmin_index, argmax_index) = scalar_argminmax(data.view());
+            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data.view()) };
+            assert_eq!(argmin_index, argmin_simd_index);
+            assert_eq!(argmax_index, argmax_simd_index);
+        }
+
+        #[test]
+        fn test_many_random_runs() {
+            for _ in 0..10_000 {
+                let data = get_array_i8(8 * 32 + 1);
+                let (argmin_index, argmax_index) = scalar_argminmax(data.view());
+                let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data.view()) };
+                assert_eq!(argmin_index, argmin_simd_index);
+                assert_eq!(argmax_index, argmax_simd_index);
+            }
+        }
+    }
+}
+
+// --------------------------------------- AVX512 ----------------------------------------
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+mod avx512 {
+    use super::super::config::AVX512;
+    use super::*;
+
+    const LANE_SIZE: usize = AVX512::LANE_SIZE_8;
+
+    impl SIMD<i8, __m512i, u64, LANE_SIZE> for AVX512 {
+        const INITIAL_INDEX: __m512i = unsafe {
+            std::mem::transmute([
+                0i8, 1i8, 2i8, 3i8, 4i8, 5i8, 6i8, 7i8, 8i8, 9i8, 10i8, 11i8, 12i8, 13i8, 14i8, 15i8,
+                16i8, 17i8, 18i8, 19i8, 20i8, 21i8, 22i8, 23i8, 24i8, 25i8, 26i8, 27i8, 28i8, 29i8, 30i8,
+                31i8, 32i8, 33i8, 34i8, 35i8, 36i8, 37i8, 38i8, 39i8, 40i8, 41i8, 42i8, 43i8, 44i8, 45i8,
+                46i8, 47i8, 48i8, 49i8, 50i8, 51i8, 52i8, 53i8, 54i8, 55i8, 56i8, 57i8, 58i8, 59i8, 60i8,
+                61i8, 62i8, 63i8
+            ])
+        };
+        const MAX_INDEX: usize = i8::MAX as usize;
+
+        #[inline(always)]
+        unsafe fn _reg_to_arr(reg: __m512i) -> [i8; LANE_SIZE] {
+            std::mem::transmute::<__m512i, [i8; LANE_SIZE]>(reg)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_loadu(data: *const i8) -> __m512i {
+            _mm512_loadu_epi8(data as *const i8)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_set1(a: usize) -> __m512i {
+            _mm512_set1_epi8(a as i8)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_add(a: __m512i, b: __m512i) -> __m512i {
+            _mm512_add_epi8(a, b)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_cmpgt(a: __m512i, b: __m512i) -> u64 {
+            _mm512_cmpgt_epi8_mask(a, b)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_cmplt(a: __m512i, b: __m512i) -> u64 {
+            _mm512_cmplt_epi8_mask(a, b)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_blendv(a: __m512i, b: __m512i, mask: u64) -> __m512i {
+            _mm512_mask_blend_epi8(mask, a, b)
+        }
+
+        // ------------------------------------ ARGMINMAX --------------------------------------
+
+        #[target_feature(enable = "avx512bw")]
+        unsafe fn argminmax(data: ArrayView1<i8>) -> (usize, usize) {
+            Self::_argminmax(data)
+        }
+    }
+
+    // ------------------------------------ TESTS --------------------------------------
+
+    #[cfg(test)]
+    mod tests {
+        use super::{AVX512, SIMD};
+        use crate::scalar::generic::scalar_argminmax;
+
+        use ndarray::Array1;
+
+        extern crate dev_utils;
+        use dev_utils::utils;
+
+        fn get_array_i8(n: usize) -> Array1<i8> {
+            utils::get_random_array(n, i8::MIN, i8::MAX)
+        }
+
+        #[test]
+        fn test_both_versions_return_the_same_results() {
+            if !is_x86_feature_detected!("avx512bw") {
+                return;
+            }
+
+            let data = get_array_i8(513);
+            assert_eq!(data.len() % 8, 1);
+
+            let (argmin_index, argmax_index) = scalar_argminmax(data.view());
+            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data.view()) };
+            assert_eq!(argmin_index, argmin_simd_index);
+            assert_eq!(argmax_index, argmax_simd_index);
+        }
+
+        #[test]
+        fn test_first_index_is_returned_when_identical_values_found() {
+            if !is_x86_feature_detected!("avx512bw") {
+                return;
+            }
+
+            let data = [
+                10,
+                std::i8::MIN,
+                6,
+                9,
+                9,
+                22,
+                std::i8::MAX,
+                4,
+                std::i8::MAX,
+            ];
+            let data: Vec<i8> = data.iter().map(|x| *x).collect();
+            let data = Array1::from(data);
+
+            let (argmin_index, argmax_index) = scalar_argminmax(data.view());
+            assert_eq!(argmin_index, 1);
+            assert_eq!(argmax_index, 6);
+
+            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data.view()) };
+            assert_eq!(argmin_simd_index, 1);
+            assert_eq!(argmax_simd_index, 6);
+        }
+
+        #[test]
+        fn test_no_overflow() {
+            if !is_x86_feature_detected!("avx512bw") {
+                return;
+            }
+
+            let n: usize = 1 << 10;
+            let data = get_array_i8(n);
+
+            let (argmin_index, argmax_index) = scalar_argminmax(data.view());
+            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data.view()) };
+            assert_eq!(argmin_index, argmin_simd_index);
+            assert_eq!(argmax_index, argmax_simd_index);
+        }
+
+        #[test]
+        fn test_many_random_runs() {
+            if !is_x86_feature_detected!("avx512bw") {
+                return;
+            }
+
+            for _ in 0..10_000 {
+                let data = get_array_i8(1025);
+                let (argmin_index, argmax_index) = scalar_argminmax(data.view());
+                let (argmin_simd_index, argmax_simd_index) =
+                    unsafe { AVX512::argminmax(data.view()) };
+                assert_eq!(argmin_index, argmin_simd_index);
+                assert_eq!(argmax_index, argmax_simd_index);
+            }
+        }
+    }
+}
+
+// ---------------------------------------- NEON -----------------------------------------
+
+#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+mod neon {
+    use super::super::config::NEON;
+    use super::*;
+
+    const LANE_SIZE: usize = NEON::LANE_SIZE_16;
+
+    impl SIMD<i8, int8x16_t, uint8x16_t, LANE_SIZE> for NEON {
+        const INITIAL_INDEX: int8x16_t =
+            unsafe { std::mem::transmute([0i8, 1i8, 2i8, 3i8, 4i8, 5i8, 6i8, 7i8, 8i8, 9i8, 10i8, 11i8, 12i8, 13i8, 14i8, 15i8]) };
+        const MAX_INDEX: usize = i8::MAX as usize;
+
+        #[inline(always)]
+        unsafe fn _reg_to_arr(reg: int8x16_t) -> [i8; LANE_SIZE] {
+            std::mem::transmute::<int8x16_t, [i8; LANE_SIZE]>(reg)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_loadu(data: *const i8) -> int8x16_t {
+            // TODO: requires v7
+            vld1q_s8(data as *const i8)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_set1(a: usize) -> int8x16_t {
+            vdupq_n_s8(a as i8)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_add(a: int8x16_t, b: int8x16_t) -> int8x16_t {
+            vaddq_s8(a, b)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_cmpgt(a: int8x16_t, b: int8x16_t) -> uint8x16_t {
+            vcgtq_s8(a, b)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_cmplt(a: int8x16_t, b: int8x16_t) -> uint8x16_t {
+            vcltq_s8(a, b)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_blendv(a: int8x16_t, b: int8x16_t, mask: uint8x16_t) -> int8x16_t {
+            vbslq_s8(mask, b, a)
+        }
+
+        // ------------------------------------ ARGMINMAX --------------------------------------
+
+        #[target_feature(enable = "neon")]
+        unsafe fn argminmax(data: ArrayView1<i8>) -> (usize, usize) {
+            Self::_argminmax(data)
+        }
+    }
+
+    // ------------------------------------ TESTS --------------------------------------
+
+    #[cfg(test)]
+    mod tests {
+        use super::{NEON, SIMD};
+        use crate::scalar::generic::scalar_argminmax;
+
+        use ndarray::Array1;
+
+        extern crate dev_utils;
+        use dev_utils::utils;
+
+        fn get_array_i8(n: usize) -> Array1<i8> {
+            utils::get_random_array(n, i8::MIN, i8::MAX)
+        }
+
+        #[test]
+        fn test_both_versions_return_the_same_results() {
+            let data = get_array_i8(513);
+            assert_eq!(data.len() % 8, 1);
+
+            let (argmin_index, argmax_index) = scalar_argminmax(data.view());
+            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data.view()) };
+            assert_eq!(argmin_index, argmin_simd_index);
+            assert_eq!(argmax_index, argmax_simd_index);
+        }
+
+        #[test]
+        fn test_first_index_is_returned_when_identical_values_found() {
+            let data = [
+                10,
+                std::i8::MIN,
+                6,
+                9,
+                9,
+                22,
+                std::i8::MAX,
+                4,
+                std::i8::MAX,
+            ];
+            let data: Vec<i8> = data.iter().map(|x| *x).collect();
+            let data = Array1::from(data);
+
+            let (argmin_index, argmax_index) = scalar_argminmax(data.view());
+            assert_eq!(argmin_index, 1);
+            assert_eq!(argmax_index, 6);
+
+            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data.view()) };
+            assert_eq!(argmin_simd_index, 1);
+            assert_eq!(argmax_simd_index, 6);
+        }
+
+        #[test]
+        fn test_no_overflow() {
+            let n: usize = 1 << 10;
+            let data = get_array_i8(n);
+
+            let (argmin_index, argmax_index) = scalar_argminmax(data.view());
+            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data.view()) };
+            assert_eq!(argmin_index, argmin_simd_index);
+            assert_eq!(argmax_index, argmax_simd_index);
+        }
+
+        #[test]
+        fn test_many_random_runs() {
+            for _ in 0..10_000 {
+                let data = get_array_i8(16 * 8 + 1);
+                let (argmin_index, argmax_index) = scalar_argminmax(data.view());
+                let (argmin_simd_index, argmax_simd_index) =
+                    unsafe { NEON::argminmax(data.view()) };
+                assert_eq!(argmin_index, argmin_simd_index);
+                assert_eq!(argmax_index, argmax_simd_index);
+            }
+        }
+    }
+}

--- a/src/simd/simd_u16.rs
+++ b/src/simd/simd_u16.rs
@@ -1,10 +1,6 @@
 use super::config::SIMDInstructionSet;
 use super::generic::SIMD;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-use crate::utils::{max_index_value, min_index_value};
 use ndarray::ArrayView1;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-use num_traits::AsPrimitive;
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 #[cfg(target_arch = "arm")]
@@ -124,20 +120,15 @@ mod avx2 {
             index_high: __m256i,
             values_high: __m256i,
         ) -> (usize, u16, usize, u16) {
-            let index_low_arr = _reg_to_i16_arr(index_low);
-            let values_low_arr = _reg_to_i16_arr(values_low);
-            let index_high_arr = _reg_to_i16_arr(index_high);
-            let values_high_arr = _reg_to_i16_arr(values_high);
-            let (min_index, min_value) = min_index_value(&index_low_arr, &values_low_arr);
-            let (max_index, max_value) = max_index_value(&index_high_arr, &values_high_arr);
+            let (min_index, min_value) = Self::_horiz_min(index_low, values_low);
+            let (max_index, max_value) = Self::_horiz_max(index_high, values_high);
             // Swap min and max here because we worked with i16ord in decreasing order (max => actual min, and vice versa)
             (
-                max_index.as_(),
+                max_index,
                 _i16decrord_to_u16(max_value),
-                min_index.as_(),
+                min_index,
                 _i16decrord_to_u16(min_value),
             )
-            // (min_index.as_(), _ord_i16_to_u16(min_value), max_index.as_(), _ord_i16_to_u16(max_value))
         }
     }
 
@@ -309,20 +300,15 @@ mod sse {
             index_high: __m128i,
             values_high: __m128i,
         ) -> (usize, u16, usize, u16) {
-            let index_low_arr = _reg_to_i16_arr(index_low);
-            let values_low_arr = _reg_to_i16_arr(values_low);
-            let index_high_arr = _reg_to_i16_arr(index_high);
-            let values_high_arr = _reg_to_i16_arr(values_high);
-            let (min_index, min_value) = min_index_value(&index_low_arr, &values_low_arr);
-            let (max_index, max_value) = max_index_value(&index_high_arr, &values_high_arr);
+            let (min_index, min_value) = Self::_horiz_min(index_low, values_low);
+            let (max_index, max_value) = Self::_horiz_max(index_high, values_high);
             // Swap min and max here because we worked with i16ord in decreasing order (max => actual min, and vice versa)
             (
-                max_index.as_(),
+                max_index,
                 _i16decrord_to_u16(max_value),
-                min_index.as_(),
+                min_index,
                 _i16decrord_to_u16(min_value),
             )
-            // (min_index.as_(), _ord_i16_to_u16(min_value), max_index.as_(), _ord_i16_to_u16(max_value))
         }
     }
 
@@ -486,17 +472,13 @@ mod avx512 {
             index_high: __m512i,
             values_high: __m512i,
         ) -> (usize, u16, usize, u16) {
-            let index_low_arr = _reg_to_i16_arr(index_low);
-            let values_low_arr = _reg_to_i16_arr(values_low);
-            let index_high_arr = _reg_to_i16_arr(index_high);
-            let values_high_arr = _reg_to_i16_arr(values_high);
-            let (min_index, min_value) = min_index_value(&index_low_arr, &values_low_arr);
-            let (max_index, max_value) = max_index_value(&index_high_arr, &values_high_arr);
+            let (min_index, min_value) = Self::_horiz_min(index_low, values_low);
+            let (max_index, max_value) = Self::_horiz_max(index_high, values_high);
             // Swap min and max here because we worked with i16ord in decreasing order (max => actual min, and vice versa)
             (
-                max_index.as_(),
+                max_index,
                 _i16decrord_to_u16(max_value),
-                min_index.as_(),
+                min_index,
                 _i16decrord_to_u16(min_value),
             )
         }

--- a/src/simd/simd_u16.rs
+++ b/src/simd/simd_u16.rs
@@ -237,6 +237,8 @@ mod sse {
 
     #[inline(always)]
     unsafe fn _u16_to_i16decrord(u16: __m128i) -> __m128i {
+        // on a scalar: v^ 0x7F
+        // transforms to monotonically **decreasing** order
         _mm_xor_si128(u16, XOR_MASK)
     }
 

--- a/src/simd/simd_u32.rs
+++ b/src/simd/simd_u32.rs
@@ -1,10 +1,6 @@
 use super::config::SIMDInstructionSet;
 use super::generic::SIMD;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-use crate::utils::{max_index_value, min_index_value};
 use ndarray::ArrayView1;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-use num_traits::AsPrimitive;
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 #[cfg(target_arch = "arm")]
@@ -101,17 +97,13 @@ mod avx2 {
             index_high: __m256i,
             values_high: __m256i,
         ) -> (usize, u32, usize, u32) {
-            let index_low_arr = _reg_to_i32_arr(index_low);
-            let values_low_arr = _reg_to_i32_arr(values_low);
-            let index_high_arr = _reg_to_i32_arr(index_high);
-            let values_high_arr = _reg_to_i32_arr(values_high);
-            let (min_index, min_value) = min_index_value(&index_low_arr, &values_low_arr);
-            let (max_index, max_value) = max_index_value(&index_high_arr, &values_high_arr);
-            // Swap min and max here because we worked with i16ord in decreasing order (max => actual min, and vice versa)
+            let (min_index, min_value) = Self::_horiz_min(index_low, values_low);
+            let (max_index, max_value) = Self::_horiz_max(index_high, values_high);
+            // Swap min and max here because we worked with i64ord in decreasing order (max => actual min, and vice versa)
             (
-                max_index.as_(),
+                max_index,
                 _i32decrord_to_u32(max_value),
-                min_index.as_(),
+                min_index,
                 _i32decrord_to_u32(min_value),
             )
         }
@@ -271,20 +263,15 @@ mod sse {
             index_high: __m128i,
             values_high: __m128i,
         ) -> (usize, u32, usize, u32) {
-            let index_low_arr = _reg_to_i32_arr(index_low);
-            let values_low_arr = _reg_to_i32_arr(values_low);
-            let index_high_arr = _reg_to_i32_arr(index_high);
-            let values_high_arr = _reg_to_i32_arr(values_high);
-            let (min_index, min_value) = min_index_value(&index_low_arr, &values_low_arr);
-            let (max_index, max_value) = max_index_value(&index_high_arr, &values_high_arr);
-            // Swap min and max here because we worked with i16ord in decreasing order (max => actual min, and vice versa)
+            let (min_index, min_value) = Self::_horiz_min(index_low, values_low);
+            let (max_index, max_value) = Self::_horiz_max(index_high, values_high);
+            // Swap min and max here because we worked with i64ord in decreasing order (max => actual min, and vice versa)
             (
-                max_index.as_(),
+                max_index,
                 _i32decrord_to_u32(max_value),
-                min_index.as_(),
+                min_index,
                 _i32decrord_to_u32(min_value),
             )
-            // (min_index.as_(), _ord_i16_to_u16(min_value), max_index.as_(), _ord_i16_to_u16(max_value))
         }
     }
 
@@ -436,17 +423,13 @@ mod avx512 {
             index_high: __m512i,
             values_high: __m512i,
         ) -> (usize, u32, usize, u32) {
-            let index_low_arr = _reg_to_i32_arr(index_low);
-            let values_low_arr = _reg_to_i32_arr(values_low);
-            let index_high_arr = _reg_to_i32_arr(index_high);
-            let values_high_arr = _reg_to_i32_arr(values_high);
-            let (min_index, min_value) = min_index_value(&index_low_arr, &values_low_arr);
-            let (max_index, max_value) = max_index_value(&index_high_arr, &values_high_arr);
-            // Swap min and max here because we worked with i16ord in decreasing order (max => actual min, and vice versa)
+            let (min_index, min_value) = Self::_horiz_min(index_low, values_low);
+            let (max_index, max_value) = Self::_horiz_max(index_high, values_high);
+            // Swap min and max here because we worked with i64ord in decreasing order (max => actual min, and vice versa)
             (
-                max_index.as_(),
+                max_index,
                 _i32decrord_to_u32(max_value),
-                min_index.as_(),
+                min_index,
                 _i32decrord_to_u32(min_value),
             )
         }

--- a/src/simd/simd_u64.rs
+++ b/src/simd/simd_u64.rs
@@ -1,11 +1,7 @@
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use super::config::SIMDInstructionSet;
 use super::generic::SIMD;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-use crate::utils::{max_index_value, min_index_value};
 use ndarray::ArrayView1;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-use num_traits::AsPrimitive;
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
@@ -97,17 +93,13 @@ mod avx2 {
             index_high: __m256i,
             values_high: __m256i,
         ) -> (usize, u64, usize, u64) {
-            let index_low_arr = _reg_to_i64_arr(index_low);
-            let values_low_arr = _reg_to_i64_arr(values_low);
-            let index_high_arr = _reg_to_i64_arr(index_high);
-            let values_high_arr = _reg_to_i64_arr(values_high);
-            let (min_index, min_value) = min_index_value(&index_low_arr, &values_low_arr);
-            let (max_index, max_value) = max_index_value(&index_high_arr, &values_high_arr);
-            // Swap min and max here because we worked with i16ord in decreasing order (max => actual min, and vice versa)
+            let (min_index, min_value) = Self::_horiz_min(index_low, values_low);
+            let (max_index, max_value) = Self::_horiz_max(index_high, values_high);
+            // Swap min and max here because we worked with i64ord in decreasing order (max => actual min, and vice versa)
             (
-                max_index.as_(),
+                max_index,
                 _i64decrord_to_u64(max_value),
-                min_index.as_(),
+                min_index,
                 _i64decrord_to_u64(min_value),
             )
         }
@@ -267,20 +259,15 @@ mod sse {
             index_high: __m128i,
             values_high: __m128i,
         ) -> (usize, u64, usize, u64) {
-            let index_low_arr = _reg_to_i64_arr(index_low);
-            let values_low_arr = _reg_to_i64_arr(values_low);
-            let index_high_arr = _reg_to_i64_arr(index_high);
-            let values_high_arr = _reg_to_i64_arr(values_high);
-            let (min_index, min_value) = min_index_value(&index_low_arr, &values_low_arr);
-            let (max_index, max_value) = max_index_value(&index_high_arr, &values_high_arr);
-            // Swap min and max here because we worked with i16ord in decreasing order (max => actual min, and vice versa)
+            let (min_index, min_value) = Self::_horiz_min(index_low, values_low);
+            let (max_index, max_value) = Self::_horiz_max(index_high, values_high);
+            // Swap min and max here because we worked with i64ord in decreasing order (max => actual min, and vice versa)
             (
-                max_index.as_(),
+                max_index,
                 _i64decrord_to_u64(max_value),
-                min_index.as_(),
+                min_index,
                 _i64decrord_to_u64(min_value),
             )
-            // (min_index.as_(), _ord_i16_to_u16(min_value), max_index.as_(), _ord_i16_to_u16(max_value))
         }
     }
 
@@ -428,17 +415,13 @@ mod avx512 {
             index_high: __m512i,
             values_high: __m512i,
         ) -> (usize, u64, usize, u64) {
-            let index_low_arr = _reg_to_i64_arr(index_low);
-            let values_low_arr = _reg_to_i64_arr(values_low);
-            let index_high_arr = _reg_to_i64_arr(index_high);
-            let values_high_arr = _reg_to_i64_arr(values_high);
-            let (min_index, min_value) = min_index_value(&index_low_arr, &values_low_arr);
-            let (max_index, max_value) = max_index_value(&index_high_arr, &values_high_arr);
-            // Swap min and max here because we worked with i16ord in decreasing order (max => actual min, and vice versa)
+            let (min_index, min_value) = Self::_horiz_min(index_low, values_low);
+            let (max_index, max_value) = Self::_horiz_max(index_high, values_high);
+            // Swap min and max here because we worked with i64ord in decreasing order (max => actual min, and vice versa)
             (
-                max_index.as_(),
+                max_index,
                 _i64decrord_to_u64(max_value),
-                min_index.as_(),
+                min_index,
                 _i64decrord_to_u64(min_value),
             )
         }

--- a/src/simd/simd_u8.rs
+++ b/src/simd/simd_u8.rs
@@ -1,0 +1,846 @@
+use super::config::SIMDInstructionSet;
+use super::generic::SIMD;
+use ndarray::ArrayView1;
+#[cfg(target_arch = "aarch64")]
+use std::arch::aarch64::*;
+#[cfg(target_arch = "arm")]
+use std::arch::arm::*;
+#[cfg(target_arch = "x86")]
+use std::arch::x86::*;
+#[cfg(target_arch = "x86_64")]
+use std::arch::x86_64::*;
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+const XOR_VALUE: i8 = 0x7F;
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[inline(always)]
+fn _i8decrord_to_u8(decrord_i8: i8) -> u8 {
+    // let v = ord_i8 ^ 0x7F;
+    unsafe { std::mem::transmute::<i8, u8>(decrord_i8 ^ XOR_VALUE) }
+}
+
+// ------------------------------------------ AVX2 ------------------------------------------
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+mod avx2 {
+    use super::super::config::AVX2;
+    use super::*;
+
+    const LANE_SIZE: usize = AVX2::LANE_SIZE_8;
+    const XOR_MASK: __m256i = unsafe { std::mem::transmute([XOR_VALUE; LANE_SIZE]) };
+
+    // TODO: add vs xor? (also for other unsigned dtypes)
+    // Fan van committen nr xor - maar denk dat implementatie nog cleaner kan
+    //  - comparison swappen => dan moeten we opt einde niet meer swappen?
+
+    #[inline(always)]
+    unsafe fn _u8_to_i8decrord(u8: __m256i) -> __m256i {
+        // on a scalar: v^ 0x7F
+        // transforms to monotonically **decreasing** order
+        _mm256_xor_si256(u8, XOR_MASK) // Only 1 operation
+    }
+
+    #[inline(always)]
+    unsafe fn _reg_to_i8_arr(reg: __m256i) -> [i8; LANE_SIZE] {
+        std::mem::transmute::<__m256i, [i8; LANE_SIZE]>(reg)
+    }
+
+    impl SIMD<u8, __m256i, __m256i, LANE_SIZE> for AVX2 {
+        const INITIAL_INDEX: __m256i = unsafe {
+            std::mem::transmute([
+                0i8, 1i8, 2i8, 3i8, 4i8, 5i8, 6i8, 7i8, 8i8, 9i8, 10i8, 11i8, 12i8, 13i8, 14i8,
+                15i8, 16i8, 17i8, 18i8, 19i8, 20i8, 21i8, 22i8, 23i8, 24i8, 25i8, 26i8, 27i8, 28i8,
+                29i8, 30i8, 31i8,
+            ])
+        };
+        const MAX_INDEX: usize = i8::MAX as usize;
+
+        #[inline(always)]
+        unsafe fn _reg_to_arr(_: __m256i) -> [u8; LANE_SIZE] {
+            // Not used because we work with i8ord and override _get_min_index_value and _get_max_index_value
+            unimplemented!()
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_loadu(data: *const u8) -> __m256i {
+            _u8_to_i8decrord(_mm256_loadu_si256(data as *const __m256i))
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_set1(a: usize) -> __m256i {
+            _mm256_set1_epi8(a as i8)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_add(a: __m256i, b: __m256i) -> __m256i {
+            _mm256_add_epi8(a, b)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_cmpgt(a: __m256i, b: __m256i) -> __m256i {
+            _mm256_cmpgt_epi8(a, b)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_cmplt(a: __m256i, b: __m256i) -> __m256i {
+            _mm256_cmpgt_epi8(b, a)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_blendv(a: __m256i, b: __m256i, mask: __m256i) -> __m256i {
+            _mm256_blendv_epi8(a, b, mask)
+        }
+
+        // ------------------------------------ ARGMINMAX --------------------------------------
+
+        #[target_feature(enable = "avx2")]
+        unsafe fn argminmax(data: ArrayView1<u8>) -> (usize, usize) {
+            Self::_argminmax(data)
+        }
+
+        #[inline(always)]
+        unsafe fn _horiz_min(index: __m256i, value: __m256i) -> (usize, u8) {
+            // 0. Find the minimum value
+            let mut vmin: __m256i = value;
+            vmin = _mm256_min_epi8(vmin, _mm256_permute2x128_si256(vmin, vmin, 1));
+            vmin = _mm256_min_epi8(vmin, _mm256_alignr_epi8(vmin, vmin, 8));
+            vmin = _mm256_min_epi8(vmin, _mm256_alignr_epi8(vmin, vmin, 4));
+            vmin = _mm256_min_epi8(vmin, _mm256_alignr_epi8(vmin, vmin, 2));
+            vmin = _mm256_min_epi8(vmin, _mm256_alignr_epi8(vmin, vmin, 1));
+            let min_value: i8 = _mm256_extract_epi8(vmin, 0) as i8;
+
+            // Extract the index of the minimum value
+            // 1. Create a mask with the index of the minimum value
+            let mask = _mm256_cmpeq_epi8(value, vmin);
+            // 2. Blend the mask with the index
+            let search_index = _mm256_blendv_epi8(
+                _mm256_set1_epi8(i8::MAX), // if mask is 0, use i8::MAX
+                index,                     // if mask is 1, use index
+                mask,
+            );
+            // 3. Find the minimum index
+            let mut imin: __m256i = search_index;
+            imin = _mm256_min_epi8(imin, _mm256_permute2x128_si256(imin, imin, 1));
+            imin = _mm256_min_epi8(imin, _mm256_alignr_epi8(imin, imin, 8));
+            imin = _mm256_min_epi8(imin, _mm256_alignr_epi8(imin, imin, 4));
+            imin = _mm256_min_epi8(imin, _mm256_alignr_epi8(imin, imin, 2));
+            imin = _mm256_min_epi8(imin, _mm256_alignr_epi8(imin, imin, 1));
+            let min_index: usize = _mm256_extract_epi8(imin, 0) as usize;
+
+            (min_index, _i8decrord_to_u8(min_value))
+        }
+
+        #[inline(always)]
+        unsafe fn _horiz_max(index: __m256i, value: __m256i) -> (usize, u8) {
+            // 0. Find the maximum value
+            let mut vmax: __m256i = value;
+            vmax = _mm256_max_epi8(vmax, _mm256_permute2x128_si256(vmax, vmax, 1));
+            vmax = _mm256_max_epi8(vmax, _mm256_alignr_epi8(vmax, vmax, 8));
+            vmax = _mm256_max_epi8(vmax, _mm256_alignr_epi8(vmax, vmax, 4));
+            vmax = _mm256_max_epi8(vmax, _mm256_alignr_epi8(vmax, vmax, 2));
+            vmax = _mm256_max_epi8(vmax, _mm256_alignr_epi8(vmax, vmax, 1));
+            let max_value: i8 = _mm256_extract_epi8(vmax, 0) as i8;
+
+            // Extract the index of the maximum value
+            // 1. Create a mask with the index of the maximum value
+            let mask = _mm256_cmpeq_epi8(value, vmax);
+            // 2. Blend the mask with the index
+            let search_index = _mm256_blendv_epi8(
+                _mm256_set1_epi8(i8::MAX), // if mask is 0, use i8::MAX
+                index,                     // if mask is 1, use index
+                mask,
+            );
+            // 3. Find the maximum index
+            let mut imin: __m256i = search_index;
+            imin = _mm256_min_epi8(imin, _mm256_permute2x128_si256(imin, imin, 1));
+            imin = _mm256_min_epi8(imin, _mm256_alignr_epi8(imin, imin, 8));
+            imin = _mm256_min_epi8(imin, _mm256_alignr_epi8(imin, imin, 4));
+            imin = _mm256_min_epi8(imin, _mm256_alignr_epi8(imin, imin, 2));
+            imin = _mm256_min_epi8(imin, _mm256_alignr_epi8(imin, imin, 1));
+            let max_index: usize = _mm256_extract_epi8(imin, 0) as usize;
+
+            (max_index, _i8decrord_to_u8(max_value))
+        }
+
+        #[inline(always)]
+        unsafe fn _get_min_max_index_value(
+            index_low: __m256i,
+            values_low: __m256i,
+            index_high: __m256i,
+            values_high: __m256i,
+        ) -> (usize, u8, usize, u8) {
+            let (min_index, min_value) = Self::_horiz_min(index_low, values_low);
+            let (max_index, max_value) = Self::_horiz_max(index_high, values_high);
+            // Swap min and max here because we worked with i8ord in decreasing order (max => actual min, and vice versa)
+            (max_index, max_value, min_index, min_value)
+        }
+    }
+
+    // ------------------------------------ TESTS --------------------------------------
+
+    #[cfg(test)]
+    mod tests {
+        use super::{AVX2, SIMD};
+        use crate::scalar::generic::scalar_argminmax;
+
+        use ndarray::Array1;
+
+        extern crate dev_utils;
+        use dev_utils::utils;
+
+        fn get_array_u8(n: usize) -> Array1<u8> {
+            utils::get_random_array(n, u8::MIN, u8::MAX)
+        }
+
+        #[test]
+        fn test_both_versions_return_the_same_results() {
+            if !is_x86_feature_detected!("avx2") {
+                return;
+            }
+
+            let data = get_array_u8(65);
+            assert_eq!(data.len() % 16, 1);
+
+            let (argmin_index, argmax_index) = scalar_argminmax(data.view());
+            let (simd_argmin_index, simd_argmax_index) = unsafe { AVX2::argminmax(data.view()) };
+            assert_eq!(argmin_index, simd_argmin_index);
+            assert_eq!(argmax_index, simd_argmax_index);
+        }
+
+        #[test]
+        fn test_first_index_is_returned_when_identical_values_found() {
+            if !is_x86_feature_detected!("avx2") {
+                return;
+            }
+
+            let data = [10, std::u8::MIN, 6, 9, 9, 22, std::u8::MAX, 4, std::u8::MAX];
+            let data: Vec<u8> = data.iter().map(|x| *x).collect();
+            let data = Array1::from(data);
+
+            let (argmin_index, argmax_index) = scalar_argminmax(data.view());
+            assert_eq!(argmin_index, 1);
+            assert_eq!(argmax_index, 6);
+
+            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data.view()) };
+            assert_eq!(argmin_simd_index, 1);
+            assert_eq!(argmax_simd_index, 6);
+        }
+
+        #[test]
+        fn test_no_overflow() {
+            if !is_x86_feature_detected!("avx2") {
+                return;
+            }
+
+            let n: usize = 1 << 10;
+            let data = get_array_u8(n);
+
+            let (argmin_index, argmax_index) = scalar_argminmax(data.view());
+            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data.view()) };
+            assert_eq!(argmin_index, argmin_simd_index);
+            assert_eq!(argmax_index, argmax_simd_index);
+        }
+
+        #[test]
+        fn test_many_random_runs() {
+            if !is_x86_feature_detected!("avx2") {
+                return;
+            }
+
+            for _ in 0..10_000 {
+                let data = get_array_u8(32 * 2 + 1);
+                let (argmin_index, argmax_index) = scalar_argminmax(data.view());
+                let (argmin_simd_index, argmax_simd_index) =
+                    unsafe { AVX2::argminmax(data.view()) };
+                assert_eq!(argmin_index, argmin_simd_index);
+                assert_eq!(argmax_index, argmax_simd_index);
+            }
+        }
+    }
+}
+
+// ----------------------------------------- SSE -----------------------------------------
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+mod sse {
+    use super::super::config::SSE;
+    use super::*;
+
+    const LANE_SIZE: usize = SSE::LANE_SIZE_8;
+    const XOR_MASK: __m128i = unsafe { std::mem::transmute([XOR_VALUE; LANE_SIZE]) };
+
+    #[inline(always)]
+    unsafe fn _u8_to_i8decrord(u8: __m128i) -> __m128i {
+        // on a scalar: v^ 0x7F
+        // transforms to monotonically **decreasing** order
+        _mm_xor_si128(u8, XOR_MASK)
+    }
+
+    #[inline(always)]
+    unsafe fn _reg_to_i8_arr(reg: __m128i) -> [i8; LANE_SIZE] {
+        std::mem::transmute::<__m128i, [i8; LANE_SIZE]>(reg)
+    }
+
+    impl SIMD<u8, __m128i, __m128i, LANE_SIZE> for SSE {
+        const INITIAL_INDEX: __m128i = unsafe {
+            std::mem::transmute([
+                0i8, 1i8, 2i8, 3i8, 4i8, 5i8, 6i8, 7i8, 8i8, 9i8, 10i8, 11i8, 12i8, 13i8, 14i8,
+                15i8,
+            ])
+        };
+        const MAX_INDEX: usize = i8::MAX as usize;
+
+        #[inline(always)]
+        unsafe fn _reg_to_arr(_: __m128i) -> [u8; LANE_SIZE] {
+            // Not used because we work with i8ord and override _get_min_index_value and _get_max_index_value
+            unimplemented!()
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_loadu(data: *const u8) -> __m128i {
+            _u8_to_i8decrord(_mm_loadu_si128(data as *const __m128i))
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_set1(a: usize) -> __m128i {
+            _mm_set1_epi8(a as i8)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_add(a: __m128i, b: __m128i) -> __m128i {
+            _mm_add_epi8(a, b)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_cmpgt(a: __m128i, b: __m128i) -> __m128i {
+            _mm_cmpgt_epi8(a, b)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_cmplt(a: __m128i, b: __m128i) -> __m128i {
+            _mm_cmplt_epi8(a, b)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_blendv(a: __m128i, b: __m128i, mask: __m128i) -> __m128i {
+            _mm_blendv_epi8(a, b, mask)
+        }
+
+        // ------------------------------------ ARGMINMAX --------------------------------------
+
+        #[target_feature(enable = "sse4.1")]
+        unsafe fn argminmax(data: ArrayView1<u8>) -> (usize, usize) {
+            Self::_argminmax(data)
+        }
+
+        #[inline(always)]
+        unsafe fn _horiz_min(index: __m128i, value: __m128i) -> (usize, u8) {
+            // 0. Find the minimum value
+            let mut vmin: __m128i = value;
+            vmin = _mm_min_epi8(vmin, _mm_alignr_epi8(vmin, vmin, 8));
+            vmin = _mm_min_epi8(vmin, _mm_alignr_epi8(vmin, vmin, 4));
+            vmin = _mm_min_epi8(vmin, _mm_alignr_epi8(vmin, vmin, 2));
+            vmin = _mm_min_epi8(vmin, _mm_alignr_epi8(vmin, vmin, 1));
+            let min_value: i8 = _mm_extract_epi8(vmin, 0) as i8;
+
+            // Extract the index of the minimum value
+            // 1. Create a mask with the index of the minimum value
+            let mask = _mm_cmpeq_epi8(value, vmin);
+            // 2. Blend the mask with the index
+            let search_index = _mm_blendv_epi8(
+                _mm_set1_epi8(i8::MAX), // if mask is 0, use i8::MAX
+                index,                  // if mask is 1, use index
+                mask,
+            );
+            // 3. Find the minimum index
+            let mut imin: __m128i = search_index;
+            imin = _mm_min_epi8(imin, _mm_alignr_epi8(imin, imin, 8));
+            imin = _mm_min_epi8(imin, _mm_alignr_epi8(imin, imin, 4));
+            imin = _mm_min_epi8(imin, _mm_alignr_epi8(imin, imin, 2));
+            imin = _mm_min_epi8(imin, _mm_alignr_epi8(imin, imin, 1));
+            let min_index: usize = _mm_extract_epi8(imin, 0) as usize;
+
+            (min_index, _i8decrord_to_u8(min_value))
+        }
+
+        #[inline(always)]
+        unsafe fn _horiz_max(index: __m128i, value: __m128i) -> (usize, u8) {
+            // 0. Find the maximum value
+            let mut vmax: __m128i = value;
+            vmax = _mm_max_epi8(vmax, _mm_alignr_epi8(vmax, vmax, 8));
+            vmax = _mm_max_epi8(vmax, _mm_alignr_epi8(vmax, vmax, 4));
+            vmax = _mm_max_epi8(vmax, _mm_alignr_epi8(vmax, vmax, 2));
+            vmax = _mm_max_epi8(vmax, _mm_alignr_epi8(vmax, vmax, 1));
+            let max_value: i8 = _mm_extract_epi8(vmax, 0) as i8;
+
+            // Extract the index of the maximum value
+            // 1. Create a mask with the index of the maximum value
+            let mask = _mm_cmpeq_epi8(value, vmax);
+            // 2. Blend the mask with the index
+            let search_index = _mm_blendv_epi8(
+                _mm_set1_epi8(i8::MAX), // if mask is 0, use i8::MAX
+                index,                  // if mask is 1, use index
+                mask,
+            );
+            // 3. Find the minimum index
+            let mut imin: __m128i = search_index;
+            imin = _mm_min_epi8(imin, _mm_alignr_epi8(imin, imin, 8));
+            imin = _mm_min_epi8(imin, _mm_alignr_epi8(imin, imin, 4));
+            imin = _mm_min_epi8(imin, _mm_alignr_epi8(imin, imin, 2));
+            imin = _mm_min_epi8(imin, _mm_alignr_epi8(imin, imin, 1));
+            let max_index: usize = _mm_extract_epi8(imin, 0) as usize;
+
+            (max_index, _i8decrord_to_u8(max_value))
+        }
+
+        #[inline(always)]
+        unsafe fn _get_min_max_index_value(
+            index_low: __m128i,
+            values_low: __m128i,
+            index_high: __m128i,
+            values_high: __m128i,
+        ) -> (usize, u8, usize, u8) {
+            let (min_index, min_value) = Self::_horiz_min(index_low, values_low);
+            let (max_index, max_value) = Self::_horiz_max(index_high, values_high);
+            // Swap min and max here because we worked with i8ord in decreasing order (max => actual min, and vice versa)
+            (max_index, max_value, min_index, min_value)
+        }
+    }
+
+    // ----------------------------------------- TESTS -----------------------------------------
+
+    #[cfg(test)]
+    mod tests {
+        use super::{SIMD, SSE};
+        use crate::scalar::generic::scalar_argminmax;
+
+        use ndarray::Array1;
+
+        extern crate dev_utils;
+        use dev_utils::utils;
+
+        fn get_array_u8(n: usize) -> Array1<u8> {
+            utils::get_random_array(n, u8::MIN, u8::MAX)
+        }
+
+        #[test]
+        fn test_both_versions_return_the_same_results() {
+            let data = get_array_u8(65);
+            assert_eq!(data.len() % 16, 1);
+
+            let (argmin_index, argmax_index) = scalar_argminmax(data.view());
+            let (simd_argmin_index, simd_argmax_index) = unsafe { SSE::argminmax(data.view()) };
+            assert_eq!(argmin_index, simd_argmin_index);
+            assert_eq!(argmax_index, simd_argmax_index);
+        }
+
+        #[test]
+        fn test_first_index_is_returned_when_identical_values_found() {
+            let data = [10, std::u8::MIN, 6, 9, 9, 22, std::u8::MAX, 4, std::u8::MAX];
+            let data: Vec<u8> = data.iter().map(|x| *x).collect();
+            let data = Array1::from(data);
+
+            let (argmin_index, argmax_index) = scalar_argminmax(data.view());
+            assert_eq!(argmin_index, 1);
+            assert_eq!(argmax_index, 6);
+
+            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data.view()) };
+            assert_eq!(argmin_simd_index, 1);
+            assert_eq!(argmax_simd_index, 6);
+        }
+
+        #[test]
+        fn test_no_overflow() {
+            let n: usize = 1 << 10;
+            let data = get_array_u8(n);
+
+            let (argmin_index, argmax_index) = scalar_argminmax(data.view());
+            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data.view()) };
+            assert_eq!(argmin_index, argmin_simd_index);
+            assert_eq!(argmax_index, argmax_simd_index);
+        }
+
+        #[test]
+        fn test_many_random_runs() {
+            for _ in 0..10_000 {
+                let data = get_array_u8(32 * 2 + 1);
+                let (argmin_index, argmax_index) = scalar_argminmax(data.view());
+                let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data.view()) };
+                assert_eq!(argmin_index, argmin_simd_index);
+                assert_eq!(argmax_index, argmax_simd_index);
+            }
+        }
+    }
+}
+
+// --------------------------------------- AVX512 ----------------------------------------
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+mod avx512 {
+    use super::super::config::AVX512;
+    use super::*;
+
+    const LANE_SIZE: usize = AVX512::LANE_SIZE_8;
+
+    const XOR_MASK: __m512i = unsafe { std::mem::transmute([XOR_VALUE; LANE_SIZE]) };
+
+    //  - comparison swappen => dan moeten we opt einde niet meer swappen?
+
+    #[inline(always)]
+    unsafe fn _u8_to_i8decrord(u8: __m512i) -> __m512i {
+        // on a scalar: v^ 0x7F
+        // transforms to monotonically **decreasing** order
+        _mm512_xor_si512(u8, XOR_MASK)
+    }
+
+    #[inline(always)]
+    unsafe fn _reg_to_i8_arr(reg: __m512i) -> [i8; LANE_SIZE] {
+        std::mem::transmute::<__m512i, [i8; LANE_SIZE]>(reg)
+    }
+
+    impl SIMD<u8, __m512i, u64, LANE_SIZE> for AVX512 {
+        const INITIAL_INDEX: __m512i = unsafe {
+            std::mem::transmute([
+                0i8, 1i8, 2i8, 3i8, 4i8, 5i8, 6i8, 7i8, 8i8, 9i8, 10i8, 11i8, 12i8, 13i8, 14i8,
+                15i8, 16i8, 17i8, 18i8, 19i8, 20i8, 21i8, 22i8, 23i8, 24i8, 25i8, 26i8, 27i8, 28i8,
+                29i8, 30i8, 31i8, 32i8, 33i8, 34i8, 35i8, 36i8, 37i8, 38i8, 39i8, 40i8, 41i8, 42i8,
+                43i8, 44i8, 45i8, 46i8, 47i8, 48i8, 49i8, 50i8, 51i8, 52i8, 53i8, 54i8, 55i8, 56i8,
+                57i8, 58i8, 59i8, 60i8, 61i8, 62i8, 63i8,
+            ])
+        };
+        const MAX_INDEX: usize = i8::MAX as usize;
+
+        #[inline(always)]
+        unsafe fn _reg_to_arr(_: __m512i) -> [u8; LANE_SIZE] {
+            unimplemented!(
+                "We work with decrordi8 and override _get_min_index_value and _get_max_index_value"
+            )
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_loadu(data: *const u8) -> __m512i {
+            _u8_to_i8decrord(_mm512_loadu_epi8(data as *const i8))
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_set1(a: usize) -> __m512i {
+            _mm512_set1_epi8(a as i8)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_add(a: __m512i, b: __m512i) -> __m512i {
+            _mm512_add_epi8(a, b)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_cmpgt(a: __m512i, b: __m512i) -> u64 {
+            _mm512_cmpgt_epi8_mask(a, b)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_cmplt(a: __m512i, b: __m512i) -> u64 {
+            _mm512_cmplt_epi8_mask(a, b)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_blendv(a: __m512i, b: __m512i, mask: u64) -> __m512i {
+            _mm512_mask_blend_epi8(mask, a, b)
+        }
+
+        // ------------------------------------ ARGMINMAX --------------------------------------
+
+        #[target_feature(enable = "avx512bw")]
+        unsafe fn argminmax(data: ArrayView1<u8>) -> (usize, usize) {
+            Self::_argminmax(data)
+        }
+
+        #[inline(always)]
+        unsafe fn _horiz_min(index: __m512i, value: __m512i) -> (usize, u8) {
+            // 0. Find the minimum value
+            let mut vmin: __m512i = value;
+            vmin = _mm512_min_epi8(vmin, _mm512_alignr_epi32(vmin, vmin, 8));
+            vmin = _mm512_min_epi8(vmin, _mm512_alignr_epi32(vmin, vmin, 4));
+            vmin = _mm512_min_epi8(vmin, _mm512_alignr_epi8(vmin, vmin, 8));
+            vmin = _mm512_min_epi8(vmin, _mm512_alignr_epi8(vmin, vmin, 4));
+            vmin = _mm512_min_epi8(vmin, _mm512_alignr_epi8(vmin, vmin, 2));
+            vmin = _mm512_min_epi8(vmin, _mm512_alignr_epi8(vmin, vmin, 1));
+            let min_value: i8 = _mm_extract_epi8(_mm512_castsi512_si128(vmin), 0) as i8;
+
+            // Extract the index of the minimum value
+            // 1. Create a mask with the index of the minimum value
+            let mask = _mm512_cmpeq_epi8_mask(value, vmin);
+            // 2. Blend the mask with the index
+            let search_index = _mm512_mask_blend_epi8(
+                mask,
+                _mm512_set1_epi8(i8::MAX), // if mask is 0, use i8::MAX
+                index,                     // if mask is 1, use index
+            );
+            // 3. Find the minimum index
+            let mut imin: __m512i = search_index;
+            imin = _mm512_min_epi8(imin, _mm512_alignr_epi32(imin, imin, 8));
+            imin = _mm512_min_epi8(imin, _mm512_alignr_epi32(imin, imin, 4));
+            imin = _mm512_min_epi8(imin, _mm512_alignr_epi8(imin, imin, 8));
+            imin = _mm512_min_epi8(imin, _mm512_alignr_epi8(imin, imin, 4));
+            imin = _mm512_min_epi8(imin, _mm512_alignr_epi8(imin, imin, 2));
+            imin = _mm512_min_epi8(imin, _mm512_alignr_epi8(imin, imin, 1));
+            let min_index: usize = _mm_extract_epi8(_mm512_castsi512_si128(imin), 0) as usize;
+
+            (min_index, _i8decrord_to_u8(min_value))
+        }
+
+        #[inline(always)]
+        unsafe fn _horiz_max(index: __m512i, value: __m512i) -> (usize, u8) {
+            // 0. Find the maximum value
+            let mut vmax: __m512i = value;
+            vmax = _mm512_max_epi8(vmax, _mm512_alignr_epi32(vmax, vmax, 8));
+            vmax = _mm512_max_epi8(vmax, _mm512_alignr_epi32(vmax, vmax, 4));
+            vmax = _mm512_max_epi8(vmax, _mm512_alignr_epi8(vmax, vmax, 8));
+            vmax = _mm512_max_epi8(vmax, _mm512_alignr_epi8(vmax, vmax, 4));
+            vmax = _mm512_max_epi8(vmax, _mm512_alignr_epi8(vmax, vmax, 2));
+            vmax = _mm512_max_epi8(vmax, _mm512_alignr_epi8(vmax, vmax, 1));
+            let max_value: i8 = _mm_extract_epi8(_mm512_castsi512_si128(vmax), 0) as i8;
+
+            // Extract the index of the maximum value
+            // 1. Create a mask with the index of the maximum value
+            let mask = _mm512_cmpeq_epi8_mask(value, vmax);
+            // 2. Blend the mask with the index
+            let search_index = _mm512_mask_blend_epi8(
+                mask,
+                _mm512_set1_epi8(i8::MAX), // if mask is 0, use i8::MAX
+                index,                     // if mask is 1, use index
+            );
+            // 3. Find the maximum index
+            let mut imin: __m512i = search_index;
+            imin = _mm512_min_epi8(imin, _mm512_alignr_epi32(imin, imin, 8));
+            imin = _mm512_min_epi8(imin, _mm512_alignr_epi32(imin, imin, 4));
+            imin = _mm512_min_epi8(imin, _mm512_alignr_epi8(imin, imin, 8));
+            imin = _mm512_min_epi8(imin, _mm512_alignr_epi8(imin, imin, 4));
+            imin = _mm512_min_epi8(imin, _mm512_alignr_epi8(imin, imin, 2));
+            imin = _mm512_min_epi8(imin, _mm512_alignr_epi8(imin, imin, 1));
+            let max_index: usize = _mm_extract_epi8(_mm512_castsi512_si128(imin), 0) as usize;
+
+            (max_index, _i8decrord_to_u8(max_value))
+        }
+
+        #[inline(always)]
+        unsafe fn _get_min_max_index_value(
+            index_low: __m512i,
+            values_low: __m512i,
+            index_high: __m512i,
+            values_high: __m512i,
+        ) -> (usize, u8, usize, u8) {
+            let (min_index, min_value) = Self::_horiz_min(index_low, values_low);
+            let (max_index, max_value) = Self::_horiz_max(index_high, values_high);
+            // Swap min and max here because we worked with i8ord in decreasing order (max => actual min, and vice versa)
+            (max_index, max_value, min_index, min_value)
+        }
+    }
+
+    // ----------------------------------------- TESTS -----------------------------------------
+
+    #[cfg(test)]
+
+    mod tests {
+        use super::{AVX512, SIMD};
+        use crate::scalar::generic::scalar_argminmax;
+
+        use ndarray::Array1;
+
+        extern crate dev_utils;
+        use dev_utils::utils;
+
+        fn get_array_u8(n: usize) -> Array1<u8> {
+            utils::get_random_array(n, u8::MIN, u8::MAX)
+        }
+
+        #[test]
+        fn test_both_versions_return_the_same_results() {
+            if !is_x86_feature_detected!("avx512f") {
+                return;
+            }
+
+            let data = get_array_u8(65);
+            assert_eq!(data.len() % 16, 1);
+
+            let (argmin_index, argmax_index) = scalar_argminmax(data.view());
+            let (simd_argmin_index, simd_argmax_index) = unsafe { AVX512::argminmax(data.view()) };
+            assert_eq!(argmin_index, simd_argmin_index);
+            assert_eq!(argmax_index, simd_argmax_index);
+        }
+
+        #[test]
+        fn test_first_index_is_returned_when_identical_values_found() {
+            if !is_x86_feature_detected!("avx512f") {
+                return;
+            }
+
+            let data = [10, std::u8::MIN, 6, 9, 9, 22, std::u8::MAX, 4, std::u8::MAX];
+            let data: Vec<u8> = data.iter().map(|x| *x).collect();
+            let data = Array1::from(data);
+
+            let (argmin_index, argmax_index) = scalar_argminmax(data.view());
+            assert_eq!(argmin_index, 1);
+            assert_eq!(argmax_index, 6);
+
+            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data.view()) };
+            assert_eq!(argmin_simd_index, 1);
+            assert_eq!(argmax_simd_index, 6);
+        }
+
+        #[test]
+        fn test_no_overflow() {
+            if !is_x86_feature_detected!("avx512f") {
+                return;
+            }
+
+            let n: usize = 1 << 10;
+            let data = get_array_u8(n);
+
+            let (argmin_index, argmax_index) = scalar_argminmax(data.view());
+            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data.view()) };
+            assert_eq!(argmin_index, argmin_simd_index);
+            assert_eq!(argmax_index, argmax_simd_index);
+        }
+
+        #[test]
+        fn test_many_random_runs() {
+            if !is_x86_feature_detected!("avx512f") {
+                return;
+            }
+
+            for _ in 0..10_000 {
+                let data = get_array_u8(32 * 4 + 1);
+                let (argmin_index, argmax_index) = scalar_argminmax(data.view());
+                let (argmin_simd_index, argmax_simd_index) =
+                    unsafe { AVX512::argminmax(data.view()) };
+                assert_eq!(argmin_index, argmin_simd_index);
+                assert_eq!(argmax_index, argmax_simd_index);
+            }
+        }
+    }
+}
+
+// ---------------------------------------- NEON -----------------------------------------
+
+#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+mod neon {
+    use super::super::config::NEON;
+    use super::*;
+
+    const LANE_SIZE: usize = NEON::LANE_SIZE_8;
+
+    impl SIMD<u8, uint8x16_t, uint8x16_t, LANE_SIZE> for NEON {
+        const INITIAL_INDEX: uint8x16_t =
+            unsafe { std::mem::transmute([0i16, 1i16, 2i16, 3i16, 4i16, 5i16, 6i16, 7i16]) };
+        const MAX_INDEX: usize = u8::MAX as usize;
+
+        #[inline(always)]
+        unsafe fn _reg_to_arr(reg: uint8x16_t) -> [u8; LANE_SIZE] {
+            std::mem::transmute::<uint8x16_t, [u8; LANE_SIZE]>(reg)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_loadu(data: *const u8) -> uint8x16_t {
+            vld1q_u8(data as *const u8)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_set1(a: usize) -> uint8x16_t {
+            vdupq_n_u8(a as u8)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_add(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
+            vaddq_u8(a, b)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_cmpgt(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
+            vcgtq_u8(a, b)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_cmplt(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
+            vcltq_u8(a, b)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_blendv(a: uint8x16_t, b: uint8x16_t, mask: uint8x16_t) -> uint8x16_t {
+            vbslq_u8(mask, b, a)
+        }
+
+        // ------------------------------------ ARGMINMAX --------------------------------------
+
+        #[target_feature(enable = "neon")]
+        unsafe fn argminmax(data: ArrayView1<u8>) -> (usize, usize) {
+            Self::_argminmax(data)
+        }
+    }
+
+    // ----------------------------------------- TESTS -----------------------------------------
+
+    #[cfg(test)]
+    mod tests {
+        use super::{NEON, SIMD};
+        use crate::scalar::generic::scalar_argminmax;
+
+        use ndarray::Array1;
+
+        extern crate dev_utils;
+        use dev_utils::utils;
+
+        fn get_array_u8(n: usize) -> Array1<u8> {
+            utils::get_random_array(n, u8::MIN, u8::MAX)
+        }
+
+        #[test]
+        fn test_both_versions_return_the_same_results() {
+            let data = get_array_u8(513);
+            assert_eq!(data.len() % 16, 1);
+
+            let (argmin_index, argmax_index) = scalar_argminmax(data.view());
+            let (simd_argmin_index, simd_argmax_index) = unsafe { NEON::argminmax(data.view()) };
+            assert_eq!(argmin_index, simd_argmin_index);
+            assert_eq!(argmax_index, simd_argmax_index);
+        }
+
+        #[test]
+        fn test_first_index_is_returned_when_identical_values_found() {
+            let data = [10, std::u8::MIN, 6, 9, 9, 22, std::u8::MAX, 4, std::u8::MAX];
+            let data: Vec<u8> = data.iter().map(|x| *x).collect();
+            let data = Array1::from(data);
+
+            let (argmin_index, argmax_index) = scalar_argminmax(data.view());
+            assert_eq!(argmin_index, 1);
+            assert_eq!(argmax_index, 6);
+
+            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data.view()) };
+            assert_eq!(argmin_simd_index, 1);
+            assert_eq!(argmax_simd_index, 6);
+        }
+
+        #[test]
+        fn test_no_overflow() {
+            let n: usize = 1 << 10;
+            let data = get_array_u8(n);
+
+            let (argmin_index, argmax_index) = scalar_argminmax(data.view());
+            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data.view()) };
+            assert_eq!(argmin_index, argmin_simd_index);
+            assert_eq!(argmax_index, argmax_simd_index);
+        }
+
+        #[test]
+        fn test_many_random_runs() {
+            for _ in 0..10_000 {
+                let data = get_array_u8(32 * 2 + 1);
+                let (argmin_index, argmax_index) = scalar_argminmax(data.view());
+                let (argmin_simd_index, argmax_simd_index) =
+                    unsafe { NEON::argminmax(data.view()) };
+                assert_eq!(argmin_index, argmin_simd_index);
+                assert_eq!(argmax_index, argmax_simd_index);
+            }
+        }
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,43 +5,77 @@
 // registers) is not necessarily the lowest min / max index when the min / max value
 // occurs multiple times.
 
+// #[inline(always)]
+// pub(crate) fn min_index_value<T: Copy + PartialOrd>(index: &[T], values: &[T]) -> (T, T) {
+//     assert_eq!(index.len(), values.len());
+//     let mut min_index: usize = 0;
+//     let mut min_value = values[min_index];
+//     for (i, value) in values.iter().enumerate() {
+//         // No skip(1) here bc 5-7% slower
+//         if *value < min_value {
+//             min_value = *value;
+//             min_index = i;
+//         } else if *value == min_value && index[i] < index[min_index] {
+//             min_index = i;
+//         }
+//     }
+//     (index[min_index], min_value)
+// }
+
 #[inline(always)]
 pub(crate) fn min_index_value<T: Copy + PartialOrd>(index: &[T], values: &[T]) -> (T, T) {
     assert_eq!(index.len(), values.len());
-    let mut min_index: usize = 0;
-    let mut min_value = values[min_index];
-    for (i, value) in values.iter().enumerate() {
-        // No skip(1) here bc 5-7% slower
-        if *value < min_value {
-            min_value = *value;
-            min_index = i;
-        } else if *value == min_value && index[i] < index[min_index] {
-            min_index = i;
-        }
-    }
-    (index[min_index], min_value)
+    values
+        .iter()
+        .enumerate()
+        .fold((index[0], values[0]), |(min_idx, min), (idx, item)| {
+            if *item < min {
+                (index[idx], *item)
+            } else if *item == min && index[idx] < min_idx {
+                (index[idx], *item)
+            } else {
+                (min_idx, min)
+            }
+        })
 }
+
+// #[inline(always)]
+// pub(crate) fn max_index_value__<T: Copy + PartialOrd>(index: &[T], values: &[T]) -> (T, T) {
+//     assert_eq!(index.len(), values.len());
+//     let mut max_index: usize = 0;
+//     let mut max_value = values[max_index];
+//     for (i, value) in values.iter().enumerate() {
+//         // No skip(1) here bc 5-7% slower
+//         if *value > max_value {
+//             max_value = *value;
+//             max_index = i;
+//         } else if *value == max_value && index[i] < index[max_index] {
+//             max_index = i;
+//         }
+
+//         // // Unbranching version of the above
+//         // let gt_mask = *value > values[max_index];
+//         // let smaller_index_mask = *value == values[max_index] && index[i] < index[max_index];
+//         // let cond = (gt_mask | smaller_index_mask) as usize;
+//         // let not_cond = (cond + 1) % 2;
+//         // max_index = (max_index * not_cond) + (i * cond);
+//     }
+//     (index[max_index], max_value)
+// }
 
 #[inline(always)]
 pub(crate) fn max_index_value<T: Copy + PartialOrd>(index: &[T], values: &[T]) -> (T, T) {
     assert_eq!(index.len(), values.len());
-    let mut max_index: usize = 0;
-    let mut max_value = values[max_index];
-    for (i, value) in values.iter().enumerate() {
-        // No skip(1) here bc 5-7% slower
-        if *value > max_value {
-            max_value = *value;
-            max_index = i;
-        } else if *value == max_value && index[i] < index[max_index] {
-            max_index = i;
-        }
-
-        // // Unbranching version of the above
-        // let gt_mask = *value > values[max_index];
-        // let smaller_index_mask = *value == values[max_index] && index[i] < index[max_index];
-        // let cond = (gt_mask | smaller_index_mask) as usize;
-        // let not_cond = (cond + 1) % 2;
-        // max_index = (max_index * not_cond) + (i * cond);
-    }
-    (index[max_index], max_value)
+    values
+        .iter()
+        .enumerate()
+        .fold((index[0], values[0]), |(max_idx, max), (idx, item)| {
+            if *item > max {
+                (index[idx], *item)
+            } else if *item == max && index[idx] < max_idx {
+                (index[idx], *item)
+            } else {
+                (max_idx, max)
+            }
+        })
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -29,9 +29,7 @@ pub(crate) fn min_index_value<T: Copy + PartialOrd>(index: &[T], values: &[T]) -
         .iter()
         .enumerate()
         .fold((index[0], values[0]), |(min_idx, min), (idx, item)| {
-            if *item < min {
-                (index[idx], *item)
-            } else if *item == min && index[idx] < min_idx {
+            if *item < min || (*item == min && index[idx] < min_idx) {
                 (index[idx], *item)
             } else {
                 (min_idx, min)
@@ -70,9 +68,7 @@ pub(crate) fn max_index_value<T: Copy + PartialOrd>(index: &[T], values: &[T]) -
         .iter()
         .enumerate()
         .fold((index[0], values[0]), |(max_idx, max), (idx, item)| {
-            if *item > max {
-                (index[idx], *item)
-            } else if *item == max && index[idx] < max_idx {
+            if *item > max || (*item == max && index[idx] < max_idx) {
                 (index[idx], *item)
             } else {
                 (max_idx, max)


### PR DESCRIPTION
:sparkles: add support for `int8`
- [x] SIMD + SCALAR implementation
  - [x] alleviate bottleneck (horizontal argmin in final vector)
          -> algorithm: https://stackoverflow.com/a/9798369
    - [x] SSE
    - [x] AVX2
    - [x] AVX512(bw) 
    - [x] ARM/AARCH64

:thinking: add support for `uint8`?  
-> would probably require the XOR conversion ~~but would exit the overflow loop 2x fewer than `int8` (guess this will be net 1.5x faster than `int8` for longer arrays)~~ :sweat_smile: nvm still limited by the `i8::MAX` for overflow
TODO: bench + horizontal SIMD implementation for neon
- [x] SSE
- [x] AVX2
- [x] AVX512(bw) 
- [x] ARM/AARCH64

:snowflake: minor improvements
- [x] faster implementation of overflow loop
- [ ] ~~remove `_get_min_max_index_value`~~ => is for another refactoring :recycle: PR

Other stuff
- [x] :robot: rerun benchmarks!