### PR TITLE
:rabbit: add codspeed benchmarking to ci/cd

### DIFF
--- a/.github/workflows/codspeed.yaml
+++ b/.github/workflows/codspeed.yaml
@@ -1,0 +1,52 @@
+name: CodSpeed Benchmarks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  # `workflow_dispatch` allows CodSpeed to trigger backtest
+  # performance analysis in order to generate initial data.
+  workflow_dispatch:
+
+jobs:
+  Benchmarks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-stable-${{ hashFiles('Cargo.toml') }}
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+      - name: Setup Rust
+        run: |
+          rustup update nightly --no-self-update
+          rustup default nightly
+
+      - name: Install cargo-codspeed (with cache)
+        uses: baptiste0928/cargo-install@v1
+        with:
+          crate: cargo-codspeed
+
+      - name: Build benchmarks
+        uses: actions-rs/cargo@v1
+        with:
+          command: codspeed
+          args: build
+
+      - uses: CodSpeedHQ/action@v1
+        name: Run benchmarks
+        with:
+          run: cargo codspeed run

--- a/.github/workflows/codspeed.yaml
+++ b/.github/workflows/codspeed.yaml
@@ -40,11 +40,8 @@ jobs:
         with:
           crate: cargo-codspeed
 
-      - name: Build benchmarks
-        uses: actions-rs/cargo@v1
-        with:
-          command: codspeed
-          args: build
+      - name: Build the benchmark target(s)
+        run: cargo codspeed build # --features half
 
       - uses: CodSpeedHQ/action@v1
         name: Run benchmarks

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ half = { version = "2.1.0", default-features = false, features=["num-traits"], o
 num-traits = { version = "0.2.15", default-features = false }
 # once_cell = "1.16.0"
 
+[features]
+default = ["half"] # TODO: remove this as default feature as soon as https://github.com/CodSpeedHQ/codspeed-rust/issues/1 is fixed
+
 [dev-dependencies]
 codspeed-criterion-compat = "1.0.1"
 criterion = "0.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ num-traits = { version = "0.2.15", default-features = false }
 # once_cell = "1.16.0"
 
 [dev-dependencies]
+codspeed-criterion-compat = "1.0.1"
 criterion = "0.3.1"
 dev_utils = { path = "dev_utils" }
 

--- a/benches/bench_f16.rs
+++ b/benches/bench_f16.rs
@@ -1,12 +1,10 @@
 #![feature(stdsimd)]
 
-#[macro_use]
-extern crate criterion;
 extern crate dev_utils;
 
 #[cfg(feature = "half")]
 use argminmax::ArgMinMax;
-use criterion::{black_box, Criterion};
+use codspeed_criterion_compat::*;
 use dev_utils::{config, utils};
 
 use argminmax::{ScalarArgMinMax, SCALAR};

--- a/benches/bench_f32.rs
+++ b/benches/bench_f32.rs
@@ -1,11 +1,10 @@
 #![feature(stdsimd)]
 
-#[macro_use]
-extern crate criterion;
 extern crate dev_utils;
 
+#[cfg(feature = "half")]
 use argminmax::ArgMinMax;
-use criterion::{black_box, Criterion};
+use codspeed_criterion_compat::*;
 use dev_utils::{config, utils};
 
 use argminmax::{ScalarArgMinMax, SCALAR};

--- a/benches/bench_f64.rs
+++ b/benches/bench_f64.rs
@@ -1,11 +1,10 @@
 #![feature(stdsimd)]
 
-#[macro_use]
-extern crate criterion;
 extern crate dev_utils;
 
+#[cfg(feature = "half")]
 use argminmax::ArgMinMax;
-use criterion::{black_box, Criterion};
+use codspeed_criterion_compat::*;
 use dev_utils::{config, utils};
 
 use argminmax::{ScalarArgMinMax, SCALAR};

--- a/benches/bench_i16.rs
+++ b/benches/bench_i16.rs
@@ -1,11 +1,10 @@
 #![feature(stdsimd)]
 
-#[macro_use]
-extern crate criterion;
 extern crate dev_utils;
 
+#[cfg(feature = "half")]
 use argminmax::ArgMinMax;
-use criterion::{black_box, Criterion};
+use codspeed_criterion_compat::*;
 use dev_utils::{config, utils};
 
 use argminmax::{ScalarArgMinMax, SCALAR};

--- a/benches/bench_i32.rs
+++ b/benches/bench_i32.rs
@@ -1,11 +1,10 @@
 #![feature(stdsimd)]
 
-#[macro_use]
-extern crate criterion;
 extern crate dev_utils;
 
+#[cfg(feature = "half")]
 use argminmax::ArgMinMax;
-use criterion::{black_box, Criterion};
+use codspeed_criterion_compat::*;
 use dev_utils::{config, utils};
 
 use argminmax::{ScalarArgMinMax, SCALAR};

--- a/benches/bench_i64.rs
+++ b/benches/bench_i64.rs
@@ -1,11 +1,10 @@
 #![feature(stdsimd)]
 
-#[macro_use]
-extern crate criterion;
 extern crate dev_utils;
 
+#[cfg(feature = "half")]
 use argminmax::ArgMinMax;
-use criterion::{black_box, Criterion};
+use codspeed_criterion_compat::*;
 use dev_utils::{config, utils};
 
 use argminmax::{ScalarArgMinMax, SCALAR};

--- a/benches/bench_i8.rs
+++ b/benches/bench_i8.rs
@@ -1,11 +1,10 @@
 #![feature(stdsimd)]
 
-#[macro_use]
-extern crate criterion;
 extern crate dev_utils;
 
+#[cfg(feature = "half")]
 use argminmax::ArgMinMax;
-use criterion::{black_box, Criterion};
+use codspeed_criterion_compat::*;
 use dev_utils::{config, utils};
 
 use argminmax::{ScalarArgMinMax, SCALAR};

--- a/benches/bench_u16.rs
+++ b/benches/bench_u16.rs
@@ -1,11 +1,10 @@
 #![feature(stdsimd)]
 
-#[macro_use]
-extern crate criterion;
 extern crate dev_utils;
 
+#[cfg(feature = "half")]
 use argminmax::ArgMinMax;
-use criterion::{black_box, Criterion};
+use codspeed_criterion_compat::*;
 use dev_utils::{config, utils};
 
 use argminmax::{ScalarArgMinMax, SCALAR};

--- a/benches/bench_u32.rs
+++ b/benches/bench_u32.rs
@@ -1,11 +1,10 @@
 #![feature(stdsimd)]
 
-#[macro_use]
-extern crate criterion;
 extern crate dev_utils;
 
+#[cfg(feature = "half")]
 use argminmax::ArgMinMax;
-use criterion::{black_box, Criterion};
+use codspeed_criterion_compat::*;
 use dev_utils::{config, utils};
 
 use argminmax::{ScalarArgMinMax, SCALAR};

--- a/benches/bench_u64.rs
+++ b/benches/bench_u64.rs
@@ -1,11 +1,10 @@
 #![feature(stdsimd)]
 
-#[macro_use]
-extern crate criterion;
 extern crate dev_utils;
 
+#[cfg(feature = "half")]
 use argminmax::ArgMinMax;
-use criterion::{black_box, Criterion};
+use codspeed_criterion_compat::*;
 use dev_utils::{config, utils};
 
 use argminmax::{ScalarArgMinMax, SCALAR};

--- a/benches/bench_u8.rs
+++ b/benches/bench_u8.rs
@@ -1,11 +1,10 @@
 #![feature(stdsimd)]
 
-#[macro_use]
-extern crate criterion;
 extern crate dev_utils;
 
+#[cfg(feature = "half")]
 use argminmax::ArgMinMax;
-use criterion::{black_box, Criterion};
+use codspeed_criterion_compat::*;
 use dev_utils::{config, utils};
 
 use argminmax::{ScalarArgMinMax, SCALAR};


### PR DESCRIPTION
To make codspeed work I had to add "half" as default feature. I will revert this once https://github.com/CodSpeedHQ/codspeed-rust/issues/1 is resolved