### PR TITLE
:construction: POC - support NaNs for SSE & AVX2 f32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ codspeed-criterion-compat = "1.0.1"
 criterion = "0.3.1"
 dev_utils = { path = "dev_utils" }
 
+[profile.release]
+lto = true
+
 
 [[bench]]
 name = "bench_f16"

--- a/benches/bench_f32.rs
+++ b/benches/bench_f32.rs
@@ -26,8 +26,8 @@ fn minmax_f32_random_array_long(c: &mut Criterion) {
         });
     }
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    if is_x86_feature_detected!("avx") {
-        c.bench_function("avx_random_long_f32", |b| {
+    if is_x86_feature_detected!("avx2") {
+        c.bench_function("avx2_random_long_f32", |b| {
             b.iter(|| unsafe { AVX2::argminmax(black_box(data)) })
         });
     }
@@ -67,8 +67,8 @@ fn minmax_f32_random_array_short(c: &mut Criterion) {
         });
     }
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    if is_x86_feature_detected!("avx") {
-        c.bench_function("avx_random_short_f32", |b| {
+    if is_x86_feature_detected!("avx2") {
+        c.bench_function("avx2_random_short_f32", |b| {
             b.iter(|| unsafe { AVX2::argminmax(black_box(data)) })
         });
     }
@@ -108,8 +108,8 @@ fn minmax_f32_worst_case_array_long(c: &mut Criterion) {
         });
     }
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    if is_x86_feature_detected!("avx") {
-        c.bench_function("avx_worst_long_f32", |b| {
+    if is_x86_feature_detected!("avx2") {
+        c.bench_function("avx2_worst_long_f32", |b| {
             b.iter(|| unsafe { AVX2::argminmax(black_box(data)) })
         });
     }
@@ -149,8 +149,8 @@ fn minmax_f32_worst_case_array_short(c: &mut Criterion) {
         });
     }
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    if is_x86_feature_detected!("avx") {
-        c.bench_function("avx_worst_short_f32", |b| {
+    if is_x86_feature_detected!("avx2") {
+        c.bench_function("avx2_worst_short_f32", |b| {
             b.iter(|| unsafe { AVX2::argminmax(black_box(data)) })
         });
     }

--- a/benches/bench_f32.rs
+++ b/benches/bench_f32.rs
@@ -27,7 +27,7 @@ fn minmax_f32_random_array_long(c: &mut Criterion) {
     }
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     if is_x86_feature_detected!("avx2") {
-        c.bench_function("avx2_random_long_f32", |b| {
+        c.bench_function("avx_random_long_f32", |b| {
             b.iter(|| unsafe { AVX2::argminmax(black_box(data)) })
         });
     }
@@ -68,7 +68,7 @@ fn minmax_f32_random_array_short(c: &mut Criterion) {
     }
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     if is_x86_feature_detected!("avx2") {
-        c.bench_function("avx2_random_short_f32", |b| {
+        c.bench_function("avx_random_short_f32", |b| {
             b.iter(|| unsafe { AVX2::argminmax(black_box(data)) })
         });
     }
@@ -109,7 +109,7 @@ fn minmax_f32_worst_case_array_long(c: &mut Criterion) {
     }
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     if is_x86_feature_detected!("avx2") {
-        c.bench_function("avx2_worst_long_f32", |b| {
+        c.bench_function("avx_worst_long_f32", |b| {
             b.iter(|| unsafe { AVX2::argminmax(black_box(data)) })
         });
     }
@@ -150,7 +150,7 @@ fn minmax_f32_worst_case_array_short(c: &mut Criterion) {
     }
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     if is_x86_feature_detected!("avx2") {
-        c.bench_function("avx2_worst_short_f32", |b| {
+        c.bench_function("avx_worst_short_f32", |b| {
             b.iter(|| unsafe { AVX2::argminmax(black_box(data)) })
         });
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,9 +126,9 @@ macro_rules! impl_argminmax {
                         } else if is_x86_feature_detected!("avx2") {
                             return unsafe { AVX2::argminmax(self) }
                         // TODO: current NaN handling requires avx2
-                        // } else if is_x86_feature_detected!("avx")  & (<$t>::NB_BITS >= 32) & (<$t>::IS_FLOAT == true) {
-                        //     // f32 and f64 do not require avx2
-                        //     return unsafe { AVX2::argminmax(self) }
+                        } else if is_x86_feature_detected!("avx")  & (<$t>::NB_BITS >= 64) & (<$t>::IS_FLOAT == true) {
+                            // f32 and f64 do not require avx2
+                            return unsafe { AVX2::argminmax(self) }
                         // // SKIP SSE4.2 bc scalar is faster or equivalent for 64 bit numbers
                         // // } else if is_x86_feature_detected!("sse4.2") & (<$t>::NB_BITS == 64) & (<$t>::IS_FLOAT == false) {
                         //     // SSE4.2 is needed for comparing 64-bit integers

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,10 +125,11 @@ macro_rules! impl_argminmax {
                             return unsafe { AVX512::argminmax(self) }
                         } else if is_x86_feature_detected!("avx2") {
                             return unsafe { AVX2::argminmax(self) }
-                        } else if is_x86_feature_detected!("avx")  & (<$t>::NB_BITS >= 32) & (<$t>::IS_FLOAT == true) {
-                            // f32 and f64 do not require avx2
-                            return unsafe { AVX2::argminmax(self) }
-                        // SKIP SSE4.2 bc scalar is faster or equivalent for 64 bit numbers
+                        // TODO: current NaN handling requires avx2
+                        // } else if is_x86_feature_detected!("avx")  & (<$t>::NB_BITS >= 32) & (<$t>::IS_FLOAT == true) {
+                        //     // f32 and f64 do not require avx2
+                        //     return unsafe { AVX2::argminmax(self) }
+                        // // SKIP SSE4.2 bc scalar is faster or equivalent for 64 bit numbers
                         // // } else if is_x86_feature_detected!("sse4.2") & (<$t>::NB_BITS == 64) & (<$t>::IS_FLOAT == false) {
                         //     // SSE4.2 is needed for comparing 64-bit integers
                         //     return unsafe { SSE::argminmax(self) }

--- a/src/scalar/generic.rs
+++ b/src/scalar/generic.rs
@@ -25,11 +25,11 @@ pub fn scalar_argminmax<T: Copy + PartialOrd>(arr: &[T]) -> (usize, usize) {
         if v != v {
             // TODO: optimize this
             // Handle NaNs: if value is NaN, than return index of that value
-            // return (i, i);
-            low = v;
-            low_index = i;
-            high = v;
-            high_index = i;
+            return (i, i);
+            // low = v;
+            // low_index = i;
+            // high = v;
+            // high_index = i;
         } else if v < low {
             low = v;
             low_index = i;

--- a/src/scalar/generic.rs
+++ b/src/scalar/generic.rs
@@ -22,7 +22,15 @@ pub fn scalar_argminmax<T: Copy + PartialOrd>(arr: &[T]) -> (usize, usize) {
     let mut high: T = unsafe { *arr.get_unchecked(high_index) };
     for i in 0..arr.len() {
         let v: T = unsafe { *arr.get_unchecked(i) };
-        if v < low {
+        if v != v {
+            // TODO: optimize this
+            // Handle NaNs: if value is NaN, than return index of that value
+            // return (i, i);
+            low = v;
+            low_index = i;
+            high = v;
+            high_index = i;
+        } else if v < low {
             low = v;
             low_index = i;
         } else if v > high {

--- a/src/simd/generic.rs
+++ b/src/simd/generic.rs
@@ -122,11 +122,11 @@ pub trait SIMD<
             // Self::_mm_prefetch(arr.as_ptr().add(start));
             let (min_index_, min_value_, max_index_, max_value_) =
                 Self::_core_argminmax(&arr[start..start + dtype_max]);
-            if min_value_ < min_value {
+            if min_value_ < min_value || min_value_ != min_value_ {
                 min_index = start + min_index_;
                 min_value = min_value_;
             }
-            if max_value_ > max_value {
+            if max_value_ > max_value || max_value_ != max_value_ {
                 max_index = start + max_index_;
                 max_value = max_value_;
             }
@@ -137,11 +137,11 @@ pub trait SIMD<
             // Self::_mm_prefetch(arr.as_ptr().add(start));
             let (min_index_, min_value_, max_index_, max_value_) =
                 Self::_core_argminmax(&arr[start..]);
-            if min_value_ < min_value {
+            if min_value_ < min_value || min_value_ != min_value_ {
                 min_index = start + min_index_;
                 min_value = min_value_;
             }
-            if max_value_ > max_value {
+            if max_value_ > max_value || max_value_ != max_value_ {
                 max_index = start + max_index_;
                 max_value = max_value_;
             }

--- a/src/simd/simd_f32.rs
+++ b/src/simd/simd_f32.rs
@@ -135,7 +135,7 @@ mod avx2 {
 
         #[test]
         fn test_both_versions_return_the_same_results() {
-            if !is_x86_feature_detected!("avx") {
+            if !is_x86_feature_detected!("avx2") {
                 return;
             }
 
@@ -150,7 +150,7 @@ mod avx2 {
 
         #[test]
         fn test_first_index_is_returned_when_identical_values_found() {
-            if !is_x86_feature_detected!("avx") {
+            if !is_x86_feature_detected!("avx2") {
                 return;
             }
 
@@ -177,6 +177,10 @@ mod avx2 {
 
         #[test]
         fn test_return_nan_index() {
+            if !is_x86_feature_detected!("avx2") {
+                return;
+            }
+
             // Case 1: NaN is the first element
             let mut data: Vec<f32> = get_array_f32(1027);
             data[0] = std::f32::NAN;
@@ -216,7 +220,7 @@ mod avx2 {
 
         #[test]
         fn test_no_overflow() {
-            if !is_x86_feature_detected!("avx") {
+            if !is_x86_feature_detected!("avx2") {
                 return;
             }
 
@@ -231,7 +235,7 @@ mod avx2 {
 
         #[test]
         fn test_many_random_runs() {
-            if !is_x86_feature_detected!("avx") {
+            if !is_x86_feature_detected!("avx2") {
                 return;
             }
 

--- a/src/simd/simd_f32.rs
+++ b/src/simd/simd_f32.rs
@@ -9,10 +9,9 @@ use std::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
 
-use super::task::{min_index_value, max_index_value};
+use super::task::{max_index_value, min_index_value};
 
 const XOR_VALUE: i32 = 0x7FFFFFFF;
-
 
 fn _ord_i32_to_f32(ord_i32: i32) -> f32 {
     // TODO: more efficient transformation -> can be decreasing order as well
@@ -201,7 +200,7 @@ mod sse {
 
         #[inline(always)]
         unsafe fn _reg_to_arr(reg: __m128i) -> [f32; LANE_SIZE] {
-           unimplemented!()
+            unimplemented!()
         }
 
         #[inline(always)]
@@ -266,12 +265,7 @@ mod sse {
                 // max_value is the only NaN
                 return (max_index as usize, max_value, max_index as usize, max_value);
             }
-            (
-                min_index as usize,
-                min_value,
-                max_index as usize,
-                max_value,
-            )
+            (min_index as usize, min_value, max_index as usize, max_value)
         }
     }
 

--- a/src/simd/simd_f32.rs
+++ b/src/simd/simd_f32.rs
@@ -55,7 +55,7 @@ mod avx2 {
 
         #[inline(always)]
         unsafe fn _mm_loadu(data: *const f32) -> __m256i {
-            _f32_as_m256i_to_i32ord(_mm256_load_epi32(data as *const i32))
+            _f32_as_m256i_to_i32ord(_mm256_loadu_epi32(data as *const i32))
         }
 
         #[inline(always)]

--- a/src/simd/simd_f32.rs
+++ b/src/simd/simd_f32.rs
@@ -177,11 +177,12 @@ mod sse {
 
     const LANE_SIZE: usize = SSE::LANE_SIZE_32;
     const XOR_MASK: __m128i = unsafe { std::mem::transmute([XOR_VALUE; LANE_SIZE]) };
+    const BIT_SHIFT: i32 = 31;
 
     #[inline(always)]
     unsafe fn _f32_as_m128i_to_i32ord(f32_as_m128i: __m128i) -> __m128i {
         // on a scalar: ((v >> 31) & 0x7FFFFFFF) ^ v
-        let sign_bit_shifted = _mm_srai_epi32(f32_as_m128i, 31);
+        let sign_bit_shifted = _mm_srai_epi32(f32_as_m128i, BIT_SHIFT);
         let sign_bit_masked = _mm_and_si128(sign_bit_shifted, XOR_MASK);
         _mm_xor_si128(sign_bit_masked, f32_as_m128i)
     }

--- a/src/simd/simd_f32.rs
+++ b/src/simd/simd_f32.rs
@@ -27,56 +27,95 @@ mod avx2 {
     use super::*;
 
     const LANE_SIZE: usize = AVX2::LANE_SIZE_32;
+    const XOR_MASK: __m256i = unsafe { std::mem::transmute([XOR_VALUE; LANE_SIZE]) };
+    const BIT_SHIFT: i32 = 31;
 
-    impl SIMD<f32, __m256, __m256, LANE_SIZE> for AVX2 {
-        const INITIAL_INDEX: __m256 = unsafe {
-            std::mem::transmute([
-                0.0f32, 1.0f32, 2.0f32, 3.0f32, 4.0f32, 5.0f32, 6.0f32, 7.0f32,
-            ])
-        };
-        // https://stackoverflow.com/a/3793950
-        const MAX_INDEX: usize = 1 << f32::MANTISSA_DIGITS;
+    #[inline(always)]
+    unsafe fn _f32_as_m256i_to_i32ord(f32_as_m256i: __m256i) -> __m256i {
+        // on a scalar: ((v >> 31) & 0x7FFFFFFF) ^ v
+        let sign_bit_shifted = _mm256_srai_epi32(f32_as_m256i, BIT_SHIFT);
+        let sign_bit_masked = _mm256_and_si256(sign_bit_shifted, XOR_MASK);
+        _mm256_xor_epi32(sign_bit_masked, f32_as_m256i)
+    }
+
+    #[inline(always)]
+    unsafe fn _reg_to_i32_arr(reg: __m256i) -> [i32; LANE_SIZE] {
+        std::mem::transmute::<__m256i, [i32; LANE_SIZE]>(reg)
+    }
+
+    impl SIMD<f32, __m256i, __m256i, LANE_SIZE> for AVX2 {
+        const INITIAL_INDEX: __m256i =
+            unsafe { std::mem::transmute([0i32, 1i32, 2i32, 3i32, 4i32, 5i32, 6i32, 7i32]) };
+        const MAX_INDEX: usize = i32::MAX as usize;
 
         #[inline(always)]
-        unsafe fn _reg_to_arr(reg: __m256) -> [f32; LANE_SIZE] {
-            std::mem::transmute::<__m256, [f32; LANE_SIZE]>(reg)
+        unsafe fn _reg_to_arr(_: __m256i) -> [f32; LANE_SIZE] {
+            unimplemented!()
         }
 
         #[inline(always)]
-        unsafe fn _mm_loadu(data: *const f32) -> __m256 {
-            _mm256_loadu_ps(data as *const f32)
+        unsafe fn _mm_loadu(data: *const f32) -> __m256i {
+            _f32_as_m256i_to_i32ord(_mm256_load_epi32(data as *const i32))
         }
 
         #[inline(always)]
-        unsafe fn _mm_set1(a: usize) -> __m256 {
-            _mm256_set1_ps(a as f32)
+        unsafe fn _mm_set1(a: usize) -> __m256i {
+            _mm256_set1_epi32(a as i32)
         }
 
         #[inline(always)]
-        unsafe fn _mm_add(a: __m256, b: __m256) -> __m256 {
-            _mm256_add_ps(a, b)
+        unsafe fn _mm_add(a: __m256i, b: __m256i) -> __m256i {
+            _mm256_add_epi32(a, b)
         }
 
         #[inline(always)]
-        unsafe fn _mm_cmpgt(a: __m256, b: __m256) -> __m256 {
-            _mm256_cmp_ps(a, b, _CMP_GT_OQ)
+        unsafe fn _mm_cmpgt(a: __m256i, b: __m256i) -> __m256i {
+            _mm256_cmpgt_epi32(a, b)
         }
 
         #[inline(always)]
-        unsafe fn _mm_cmplt(a: __m256, b: __m256) -> __m256 {
-            _mm256_cmp_ps(b, a, _CMP_GT_OQ)
+        unsafe fn _mm_cmplt(a: __m256i, b: __m256i) -> __m256i {
+            _mm256_cmpgt_epi32(b, a)
         }
 
         #[inline(always)]
-        unsafe fn _mm_blendv(a: __m256, b: __m256, mask: __m256) -> __m256 {
-            _mm256_blendv_ps(a, b, mask)
+        unsafe fn _mm_blendv(a: __m256i, b: __m256i, mask: __m256i) -> __m256i {
+            _mm256_blendv_epi8(a, b, mask)
         }
 
         // ------------------------------------ ARGMINMAX --------------------------------------
 
-        #[target_feature(enable = "avx")]
+        #[target_feature(enable = "avx2")]
         unsafe fn argminmax(data: &[f32]) -> (usize, usize) {
             Self::_argminmax(data)
+        }
+
+        #[inline(always)]
+        unsafe fn _get_min_max_index_value(
+            index_low: __m256i,
+            values_low: __m256i,
+            index_high: __m256i,
+            values_high: __m256i,
+        ) -> (usize, f32, usize, f32) {
+            // Get the results as arrays
+            let index_low_arr = _reg_to_i32_arr(index_low);
+            let values_low_arr = _reg_to_i32_arr(values_low);
+            let index_high_arr = _reg_to_i32_arr(index_high);
+            let values_high_arr = _reg_to_i32_arr(values_high);
+            // Find the min and max values and their indices
+            let (min_index, min_value) = min_index_value(&index_low_arr, &values_low_arr);
+            let (max_index, max_value) = max_index_value(&index_high_arr, &values_high_arr);
+            // Return the results - convert the ordinal ints back to floats
+            let min_value = _ord_i32_to_f32(min_value);
+            let max_value = _ord_i32_to_f32(max_value);
+            if min_value != min_value && max_value == max_value {
+                // min_value is the only NaN
+                return (min_index as usize, min_value, min_index as usize, min_value);
+            } else if min_value == min_value && max_value != max_value {
+                // max_value is the only NaN
+                return (max_index as usize, max_value, max_index as usize, max_value);
+            }
+            (min_index as usize, min_value, max_index as usize, max_value)
         }
     }
 
@@ -137,6 +176,45 @@ mod avx2 {
         }
 
         #[test]
+        fn test_return_nan_index() {
+            // Case 1: NaN is the first element
+            let mut data: Vec<f32> = get_array_f32(1027);
+            data[0] = std::f32::NAN;
+
+            let (argmin_index, argmax_index) = scalar_argminmax(&data);
+            assert_eq!(argmin_index, 0);
+            assert_eq!(argmax_index, 0);
+
+            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
+            assert_eq!(argmin_simd_index, 0);
+            assert_eq!(argmax_simd_index, 0);
+
+            // Case 2: NaN is the last element
+            let mut data: Vec<f32> = get_array_f32(1027);
+            data[1026] = std::f32::NAN;
+
+            let (argmin_index, argmax_index) = scalar_argminmax(&data);
+            assert_eq!(argmin_index, 1026);
+            assert_eq!(argmax_index, 1026);
+
+            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
+            assert_eq!(argmin_simd_index, 1026);
+            assert_eq!(argmax_simd_index, 1026);
+
+            // Case 3: NaN is somewhere in the middle element
+            let mut data: Vec<f32> = get_array_f32(1027);
+            data[123] = std::f32::NAN;
+
+            let (argmin_index, argmax_index) = scalar_argminmax(&data);
+            assert_eq!(argmin_index, 123);
+            assert_eq!(argmax_index, 123);
+
+            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
+            assert_eq!(argmin_simd_index, 123);
+            assert_eq!(argmax_simd_index, 123);
+        }
+
+        #[test]
         fn test_no_overflow() {
             if !is_x86_feature_detected!("avx") {
                 return;
@@ -193,14 +271,11 @@ mod sse {
     }
 
     impl SIMD<f32, __m128i, __m128i, LANE_SIZE> for SSE {
-        const INITIAL_INDEX: __m128i =
-            // unsafe { std::mem::transmute([0.0f32, 1.0f32, 2.0f32, 3.0f32]) };
-            unsafe { std::mem::transmute([0i32, 1i32, 2i32, 3i32]) };
-        // https://stackoverflow.com/a/3793950
+        const INITIAL_INDEX: __m128i = unsafe { std::mem::transmute([0i32, 1i32, 2i32, 3i32]) };
         const MAX_INDEX: usize = i32::MAX as usize;
 
         #[inline(always)]
-        unsafe fn _reg_to_arr(reg: __m128i) -> [f32; LANE_SIZE] {
+        unsafe fn _reg_to_arr(_: __m128i) -> [f32; LANE_SIZE] {
             unimplemented!()
         }
 


### PR DESCRIPTION
This PR aims at handling Nans, #16.

For the **scalar implementation** I check whether the scalar value is not equal to itself. This check will only be true if the scalar value is NAN, as the following is correct in Rust:
```rs
let v = f32::NAN;
assert!(v != v);
```

For the **SIMD implementation** I used a transformation similar to the one used in #1 - this transformation projects the NANs to integer values that are *either* higher / lower than the "real" floating point values. The transformation leverages the 2-complement https://observablehq.com/@rreusser/half-precision-floating-point-visualized

Some remarks:
- `+ inf` & `- inf` will get projected as well
  - [x] validate if these are inbetween the NaNs & the "real" floating point values (pretty sure this is the case)  
    => this is indeed the case - see plot :arrow_down: 
    ![image](https://user-images.githubusercontent.com/18898740/216831902-ad5eddbf-9ba1-4687-ab78-333f1314fd35.png)
- there are a plethora of ways to represent NaNs in floating point representation: exponent should be `11111` and the fraction should be non-zero. Thus the sign bit may be 1 or 0 -> resulting in half of the NaNs getting projected above and the other half below the "real" floating point values. Thus, only 1 of the 2 checks (either > or <) will fire & thus detect the `NaN`. This might be a problem when we want to implement `argmin` and `argmax` as separate functions..

---

Paths I looked into but did not seem worthwhile:
* I tried to handle NaNs with SIMD instructions, but the SIMD instruction to check whether there are a NaNs in the register [turns out to be rather computationally expense](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_cmpord_ps&ig_expand=1381)
