### PR TITLE
Add NEON SIMD types to new NaN v3 design

### DIFF
--- a/src/simd/generic.rs
+++ b/src/simd/generic.rs
@@ -198,10 +198,15 @@ pub trait SIMD<
 
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 macro_rules! unimplement_simd {
-    ($scalar_type:ty, $reg:ty, $simd_type:ident) => {
+    ($scalar_type:ty, $reg:ty, $simd_type:ident, $zero:literal) => {
         impl SIMD<$scalar_type, $reg, $reg, 0> for $simd_type {
             const INITIAL_INDEX: $reg = 0;
             const MAX_INDEX: usize = 0;
+            
+            const INDEX_INCREMENT: $reg = 0;
+            const MIN_VALUE: $scalar_type = $zero;
+            const MAX_VALUE: $scalar_type = $zero;
+
 
             unsafe fn _reg_to_arr(_reg: $reg) -> [$scalar_type; 0] {
                 unimplemented!()
@@ -211,7 +216,7 @@ macro_rules! unimplement_simd {
                 unimplemented!()
             }
 
-            unsafe fn _mm_set1(_a: usize) -> $reg {
+            unsafe fn _mm_set1(_a: $scalar_type) -> $reg {
                 unimplemented!()
             }
 

--- a/src/simd/simd_f16.rs
+++ b/src/simd/simd_f16.rs
@@ -750,7 +750,15 @@ mod neon {
     impl SIMD<f16, int16x8_t, uint16x8_t, LANE_SIZE> for NEON {
         const INITIAL_INDEX: int16x8_t =
             unsafe { std::mem::transmute([0i16, 1i16, 2i16, 3i16, 4i16, 5i16, 6i16, 7i16]) };
-        const MAX_INDEX: usize = i16::MAX as usize;
+        
+        const INDEX_INCREMENT: int16x8_t =
+            unsafe { std::mem::transmute([LANE_SIZE as i16; LANE_SIZE]) };
+
+        const MAX_INDEX: usize = MAX_INDEX;
+
+        const MIN_VALUE: f16 = MIN_VALUE;
+        const MAX_VALUE: f16 = MAX_VALUE;
+        
 
         #[inline(always)]
         unsafe fn _reg_to_arr(_: int16x8_t) -> [f16; LANE_SIZE] {
@@ -766,8 +774,8 @@ mod neon {
         }
 
         #[inline(always)]
-        unsafe fn _mm_set1(a: usize) -> int16x8_t {
-            vdupq_n_s16(a as i16)
+        unsafe fn _mm_set1(a: f16) -> int16x8_t {
+            vdupq_n_s16(std::mem::transmute::<f16, i16>(a))
         }
 
         #[inline(always)]
@@ -791,11 +799,6 @@ mod neon {
         }
 
         // ------------------------------------ ARGMINMAX --------------------------------------
-
-        #[target_feature(enable = "neon")]
-        unsafe fn argminmax(data: &[f16]) -> (usize, usize) {
-            Self::_argminmax(data)
-        }
 
         #[inline(always)]
         unsafe fn _horiz_min(index: int16x8_t, value: int16x8_t) -> (usize, f16) {
@@ -851,6 +854,11 @@ mod neon {
             let max_index: usize = vgetq_lane_s16(imin, 0) as usize;
 
             (max_index, _ord_i16_to_f16(max_value))
+        }
+
+        #[target_feature(enable = "neon")]
+        unsafe fn argminmax(data: &[f16]) -> (usize, usize) {
+            Self::_argminmax(data)
         }
     }
 

--- a/src/simd/simd_f32_ignore_nans.rs
+++ b/src/simd/simd_f32_ignore_nans.rs
@@ -489,12 +489,19 @@ mod neon {
         const INITIAL_INDEX: float32x4_t =
             unsafe { std::mem::transmute([0.0f32, 1.0f32, 2.0f32, 3.0f32]) };
 
+        const INDEX_INCREMENT: float32x4_t =
+            unsafe { std::mem::transmute([LANE_SIZE as f32; LANE_SIZE]) };
+
+        // https://stackoverflow.com/a/3793950
+        const MAX_INDEX: usize = MAX_INDEX;
+        const MIN_VALUE: f32 = MIN_VALUE;
+
+
+        const MAX_VALUE: f32 = MAX_VALUE;
         #[inline(always)]
         unsafe fn _reg_to_arr(reg: float32x4_t) -> [f32; LANE_SIZE] {
             std::mem::transmute::<float32x4_t, [f32; LANE_SIZE]>(reg)
         }
-        // https://stackoverflow.com/a/3793950
-        const MAX_INDEX: usize = 1 << f32::MANTISSA_DIGITS;
 
         #[inline(always)]
         unsafe fn _mm_loadu(data: *const f32) -> float32x4_t {
@@ -502,7 +509,7 @@ mod neon {
         }
 
         #[inline(always)]
-        unsafe fn _mm_set1(a: usize) -> float32x4_t {
+        unsafe fn _mm_set1(a: f32) -> float32x4_t {
             vdupq_n_f32(a as f32)
         }
 

--- a/src/simd/simd_f64_ignore_nans.rs
+++ b/src/simd/simd_f64_ignore_nans.rs
@@ -430,5 +430,5 @@ mod neon {
     // compiler will complain that the trait is not implemented for the struct -
     // even though we are not using the trait for the NEON struct when dealing with
     // > 64 bit data types.
-    unimplement_simd!(f64, usize, NEON);
+    unimplement_simd!(f64, usize, NEON, 0.0);
 }

--- a/src/simd/simd_i16.rs
+++ b/src/simd/simd_i16.rs
@@ -655,7 +655,15 @@ mod neon {
     impl SIMD<i16, int16x8_t, uint16x8_t, LANE_SIZE> for NEON {
         const INITIAL_INDEX: int16x8_t =
             unsafe { std::mem::transmute([0i16, 1i16, 2i16, 3i16, 4i16, 5i16, 6i16, 7i16]) };
-        const MAX_INDEX: usize = i16::MAX as usize;
+
+        const INDEX_INCREMENT: int16x8_t =
+            unsafe { std::mem::transmute([LANE_SIZE as i16; LANE_SIZE]) };
+        
+        const MAX_INDEX: usize = MAX_INDEX;
+
+        const MIN_VALUE: i16 = MIN_VALUE;
+        const MAX_VALUE: i16 = MAX_VALUE;
+        
 
         #[inline(always)]
         unsafe fn _reg_to_arr(reg: int16x8_t) -> [i16; LANE_SIZE] {
@@ -668,8 +676,8 @@ mod neon {
         }
 
         #[inline(always)]
-        unsafe fn _mm_set1(a: usize) -> int16x8_t {
-            vdupq_n_s16(a as i16)
+        unsafe fn _mm_set1(a: i16) -> int16x8_t {
+            vdupq_n_s16(a)
         }
 
         #[inline(always)]
@@ -693,11 +701,6 @@ mod neon {
         }
 
         // ------------------------------------ ARGMINMAX --------------------------------------
-
-        #[target_feature(enable = "neon")]
-        unsafe fn argminmax(data: &[i16]) -> (usize, usize) {
-            Self::_argminmax(data)
-        }
 
         #[inline(always)]
         unsafe fn _horiz_min(index: int16x8_t, value: int16x8_t) -> (usize, i16) {
@@ -753,6 +756,11 @@ mod neon {
             let max_index: usize = vgetq_lane_s16(imin, 0) as usize;
 
             (max_index, max_value)
+        }
+
+        #[target_feature(enable = "neon")]
+        unsafe fn argminmax(data: &[i16]) -> (usize, usize) {
+            Self::_argminmax(data)
         }
     }
 

--- a/src/simd/simd_i32.rs
+++ b/src/simd/simd_i32.rs
@@ -423,7 +423,14 @@ mod neon {
 
     impl SIMD<i32, int32x4_t, uint32x4_t, LANE_SIZE> for NEON {
         const INITIAL_INDEX: int32x4_t = unsafe { std::mem::transmute([0i32, 1i32, 2i32, 3i32]) };
-        const MAX_INDEX: usize = i32::MAX as usize;
+        
+        const INDEX_INCREMENT: int32x4_t =
+            unsafe { std::mem::transmute([LANE_SIZE as i32; LANE_SIZE]) };
+        const MAX_INDEX: usize = MAX_INDEX;
+
+        const MIN_VALUE: i32 = MIN_VALUE;
+        const MAX_VALUE: i32 = MAX_VALUE;
+        
 
         #[inline(always)]
         unsafe fn _reg_to_arr(reg: int32x4_t) -> [i32; LANE_SIZE] {
@@ -436,8 +443,8 @@ mod neon {
         }
 
         #[inline(always)]
-        unsafe fn _mm_set1(a: usize) -> int32x4_t {
-            vdupq_n_s32(a as i32)
+        unsafe fn _mm_set1(a: i32) -> int32x4_t {
+            vdupq_n_s32(a)
         }
 
         #[inline(always)]

--- a/src/simd/simd_i64.rs
+++ b/src/simd/simd_i64.rs
@@ -422,5 +422,5 @@ mod neon {
     // compiler will complain that the trait is not implemented for the struct -
     // even though we are not using the trait for the NEON struct when dealing with
     // > 64 bit data types.
-    unimplement_simd!(i64, usize, NEON);
+    unimplement_simd!(i64, usize, NEON, 0);
 }

--- a/src/simd/simd_i8.rs
+++ b/src/simd/simd_i8.rs
@@ -648,7 +648,13 @@ mod neon {
                 15i8,
             ])
         };
-        const MAX_INDEX: usize = i8::MAX as usize;
+        
+        const INDEX_INCREMENT: int8x16_t =
+            unsafe { std::mem::transmute([LANE_SIZE as i8; LANE_SIZE]) };
+        const MAX_INDEX: usize = MAX_INDEX;
+
+        const MIN_VALUE: i8 = MIN_VALUE;
+        const MAX_VALUE: i8 = MAX_VALUE;
 
         #[inline(always)]
         unsafe fn _reg_to_arr(reg: int8x16_t) -> [i8; LANE_SIZE] {
@@ -662,8 +668,8 @@ mod neon {
         }
 
         #[inline(always)]
-        unsafe fn _mm_set1(a: usize) -> int8x16_t {
-            vdupq_n_s8(a as i8)
+        unsafe fn _mm_set1(a: i8) -> int8x16_t {
+            vdupq_n_s8(a)
         }
 
         #[inline(always)]

--- a/src/simd/simd_u16.rs
+++ b/src/simd/simd_u16.rs
@@ -748,7 +748,14 @@ mod neon {
     impl SIMD<u16, uint16x8_t, uint16x8_t, LANE_SIZE> for NEON {
         const INITIAL_INDEX: uint16x8_t =
             unsafe { std::mem::transmute([0i16, 1i16, 2i16, 3i16, 4i16, 5i16, 6i16, 7i16]) };
-        const MAX_INDEX: usize = u16::MAX as usize;
+
+        const INDEX_INCREMENT: uint16x8_t =
+            unsafe { std::mem::transmute([LANE_SIZE as i16; LANE_SIZE]) };
+        const MAX_INDEX: usize = MAX_INDEX;
+
+        const MIN_VALUE: u16 = MIN_VALUE;
+        const MAX_VALUE: u16 = MAX_VALUE;
+
 
         #[inline(always)]
         unsafe fn _reg_to_arr(reg: uint16x8_t) -> [u16; LANE_SIZE] {
@@ -761,8 +768,8 @@ mod neon {
         }
 
         #[inline(always)]
-        unsafe fn _mm_set1(a: usize) -> uint16x8_t {
-            vdupq_n_u16(a as u16)
+        unsafe fn _mm_set1(a: u16) -> uint16x8_t {
+            vdupq_n_u16(a )
         }
 
         #[inline(always)]

--- a/src/simd/simd_u32.rs
+++ b/src/simd/simd_u32.rs
@@ -534,7 +534,13 @@ mod neon {
 
     impl SIMD<u32, uint32x4_t, uint32x4_t, LANE_SIZE> for NEON {
         const INITIAL_INDEX: uint32x4_t = unsafe { std::mem::transmute([0u32, 1u32, 2u32, 3u32]) };
-        const MAX_INDEX: usize = u32::MAX as usize;
+        
+        const INDEX_INCREMENT: uint32x4_t =
+            unsafe { std::mem::transmute([LANE_SIZE as i32; LANE_SIZE]) };
+        const MAX_INDEX: usize = MAX_INDEX;
+
+        const MIN_VALUE: u32 = MIN_VALUE;
+        const MAX_VALUE: u32 = MAX_VALUE;
 
         #[inline(always)]
         unsafe fn _reg_to_arr(reg: uint32x4_t) -> [u32; LANE_SIZE] {
@@ -547,7 +553,7 @@ mod neon {
         }
 
         #[inline(always)]
-        unsafe fn _mm_set1(a: usize) -> uint32x4_t {
+        unsafe fn _mm_set1(a: u32) -> uint32x4_t {
             vdupq_n_u32(a as u32)
         }
 

--- a/src/simd/simd_u64.rs
+++ b/src/simd/simd_u64.rs
@@ -532,5 +532,5 @@ mod neon {
     // compiler will complain that the trait is not implemented for the struct -
     // even though we are not using the trait for the NEON struct when dealing with
     // > 64 bit data types.
-    unimplement_simd!(u64, usize, NEON);
+    unimplement_simd!(u64, usize, NEON, 0);
 }

--- a/src/simd/simd_u8.rs
+++ b/src/simd/simd_u8.rs
@@ -743,7 +743,13 @@ mod neon {
                 15u8,
             ])
         };
-        const MAX_INDEX: usize = u8::MAX as usize;
+        
+        const INDEX_INCREMENT: uint8x16_t =
+            unsafe { std::mem::transmute([LANE_SIZE as i8; LANE_SIZE]) };
+        const MAX_INDEX: usize = MAX_INDEX;
+
+        const MIN_VALUE: u8 = MIN_VALUE;
+        const MAX_VALUE: u8 = MAX_VALUE;
 
         #[inline(always)]
         unsafe fn _reg_to_arr(reg: uint8x16_t) -> [u8; LANE_SIZE] {
@@ -756,8 +762,8 @@ mod neon {
         }
 
         #[inline(always)]
-        unsafe fn _mm_set1(a: usize) -> uint8x16_t {
-            vdupq_n_u8(a as u8)
+        unsafe fn _mm_set1(a: u8) -> uint8x16_t {
+            vdupq_n_u8(a)
         }
 
         #[inline(always)]


### PR DESCRIPTION
Apparently we can indeed create pulls into pull requests.

Here we go. This should add some functions and types for the NEON/arm64 SIMD specialisations.
