### PR TITLE
:recycle: parameterize tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,9 @@ arrow = { version = ">0", default-features = false, optional = true}
 default = ["half"] # TODO: remove this as default feature as soon as https://github.com/CodSpeedHQ/codspeed-rust/issues/1 is fixed
 
 [dev-dependencies]
-# rstest = { version = "0.16", default-features = false}
-# rstest_reuse = "0.5"
+rstest = { version = "0.16", default-features = false }
+rstest_reuse = { version = "0.5", default-features = false }
+rand = { version = "0.7.2", default-features = false }
 codspeed-criterion-compat = "1.0.1"
 criterion = "0.3.1"
 dev_utils = { path = "dev_utils" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,11 @@
 #![feature(avx512_target_feature)]
 #![feature(arm_target_feature)]
 
+// It is necessary to import this at the root of the crate
+// See: https://github.com/la10736/rstest/tree/master/rstest_reuse#use-rstest_resuse-at-the-top-of-your-crate
+#[cfg(test)]
+use rstest_reuse;
+
 // #[macro_use]
 // extern crate lazy_static;
 

--- a/src/scalar/scalar_f16.rs
+++ b/src/scalar/scalar_f16.rs
@@ -82,7 +82,6 @@ mod tests {
 
     use half::f16;
 
-    extern crate dev_utils;
     use dev_utils::utils;
 
     fn get_array_f16(len: usize) -> Vec<f16> {

--- a/src/simd/mod.rs
+++ b/src/simd/mod.rs
@@ -22,3 +22,7 @@ mod simd_u16;
 mod simd_u32;
 mod simd_u64;
 mod simd_u8;
+
+// Test utils
+#[cfg(test)]
+mod test_utils;

--- a/src/simd/simd_f16_ignore_nan.rs
+++ b/src/simd/simd_f16_ignore_nan.rs
@@ -11,7 +11,7 @@ use super::generic::{SIMDArgMinMaxIgnoreNaN, SIMDOps, SIMDSetOps};
 #[cfg(feature = "half")]
 use half::f16;
 
-// ------------------------------------------ AVX2 ------------------------------------------
+// --------------------------------------- AVX2 ----------------------------------------
 
 #[cfg(feature = "half")]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -23,7 +23,7 @@ mod avx2_ignore_nan {
     unimpl_SIMDArgMinMaxIgnoreNaN!(f16, usize, AVX2IgnoreNaN);
 }
 
-// ----------------------------------------- SSE -----------------------------------------
+// ---------------------------------------- SSE ----------------------------------------
 
 #[cfg(feature = "half")]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -35,7 +35,7 @@ mod sse_ignore_nan {
     unimpl_SIMDArgMinMaxIgnoreNaN!(f16, usize, SSEIgnoreNaN);
 }
 
-// --------------------------------------- AVX512 ----------------------------------------
+// -------------------------------------- AVX512 ---------------------------------------
 
 #[cfg(feature = "half")]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -47,7 +47,7 @@ mod avx512_ignore_nan {
     unimpl_SIMDArgMinMaxIgnoreNaN!(f16, usize, AVX512IgnoreNaN);
 }
 
-// ---------------------------------------- NEON -----------------------------------------
+// --------------------------------------- NEON ----------------------------------------
 
 #[cfg(feature = "half")]
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]

--- a/src/simd/simd_f16_return_nan.rs
+++ b/src/simd/simd_f16_return_nan.rs
@@ -64,7 +64,7 @@ fn _i16ord_to_f16(ord_i16: i16) -> f16 {
 #[cfg(feature = "half")]
 const MAX_INDEX: usize = i16::MAX as usize;
 
-// ------------------------------------------ AVX2 ------------------------------------------
+// --------------------------------------- AVX2 ----------------------------------------
 
 #[cfg(feature = "half")]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -204,259 +204,9 @@ mod avx2 {
             Self::_argminmax(data)
         }
     }
-
-    //----- TESTS -----
-
-    #[cfg(test)]
-    mod tests {
-        use super::SIMDArgMinMax;
-        use super::AVX2;
-        use crate::scalar::generic::scalar_argminmax;
-
-        use half::f16;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_f16(n: usize) -> Vec<f16> {
-            let arr = utils::get_random_array(n, i16::MIN, i16::MAX);
-            arr.iter().map(|x| f16::from_f32(*x as f32)).collect()
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            let data: &[f16] = &get_array_f16(1025);
-            assert_eq!(data.len() % 8, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            let data = [
-                f16::from_f32(10.),
-                f16::MAX,
-                f16::from_f32(6.),
-                f16::NEG_INFINITY,
-                f16::NEG_INFINITY,
-                f16::MAX,
-                f16::from_f32(5_000.0),
-            ];
-            let data: Vec<f16> = data.iter().map(|x| *x).collect();
-            let data: &[f16] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 3);
-            assert_eq!(argmax_index, 1);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-            assert_eq!(argmin_simd_index, 3);
-            assert_eq!(argmax_simd_index, 1);
-        }
-
-        #[test]
-        fn test_return_infs() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            let arr_len: usize = 1027;
-            let mut data: Vec<f16> = get_array_f16(arr_len);
-
-            // Case 1: all elements are +inf
-            for i in 0..data.len() {
-                data[i] = f16::INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 2: all elements are -inf
-            for i in 0..data.len() {
-                data[i] = f16::NEG_INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 3: add some +inf and -inf in the middle
-            let mut data: Vec<f16> = get_array_f16(arr_len);
-            data[100] = f16::INFINITY;
-            data[200] = f16::NEG_INFINITY;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 200);
-            assert_eq!(argmax_index, 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 200);
-            assert_eq!(argmax_simd_index, 100);
-        }
-
-        #[test]
-        fn test_return_nans() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            let arr_len: usize = 1027;
-
-            // Case 1: NaN is the first element
-            let mut data: Vec<f16> = get_array_f16(arr_len);
-            data[0] = f16::NAN;
-            println!("{:?}", data);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 2: first 100 elements are NaN
-            for i in 0..100 {
-                data[i] = f16::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 3: NaN is the last element
-            let mut data: Vec<f16> = get_array_f16(arr_len);
-            data[arr_len - 1] = f16::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 1026);
-            assert_eq!(argmax_index, 1026);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 1026);
-            assert_eq!(argmax_simd_index, 1026);
-
-            // Case 4: last 100 elements are NaN
-            for i in 0..100 {
-                data[arr_len - 1 - i] = f16::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, arr_len - 100);
-            assert_eq!(argmax_index, arr_len - 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, arr_len - 100);
-            assert_eq!(argmax_simd_index, arr_len - 100);
-
-            // Case 5: NaN is somewhere in the middle element
-            let mut data: Vec<f16> = get_array_f16(arr_len);
-            data[123] = f16::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 123);
-            assert_eq!(argmax_index, 123);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 123);
-            assert_eq!(argmax_simd_index, 123);
-
-            // Case 6: NaN in the middle of the array and last 100 elements are NaN
-            for i in 0..100 {
-                data[arr_len - 1 - i] = f16::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 123);
-            assert_eq!(argmax_index, 123);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 123);
-            assert_eq!(argmax_simd_index, 123);
-
-            // Case 7: all elements are NaN
-            for i in 0..data.len() {
-                data[i] = f16::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 8: array exact multiple of LANE_SIZE and only 1 element is NaN
-            let mut data: Vec<f16> = get_array_f16(128);
-            data[17] = f16::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 17);
-            assert_eq!(argmax_index, 17);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 17);
-            assert_eq!(argmax_simd_index, 17);
-        }
-
-        #[test]
-        fn test_no_overflow() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            let n: usize = 1 << 18;
-            let data: &[f16] = &get_array_f16(n);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            for _ in 0..10_000 {
-                let data: &[f16] = &get_array_f16(32 * 8 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// ----------------------------------------- SSE -----------------------------------------
+// ---------------------------------------- SSE ----------------------------------------
 
 #[cfg(feature = "half")]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -583,235 +333,9 @@ mod sse {
             Self::_argminmax(data)
         }
     }
-
-    // ----------------------------------------- TESTS -----------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::SIMDArgMinMax;
-        use super::SSE;
-        use crate::scalar::generic::scalar_argminmax;
-
-        use half::f16;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_f16(n: usize) -> Vec<f16> {
-            let arr = utils::get_random_array(n, i16::MIN, i16::MAX);
-            arr.iter().map(|x| f16::from_f32(*x as f32)).collect()
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            let data: &[f16] = &get_array_f16(1025);
-            assert_eq!(data.len() % 8, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            let data = [
-                f16::from_f32(10.),
-                f16::MAX,
-                f16::from_f32(6.),
-                f16::NEG_INFINITY,
-                f16::NEG_INFINITY,
-                f16::MAX,
-                f16::from_f32(5_000.0),
-            ];
-            let data: Vec<f16> = data.iter().map(|x| *x).collect();
-            let data: &[f16] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 3);
-            assert_eq!(argmax_index, 1);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-            assert_eq!(argmin_simd_index, 3);
-            assert_eq!(argmax_simd_index, 1);
-        }
-
-        #[test]
-        fn test_return_infs() {
-            let arr_len: usize = 1027;
-            let mut data: Vec<f16> = get_array_f16(arr_len);
-
-            // Case 1: all elements are +inf
-            for i in 0..data.len() {
-                data[i] = f16::INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 2: all elements are -inf
-            for i in 0..data.len() {
-                data[i] = f16::NEG_INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 3: add some +inf and -inf in the middle
-            let mut data: Vec<f16> = get_array_f16(arr_len);
-            data[100] = f16::INFINITY;
-            data[200] = f16::NEG_INFINITY;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 200);
-            assert_eq!(argmax_index, 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 200);
-            assert_eq!(argmax_simd_index, 100);
-        }
-
-        #[test]
-        fn test_return_nans() {
-            let arr_len: usize = 1027;
-
-            // Case 1: NaN is the first element
-            let mut data: Vec<f16> = get_array_f16(arr_len);
-            data[0] = f16::NAN;
-            println!("{:?}", data);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 2: first 100 elements are NaN
-            for i in 0..100 {
-                data[i] = f16::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 3: NaN is the last element
-            let mut data: Vec<f16> = get_array_f16(arr_len);
-            data[arr_len - 1] = f16::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 1026);
-            assert_eq!(argmax_index, 1026);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 1026);
-            assert_eq!(argmax_simd_index, 1026);
-
-            // Case 4: last 100 elements are NaN
-            for i in 0..100 {
-                data[arr_len - 1 - i] = f16::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, arr_len - 100);
-            assert_eq!(argmax_index, arr_len - 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, arr_len - 100);
-            assert_eq!(argmax_simd_index, arr_len - 100);
-
-            // Case 5: NaN is somewhere in the middle element
-            let mut data: Vec<f16> = get_array_f16(arr_len);
-            data[123] = f16::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 123);
-            assert_eq!(argmax_index, 123);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 123);
-            assert_eq!(argmax_simd_index, 123);
-
-            // Case 6: NaN in the middle of the array and last 100 elements are NaN
-            for i in 0..100 {
-                data[arr_len - 1 - i] = f16::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 123);
-            assert_eq!(argmax_index, 123);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 123);
-            assert_eq!(argmax_simd_index, 123);
-
-            // Case 7: all elements are NaN
-            for i in 0..data.len() {
-                data[i] = f16::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 8: array exact multiple of LANE_SIZE and only 1 element is NaN
-            let mut data: Vec<f16> = get_array_f16(128);
-            data[17] = f16::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 17);
-            assert_eq!(argmax_index, 17);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 17);
-            assert_eq!(argmax_simd_index, 17);
-        }
-
-        #[test]
-        fn test_no_overflow() {
-            let n: usize = 1 << 18;
-            let data: &[f16] = &get_array_f16(n);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            for _ in 0..10_000 {
-                let data: &[f16] = &get_array_f16(32 * 8 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// --------------------------------------- AVX512 ----------------------------------------
+// -------------------------------------- AVX512 ---------------------------------------
 
 #[cfg(feature = "half")]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -951,259 +475,9 @@ mod avx512 {
             Self::_argminmax(data)
         }
     }
-
-    // ----------------------------------------- TESTS -----------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::SIMDArgMinMax;
-        use super::AVX512;
-        use crate::scalar::generic::scalar_argminmax;
-
-        use half::f16;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_f16(n: usize) -> Vec<f16> {
-            let arr = utils::get_random_array(n, i16::MIN, i16::MAX);
-            arr.iter().map(|x| f16::from_f32(*x as f32)).collect()
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            if !is_x86_feature_detected!("avx512bw") {
-                return;
-            }
-
-            let data: &[f16] = &get_array_f16(1025);
-            assert_eq!(data.len() % 8, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            if !is_x86_feature_detected!("avx512bw") {
-                return;
-            }
-
-            let data = [
-                f16::from_f32(10.),
-                f16::MAX,
-                f16::from_f32(6.),
-                f16::NEG_INFINITY,
-                f16::NEG_INFINITY,
-                f16::MAX,
-                f16::from_f32(5_000.0),
-            ];
-            let data: Vec<f16> = data.iter().map(|x| *x).collect();
-            let data: &[f16] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 3);
-            assert_eq!(argmax_index, 1);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-            assert_eq!(argmin_simd_index, 3);
-            assert_eq!(argmax_simd_index, 1);
-        }
-
-        #[test]
-        fn test_return_infs() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            let arr_len: usize = 1027;
-            let mut data: Vec<f16> = get_array_f16(arr_len);
-
-            // Case 1: all elements are +inf
-            for i in 0..data.len() {
-                data[i] = f16::INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 2: all elements are -inf
-            for i in 0..data.len() {
-                data[i] = f16::NEG_INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 3: add some +inf and -inf in the middle
-            let mut data: Vec<f16> = get_array_f16(arr_len);
-            data[100] = f16::INFINITY;
-            data[200] = f16::NEG_INFINITY;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 200);
-            assert_eq!(argmax_index, 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 200);
-            assert_eq!(argmax_simd_index, 100);
-        }
-
-        #[test]
-        fn test_return_nans() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            let arr_len: usize = 1027;
-
-            // Case 1: NaN is the first element
-            let mut data: Vec<f16> = get_array_f16(arr_len);
-            data[0] = f16::NAN;
-            println!("{:?}", data);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 2: first 100 elements are NaN
-            for i in 0..100 {
-                data[i] = f16::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 3: NaN is the last element
-            let mut data: Vec<f16> = get_array_f16(arr_len);
-            data[arr_len - 1] = f16::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 1026);
-            assert_eq!(argmax_index, 1026);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 1026);
-            assert_eq!(argmax_simd_index, 1026);
-
-            // Case 4: last 100 elements are NaN
-            for i in 0..100 {
-                data[arr_len - 1 - i] = f16::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, arr_len - 100);
-            assert_eq!(argmax_index, arr_len - 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, arr_len - 100);
-            assert_eq!(argmax_simd_index, arr_len - 100);
-
-            // Case 5: NaN is somewhere in the middle element
-            let mut data: Vec<f16> = get_array_f16(arr_len);
-            data[123] = f16::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 123);
-            assert_eq!(argmax_index, 123);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 123);
-            assert_eq!(argmax_simd_index, 123);
-
-            // Case 6: NaN in the middle of the array and last 100 elements are NaN
-            for i in 0..100 {
-                data[arr_len - 1 - i] = f16::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 123);
-            assert_eq!(argmax_index, 123);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 123);
-            assert_eq!(argmax_simd_index, 123);
-
-            // Case 7: all elements are NaN
-            for i in 0..data.len() {
-                data[i] = f16::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 8: array exact multiple of LANE_SIZE and only 1 element is NaN
-            let mut data: Vec<f16> = get_array_f16(128);
-            data[17] = f16::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 17);
-            assert_eq!(argmax_index, 17);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 17);
-            assert_eq!(argmax_simd_index, 17);
-        }
-
-        #[test]
-        fn test_no_overflow() {
-            if !is_x86_feature_detected!("avx512bw") {
-                return;
-            }
-
-            let n: usize = 1 << 18;
-            let data: &[f16] = &get_array_f16(n);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            if !is_x86_feature_detected!("avx512bw") {
-                return;
-            }
-
-            for _ in 0..10_000 {
-                let data: &[f16] = &get_array_f16(32 * 8 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// ---------------------------------------- NEON -----------------------------------------
+// --------------------------------------- NEON ----------------------------------------
 
 #[cfg(feature = "half")]
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
@@ -1332,230 +606,168 @@ mod neon {
             Self::_argminmax(data)
         }
     }
+}
 
-    // ----------------------------------------- TESTS -----------------------------------------
+// ======================================= TESTS =======================================
 
-    #[cfg(test)]
-    mod tests {
-        use super::SIMDArgMinMax;
-        use super::NEON;
-        use crate::scalar::generic::scalar_argminmax;
+#[cfg(feature = "half")]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "arm",
+    target_arch = "aarch64",
+))]
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use rstest_reuse::{self, *};
 
-        use half::f16;
+    use half::f16;
 
-        extern crate dev_utils;
-        use dev_utils::utils;
+    use crate::scalar::generic::scalar_argminmax;
+    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    use crate::simd::config::NEON;
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    use crate::simd::config::{AVX2, AVX512, SSE};
+    use crate::SIMDArgMinMax;
 
-        fn get_array_f16(n: usize) -> Vec<f16> {
-            let arr = utils::get_random_array(n, i16::MIN, i16::MAX);
-            arr.iter().map(|x| f16::from_f32(*x as f32)).collect()
+    use super::super::test_utils::{
+        test_long_array_argminmax, test_no_overflow_argminmax, test_random_runs_argminmax,
+    };
+    // Float specific tests
+    use super::super::test_utils::{test_return_infs_argminmax, test_return_nans_argminmax};
+
+    use dev_utils::utils;
+
+    fn get_array_f16(n: usize) -> Vec<f16> {
+        let arr = utils::get_random_array(n, i16::MIN, i16::MAX);
+        arr.iter().map(|x| f16::from_f32(*x as f32)).collect()
+    }
+
+    // ------------ Template for x86 / x86_64 -------------
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[template]
+    #[rstest]
+    #[case::sse(SSE, is_x86_feature_detected!("sse4.1"))]
+    #[case::avx2(AVX2, is_x86_feature_detected!("avx2"))]
+    #[case::avx512(AVX512, is_x86_feature_detected!("avx512bw"))]
+    fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T,
+        #[case] simd_available: bool,
+    ) {
+    }
+
+    // ------------ Template for ARM / AArch64 ------------
+
+    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[template]
+    #[rstest]
+    #[case::neon(NEON, true)]
+    fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T,
+        #[case] simd_available: bool,
+    ) {
+    }
+
+    // ----------------- The actual tests -----------------
+
+    #[apply(simd_implementations)]
+    fn test_first_index_is_returned_when_identical_values_found<
+        T,
+        SIMDV,
+        SIMDM,
+        const LANE_SIZE: usize,
+    >(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMax<f16, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
         }
 
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            let data: &[f16] = &get_array_f16(1025);
-            assert_eq!(data.len() % 8, 1);
+        let data = [
+            f16::from_f32(10.),
+            f16::MAX,
+            f16::from_f32(6.),
+            f16::NEG_INFINITY,
+            f16::NEG_INFINITY,
+            f16::MAX,
+            f16::from_f32(5_000.0),
+        ];
+        let data: &[f16] = &data;
 
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
+        let (argmin_index, argmax_index) = scalar_argminmax(data);
+        assert_eq!(argmin_index, 3);
+        assert_eq!(argmax_index, 1);
+
+        let (argmin_simd_index, argmax_simd_index) = unsafe { T::argminmax(data) };
+        assert_eq!(argmin_simd_index, 3);
+        assert_eq!(argmax_simd_index, 1);
+    }
+
+    #[apply(simd_implementations)]
+    fn test_return_same_result<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMax<f16, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
         }
+        test_long_array_argminmax(get_array_f16, scalar_argminmax, T::argminmax);
+        test_random_runs_argminmax(get_array_f16, scalar_argminmax, T::argminmax);
+    }
 
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            let data = [
-                f16::from_f32(10.),
-                f16::MAX,
-                f16::from_f32(6.),
-                f16::NEG_INFINITY,
-                f16::NEG_INFINITY,
-                f16::MAX,
-                f16::from_f32(5_000.0),
-            ];
-            let data: Vec<f16> = data.iter().map(|x| *x).collect();
-            let data: &[f16] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 3);
-            assert_eq!(argmax_index, 1);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data) };
-            assert_eq!(argmin_simd_index, 3);
-            assert_eq!(argmax_simd_index, 1);
+    #[apply(simd_implementations)]
+    fn test_no_overflow<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMax<f16, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
         }
+        test_no_overflow_argminmax(get_array_f16, scalar_argminmax, T::argminmax, None);
+    }
 
-        #[test]
-        fn test_return_infs() {
-            let arr_len: usize = 1027;
-            let mut data: Vec<f16> = get_array_f16(arr_len);
-
-            // Case 1: all elements are +inf
-            for i in 0..data.len() {
-                data[i] = f16::INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 2: all elements are -inf
-            for i in 0..data.len() {
-                data[i] = f16::NEG_INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 3: add some +inf and -inf in the middle
-            let mut data: Vec<f16> = get_array_f16(arr_len);
-            data[100] = f16::INFINITY;
-            data[200] = f16::NEG_INFINITY;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 200);
-            assert_eq!(argmax_index, 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 200);
-            assert_eq!(argmax_simd_index, 100);
+    #[apply(simd_implementations)]
+    fn test_return_infs<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMax<f16, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
         }
+        test_return_infs_argminmax(get_array_f16, scalar_argminmax, T::argminmax);
+    }
 
-        #[test]
-        fn test_return_nans() {
-            let arr_len: usize = 1027;
-
-            // Case 1: NaN is the first element
-            let mut data: Vec<f16> = get_array_f16(arr_len);
-            data[0] = f16::NAN;
-            println!("{:?}", data);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 2: first 100 elements are NaN
-            for i in 0..100 {
-                data[i] = f16::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 3: NaN is the last element
-            let mut data: Vec<f16> = get_array_f16(arr_len);
-            data[arr_len - 1] = f16::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 1026);
-            assert_eq!(argmax_index, 1026);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 1026);
-            assert_eq!(argmax_simd_index, 1026);
-
-            // Case 4: last 100 elements are NaN
-            for i in 0..100 {
-                data[arr_len - 1 - i] = f16::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, arr_len - 100);
-            assert_eq!(argmax_index, arr_len - 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(&data) };
-            assert_eq!(argmin_simd_index, arr_len - 100);
-            assert_eq!(argmax_simd_index, arr_len - 100);
-
-            // Case 5: NaN is somewhere in the middle element
-            let mut data: Vec<f16> = get_array_f16(arr_len);
-            data[123] = f16::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 123);
-            assert_eq!(argmax_index, 123);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 123);
-            assert_eq!(argmax_simd_index, 123);
-
-            // Case 6: NaN in the middle of the array and last 100 elements are NaN
-            for i in 0..100 {
-                data[arr_len - 1 - i] = f16::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 123);
-            assert_eq!(argmax_index, 123);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 123);
-            assert_eq!(argmax_simd_index, 123);
-
-            // Case 7: all elements are NaN
-            for i in 0..data.len() {
-                data[i] = f16::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 8: array exact multiple of LANE_SIZE and only 1 element is NaN
-            let mut data: Vec<f16> = get_array_f16(128);
-            data[17] = f16::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 17);
-            assert_eq!(argmax_index, 17);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 17);
-            assert_eq!(argmax_simd_index, 17);
+    #[apply(simd_implementations)]
+    fn test_return_nans<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMax<f16, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
         }
-
-        #[test]
-        fn test_no_overflow() {
-            let n: usize = 1 << 18;
-            let data: &[f16] = &get_array_f16(n);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            for _ in 0..10_000 {
-                let data: &[f16] = &get_array_f16(32 * 8 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
+        test_return_nans_argminmax(get_array_f16, scalar_argminmax, T::argminmax);
     }
 }

--- a/src/simd/simd_f16_return_nan.rs
+++ b/src/simd/simd_f16_return_nan.rs
@@ -632,7 +632,8 @@ mod tests {
     use crate::SIMDArgMinMax;
 
     use super::super::test_utils::{
-        test_long_array_argminmax, test_no_overflow_argminmax, test_random_runs_argminmax,
+        test_first_index_identical_values_argminmax, test_long_array_argminmax,
+        test_no_overflow_argminmax, test_random_runs_argminmax,
     };
     // Float specific tests
     use super::super::test_utils::{test_return_infs_argminmax, test_return_nans_argminmax};
@@ -689,25 +690,7 @@ mod tests {
         if !simd_available {
             return;
         }
-
-        let data = [
-            f16::from_f32(10.),
-            f16::MAX,
-            f16::from_f32(6.),
-            f16::NEG_INFINITY,
-            f16::NEG_INFINITY,
-            f16::MAX,
-            f16::from_f32(5_000.0),
-        ];
-        let data: &[f16] = &data;
-
-        let (argmin_index, argmax_index) = scalar_argminmax(data);
-        assert_eq!(argmin_index, 3);
-        assert_eq!(argmax_index, 1);
-
-        let (argmin_simd_index, argmax_simd_index) = unsafe { T::argminmax(data) };
-        assert_eq!(argmin_simd_index, 3);
-        assert_eq!(argmax_simd_index, 1);
+        test_first_index_identical_values_argminmax(scalar_argminmax, T::argminmax);
     }
 
     #[apply(simd_implementations)]

--- a/src/simd/simd_f32_ignore_nan.rs
+++ b/src/simd/simd_f32_ignore_nan.rs
@@ -301,7 +301,8 @@ mod tests {
     use crate::SIMDArgMinMaxIgnoreNaN; // TODO use type-state pattern
 
     use super::super::test_utils::{
-        test_long_array_argminmax, test_no_overflow_argminmax, test_random_runs_argminmax,
+        test_first_index_identical_values_argminmax, test_long_array_argminmax,
+        test_no_overflow_argminmax, test_random_runs_argminmax,
     };
     // Float specific tests
     use super::super::test_utils::{test_ignore_nans_argminmax, test_return_infs_argminmax};
@@ -357,25 +358,7 @@ mod tests {
         if !simd_available {
             return;
         }
-
-        let data = [
-            10.,
-            f32::MAX,
-            6.,
-            f32::NEG_INFINITY,
-            f32::NEG_INFINITY,
-            f32::MAX,
-            10_000.0,
-        ];
-        let data: &[f32] = &data;
-
-        let (argmin_index, argmax_index) = scalar_argminmax(data);
-        assert_eq!(argmin_index, 3);
-        assert_eq!(argmax_index, 1);
-
-        let (argmin_simd_index, argmax_simd_index) = unsafe { T::argminmax(data) };
-        assert_eq!(argmin_simd_index, 3);
-        assert_eq!(argmax_simd_index, 1);
+        test_first_index_identical_values_argminmax(scalar_argminmax, T::argminmax);
     }
 
     #[apply(simd_implementations)]

--- a/src/simd/simd_f32_ignore_nan.rs
+++ b/src/simd/simd_f32_ignore_nan.rs
@@ -25,10 +25,10 @@ use std::arch::x86_64::*;
 // https://stackoverflow.com/a/3793950
 const MAX_INDEX: usize = 1 << f32::MANTISSA_DIGITS;
 
-// ------------------------------------------ AVX2 ------------------------------------------
+// --------------------------------------- AVX2 ----------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-mod avx2_ignore_nan {
+mod avx_ignore_nan {
     use super::super::config::{AVX2IgnoreNaN, AVX2};
     use super::*;
 
@@ -88,230 +88,9 @@ mod avx2_ignore_nan {
             Self::_argminmax(data)
         }
     }
-
-    // ------------------------------------ TESTS --------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::AVX2IgnoreNaN as AVX2;
-        use super::SIMDArgMinMaxIgnoreNaN;
-        use crate::scalar::generic::scalar_argminmax_ignore_nans as scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_f32(n: usize) -> Vec<f32> {
-            utils::get_random_array(n, f32::MIN, f32::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            if !is_x86_feature_detected!("avx") {
-                return;
-            }
-
-            let data: &[f32] = &get_array_f32(1025);
-            assert_eq!(data.len() % 8, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            if !is_x86_feature_detected!("avx") {
-                return;
-            }
-
-            let data = [
-                10.,
-                f32::MAX,
-                6.,
-                f32::NEG_INFINITY,
-                f32::NEG_INFINITY,
-                f32::MAX,
-                10_000.0,
-            ];
-            let data: Vec<f32> = data.iter().map(|x| *x).collect();
-            let data: &[f32] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 3);
-            assert_eq!(argmax_index, 1);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-            assert_eq!(argmin_simd_index, 3);
-            assert_eq!(argmax_simd_index, 1);
-        }
-
-        #[test]
-        fn test_return_infs() {
-            if !is_x86_feature_detected!("avx") {
-                return;
-            }
-
-            let arr_len: usize = 1027;
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-
-            // Case 1: all elements are +inf
-            for i in 0..data.len() {
-                data[i] = f32::INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 2: all elements are -inf
-            for i in 0..data.len() {
-                data[i] = f32::NEG_INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 3: add some +inf and -inf in the middle
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-            data[100] = f32::INFINITY;
-            data[200] = f32::NEG_INFINITY;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 200);
-            assert_eq!(argmax_index, 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 200);
-            assert_eq!(argmax_simd_index, 100);
-        }
-
-        #[test]
-        fn test_ignore_nans() {
-            if !is_x86_feature_detected!("avx") {
-                return;
-            }
-
-            let arr_len: usize = 1027;
-
-            // Case 1: NaN is the first element
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-            data[0] = f32::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert!(argmin_index != 0);
-            assert!(argmax_index != 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert!(argmin_simd_index != 0);
-            assert!(argmax_simd_index != 0);
-
-            // Case 2: first 100 elements are NaN
-            for i in 0..100 {
-                data[i] = f32::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert!(argmin_index > 99);
-            assert!(argmax_index > 99);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert!(argmin_simd_index > 99);
-            assert!(argmax_simd_index > 99);
-
-            // Case 3: NaN is the last element
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-            data[arr_len - 1] = f32::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert!(argmin_index != 1026);
-            assert!(argmax_index != 1026);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert!(argmin_simd_index != 1026);
-            assert!(argmax_simd_index != 1026);
-
-            // Case 4: last 100 elements are NaN
-            for i in 0..100 {
-                data[arr_len - 1 - i] = f32::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert!(argmin_index < arr_len - 100);
-            assert!(argmax_index < arr_len - 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert!(argmin_simd_index < arr_len - 100);
-            assert!(argmax_simd_index < arr_len - 100);
-
-            // Case 5: NaN is somewhere in the middle element
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-            data[123] = f32::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert!(argmin_index != 123);
-            assert!(argmax_index != 123);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert!(argmin_simd_index != 123);
-            assert!(argmax_simd_index != 123);
-
-            // Case 6: all elements are NaN
-            for i in 0..data.len() {
-                data[i] = f32::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-        }
-
-        #[test]
-        fn test_no_overflow() {
-            if !is_x86_feature_detected!("avx") {
-                return;
-            }
-
-            let n: usize = 1 << 25;
-            let data: &[f32] = &get_array_f32(n);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            if !is_x86_feature_detected!("avx") {
-                return;
-            }
-
-            for _ in 0..10_000 {
-                let data: &[f32] = &get_array_f32(32 * 8 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// ----------------------------------------- SSE -----------------------------------------
+// ---------------------------------------- SSE ----------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod sse_ignore_nan {
@@ -371,206 +150,9 @@ mod sse_ignore_nan {
             Self::_argminmax(data)
         }
     }
-
-    // ------------------------------------ TESTS --------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::SIMDArgMinMaxIgnoreNaN;
-        use super::SSEIgnoreNaN as SSE;
-        use crate::scalar::generic::scalar_argminmax_ignore_nans as scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_f32(n: usize) -> Vec<f32> {
-            utils::get_random_array(n, f32::MIN, f32::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            let data: &[f32] = &get_array_f32(1025);
-            assert_eq!(data.len() % 4, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            let data = [
-                10.,
-                f32::MAX,
-                6.,
-                f32::NEG_INFINITY,
-                f32::NEG_INFINITY,
-                f32::MAX,
-                10_000.0,
-            ];
-            let data: Vec<f32> = data.iter().map(|x| *x).collect();
-            let data: &[f32] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 3);
-            assert_eq!(argmax_index, 1);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-            assert_eq!(argmin_simd_index, 3);
-            assert_eq!(argmax_simd_index, 1);
-        }
-
-        #[test]
-        fn test_return_infs() {
-            let arr_len: usize = 1027;
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-
-            // Case 1: all elements are +inf
-            for i in 0..data.len() {
-                data[i] = f32::INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 2: all elements are -inf
-            for i in 0..data.len() {
-                data[i] = f32::NEG_INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 3: add some +inf and -inf in the middle
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-            data[100] = f32::INFINITY;
-            data[200] = f32::NEG_INFINITY;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 200);
-            assert_eq!(argmax_index, 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 200);
-            assert_eq!(argmax_simd_index, 100);
-        }
-
-        #[test]
-        fn test_ignore_nans() {
-            let arr_len: usize = 1027;
-
-            // Case 1: NaN is the first element
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-            data[0] = f32::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert!(argmin_index != 0);
-            assert!(argmax_index != 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert!(argmin_simd_index != 0);
-            assert!(argmax_simd_index != 0);
-
-            // Case 2: first 100 elements are NaN
-            for i in 0..100 {
-                data[i] = f32::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert!(argmin_index > 99);
-            assert!(argmax_index > 99);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert!(argmin_simd_index > 99);
-            assert!(argmax_simd_index > 99);
-
-            // Case 3: NaN is the last element
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-            data[arr_len - 1] = f32::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert!(argmin_index != 1026);
-            assert!(argmax_index != 1026);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert!(argmin_simd_index != 1026);
-            assert!(argmax_simd_index != 1026);
-
-            // Case 4: last 100 elements are NaN
-            for i in 0..100 {
-                data[arr_len - 1 - i] = f32::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert!(argmin_index < arr_len - 100);
-            assert!(argmax_index < arr_len - 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert!(argmin_simd_index < arr_len - 100);
-            assert!(argmax_simd_index < arr_len - 100);
-
-            // Case 5: NaN is somewhere in the middle element
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-            data[123] = f32::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert!(argmin_index != 123);
-            assert!(argmax_index != 123);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert!(argmin_simd_index != 123);
-            assert!(argmax_simd_index != 123);
-
-            // Case 6: all elements are NaN
-            for i in 0..data.len() {
-                data[i] = f32::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-        }
-
-        #[test]
-        fn test_no_overflow() {
-            let n: usize = 1 << 25;
-            let data: &[f32] = &get_array_f32(n);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            for _ in 0..10_000 {
-                let data: &[f32] = &get_array_f32(32 * 4 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// --------------------------------------- AVX512 ----------------------------------------
+// -------------------------------------- AVX512 ---------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod avx512_ignore_nan {
@@ -634,230 +216,9 @@ mod avx512_ignore_nan {
             Self::_argminmax(data)
         }
     }
-
-    // ------------------------------------ TESTS --------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::AVX512IgnoreNaN as AVX512;
-        use super::SIMDArgMinMaxIgnoreNaN;
-        use crate::scalar::generic::scalar_argminmax_ignore_nans as scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_f32(n: usize) -> Vec<f32> {
-            utils::get_random_array(n, f32::MIN, f32::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            let data: &[f32] = &get_array_f32(1025);
-            assert_eq!(data.len() % 16, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            let data = [
-                10.,
-                f32::MAX,
-                6.,
-                f32::NEG_INFINITY,
-                f32::NEG_INFINITY,
-                f32::MAX,
-                10_000.0,
-            ];
-            let data: Vec<f32> = data.iter().map(|x| *x).collect();
-            let data: &[f32] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 3);
-            assert_eq!(argmax_index, 1);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-            assert_eq!(argmin_simd_index, 3);
-            assert_eq!(argmax_simd_index, 1);
-        }
-
-        #[test]
-        fn test_return_infs() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            let arr_len: usize = 1027;
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-
-            // Case 1: all elements are +inf
-            for i in 0..data.len() {
-                data[i] = f32::INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 2: all elements are -inf
-            for i in 0..data.len() {
-                data[i] = f32::NEG_INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 3: add some +inf and -inf in the middle
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-            data[100] = f32::INFINITY;
-            data[200] = f32::NEG_INFINITY;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 200);
-            assert_eq!(argmax_index, 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 200);
-            assert_eq!(argmax_simd_index, 100);
-        }
-
-        #[test]
-        fn test_ignore_nans() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            let arr_len: usize = 1027;
-
-            // Case 1: NaN is the first element
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-            data[0] = f32::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert!(argmin_index != 0);
-            assert!(argmax_index != 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert!(argmin_simd_index != 0);
-            assert!(argmax_simd_index != 0);
-
-            // Case 2: first 100 elements are NaN
-            for i in 0..100 {
-                data[i] = f32::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert!(argmin_index > 99);
-            assert!(argmax_index > 99);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert!(argmin_simd_index > 99);
-            assert!(argmax_simd_index > 99);
-
-            // Case 3: NaN is the last element
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-            data[arr_len - 1] = f32::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert!(argmin_index != 1026);
-            assert!(argmax_index != 1026);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert!(argmin_simd_index != 1026);
-            assert!(argmax_simd_index != 1026);
-
-            // Case 4: last 100 elements are NaN
-            for i in 0..100 {
-                data[arr_len - 1 - i] = f32::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert!(argmin_index < arr_len - 100);
-            assert!(argmax_index < arr_len - 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert!(argmin_simd_index < arr_len - 100);
-            assert!(argmax_simd_index < arr_len - 100);
-
-            // Case 5: NaN is somewhere in the middle element
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-            data[123] = f32::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert!(argmin_index != 123);
-            assert!(argmax_index != 123);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert!(argmin_simd_index != 123);
-            assert!(argmax_simd_index != 123);
-
-            // Case 6: all elements are NaN
-            for i in 0..data.len() {
-                data[i] = f32::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-        }
-
-        #[test]
-        fn test_no_overflow() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            let n: usize = 1 << 25;
-            let data: &[f32] = &get_array_f32(n);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            for _ in 0..10_000 {
-                let data: &[f32] = &get_array_f32(32 * 16 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// ---------------------------------------- NEON -----------------------------------------
+// --------------------------------------- NEON ----------------------------------------
 
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 mod neon_ignore_nan {
@@ -917,201 +278,164 @@ mod neon_ignore_nan {
             Self::_argminmax(data)
         }
     }
+}
 
-    // ------------------------------------ TESTS --------------------------------------
+// ======================================= TESTS =======================================
 
-    #[cfg(test)]
-    mod tests {
-        use super::NEONIgnoreNaN as NEON;
-        use super::SIMDArgMinMaxIgnoreNaN;
-        use crate::scalar::generic::scalar_argminmax_ignore_nans as scalar_argminmax;
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "arm",
+    target_arch = "aarch64",
+))]
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use rstest_reuse::{self, *};
 
-        extern crate dev_utils;
-        use dev_utils::utils;
+    use crate::scalar::generic::scalar_argminmax_ignore_nans as scalar_argminmax;
+    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    use crate::simd::config::NEONIgnoreNaN;
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    use crate::simd::config::{AVX2IgnoreNaN, AVX512IgnoreNaN, SSEIgnoreNaN};
+    use crate::SIMDArgMinMaxIgnoreNaN; // TODO use type-state pattern
 
-        fn get_array_f32(n: usize) -> Vec<f32> {
-            utils::get_random_array(n, f32::MIN, f32::MAX)
+    use super::super::test_utils::{
+        test_long_array_argminmax, test_no_overflow_argminmax, test_random_runs_argminmax,
+    };
+    // Float specific tests
+    use super::super::test_utils::{test_ignore_nans_argminmax, test_return_infs_argminmax};
+
+    use dev_utils::utils;
+
+    fn get_array_f32(n: usize) -> Vec<f32> {
+        utils::get_random_array(n, f32::MIN, f32::MAX)
+    }
+
+    // ------------ Template for x86 / x86_64 -------------
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[template]
+    #[rstest]
+    #[case::sse(SSEIgnoreNaN, is_x86_feature_detected!("sse4.1"))]
+    #[case::avx2(AVX2IgnoreNaN, is_x86_feature_detected!("avx"))]
+    #[case::avx512(AVX512IgnoreNaN, is_x86_feature_detected!("avx512f"))]
+    fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T,
+        #[case] simd_available: bool,
+    ) {
+    }
+
+    // ------------ Template for ARM / AArch64 ------------
+
+    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[template]
+    #[rstest]
+    #[case::neon(NEONIgnoreNaN, true)]
+    fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T,
+        #[case] simd_available: bool,
+    ) {
+    }
+
+    // ----------------- The actual tests -----------------
+
+    #[apply(simd_implementations)]
+    fn test_first_index_is_returned_when_identical_values_found<
+        T,
+        SIMDV,
+        SIMDM,
+        const LANE_SIZE: usize,
+    >(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMaxIgnoreNaN<f32, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
         }
 
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            let data: &[f32] = &get_array_f32(1025);
-            assert_eq!(data.len() % 4, 1);
+        let data = [
+            10.,
+            f32::MAX,
+            6.,
+            f32::NEG_INFINITY,
+            f32::NEG_INFINITY,
+            f32::MAX,
+            10_000.0,
+        ];
+        let data: &[f32] = &data;
 
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
+        let (argmin_index, argmax_index) = scalar_argminmax(data);
+        assert_eq!(argmin_index, 3);
+        assert_eq!(argmax_index, 1);
+
+        let (argmin_simd_index, argmax_simd_index) = unsafe { T::argminmax(data) };
+        assert_eq!(argmin_simd_index, 3);
+        assert_eq!(argmax_simd_index, 1);
+    }
+
+    #[apply(simd_implementations)]
+    fn test_return_same_result<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMaxIgnoreNaN<f32, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
         }
+        test_long_array_argminmax(get_array_f32, scalar_argminmax, T::argminmax);
+        test_random_runs_argminmax(get_array_f32, scalar_argminmax, T::argminmax);
+    }
 
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            let data = [
-                10.,
-                f32::MAX,
-                6.,
-                f32::NEG_INFINITY,
-                f32::NEG_INFINITY,
-                f32::MAX,
-                10_000.0,
-            ];
-            let data: Vec<f32> = data.iter().map(|x| *x).collect();
-            let data: &[f32] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 3);
-            assert_eq!(argmax_index, 1);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data) };
-            assert_eq!(argmin_simd_index, 3);
-            assert_eq!(argmax_simd_index, 1);
+    #[apply(simd_implementations)]
+    fn test_no_overflow<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMaxIgnoreNaN<f32, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
         }
+        test_no_overflow_argminmax(get_array_f32, scalar_argminmax, T::argminmax, Some(1 << 25));
+    }
 
-        #[test]
-        fn test_return_infs() {
-            let arr_len: usize = 1027;
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-
-            // Case 1: all elements are +inf
-            for i in 0..data.len() {
-                data[i] = f32::INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 2: all elements are -inf
-            for i in 0..data.len() {
-                data[i] = f32::NEG_INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 3: add some +inf and -inf in the middle
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-            data[100] = f32::INFINITY;
-            data[200] = f32::NEG_INFINITY;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 200);
-            assert_eq!(argmax_index, 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 200);
-            assert_eq!(argmax_simd_index, 100);
+    #[apply(simd_implementations)]
+    fn test_return_infs<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMaxIgnoreNaN<f32, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
         }
+        test_return_infs_argminmax(get_array_f32, scalar_argminmax, T::argminmax);
+    }
 
-        #[test]
-        fn test_ignore_nans() {
-            let arr_len: usize = 1027;
-
-            // Case 1: NaN is the first element
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-            data[0] = f32::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert!(argmin_index != 0);
-            assert!(argmax_index != 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(&data) };
-            assert!(argmin_simd_index != 0);
-            assert!(argmax_simd_index != 0);
-
-            // Case 2: first 100 elements are NaN
-            for i in 0..100 {
-                data[i] = f32::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert!(argmin_index > 99);
-            assert!(argmax_index > 99);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(&data) };
-            assert!(argmin_simd_index > 99);
-            assert!(argmax_simd_index > 99);
-
-            // Case 3: NaN is the last element
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-            data[arr_len - 1] = f32::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert!(argmin_index != 1026);
-            assert!(argmax_index != 1026);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(&data) };
-            assert!(argmin_simd_index != 1026);
-            assert!(argmax_simd_index != 1026);
-
-            // Case 4: last 100 elements are NaN
-            for i in 0..100 {
-                data[arr_len - 1 - i] = f32::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert!(argmin_index < arr_len - 100);
-            assert!(argmax_index < arr_len - 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(&data) };
-            assert!(argmin_simd_index < arr_len - 100);
-            assert!(argmax_simd_index < arr_len - 100);
-
-            // Case 5: NaN is somewhere in the middle element
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-            data[123] = f32::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert!(argmin_index != 123);
-            assert!(argmax_index != 123);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(&data) };
-            assert!(argmin_simd_index != 123);
-            assert!(argmax_simd_index != 123);
-
-            // Case 6: all elements are NaN
-            for i in 0..data.len() {
-                data[i] = f32::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
+    #[apply(simd_implementations)]
+    fn test_ignore_nans<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMaxIgnoreNaN<f32, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
         }
-
-        #[test]
-        fn test_no_overflow() {
-            let n: usize = 1 << 25;
-            let data: &[f32] = &get_array_f32(n);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            for _ in 0..10_000 {
-                let data: &[f32] = &get_array_f32(32 * 4 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
+        test_ignore_nans_argminmax(get_array_f32, scalar_argminmax, T::argminmax);
     }
 }

--- a/src/simd/simd_f32_return_nan.rs
+++ b/src/simd/simd_f32_return_nan.rs
@@ -445,7 +445,7 @@ mod tests {
     #[template]
     #[rstest]
     #[case::sse(SSE, is_x86_feature_detected!("sse4.1"))]
-    #[case::avx2(AVX2, is_x86_feature_detected!("avx"))]
+    #[case::avx2(AVX2, is_x86_feature_detected!("avx2"))]
     #[case::avx512(AVX512, is_x86_feature_detected!("avx512f"))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,

--- a/src/simd/simd_f32_return_nan.rs
+++ b/src/simd/simd_f32_return_nan.rs
@@ -52,10 +52,10 @@ fn _i32ord_to_f32(ord_i32: i32) -> f32 {
 
 const MAX_INDEX: usize = i32::MAX as usize;
 
-// ------------------------------------------ AVX2 ------------------------------------------
+// --------------------------------------- AVX2 ----------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-mod avx2_return_nan {
+mod avx2 {
     use super::super::config::AVX2;
     use super::*;
 
@@ -138,254 +138,9 @@ mod avx2_return_nan {
             Self::_argminmax(data)
         }
     }
-
-    // ------------------------------------ TESTS --------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::{SIMDArgMinMax, AVX2};
-        use crate::scalar::generic::scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_f32(n: usize) -> Vec<f32> {
-            utils::get_random_array(n, f32::MIN, f32::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            let data: &[f32] = &get_array_f32(1025);
-            assert_eq!(data.len() % 8, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            let data = [
-                10.,
-                f32::MAX,
-                6.,
-                f32::NEG_INFINITY,
-                f32::NEG_INFINITY,
-                f32::MAX,
-                10_000.0,
-            ];
-            let data: Vec<f32> = data.iter().map(|x| *x).collect();
-            let data: &[f32] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 3);
-            assert_eq!(argmax_index, 1);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-            assert_eq!(argmin_simd_index, 3);
-            assert_eq!(argmax_simd_index, 1);
-        }
-
-        #[test]
-        fn test_return_infs() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            let arr_len: usize = 1027;
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-
-            // Case 1: all elements are +inf
-            for i in 0..data.len() {
-                data[i] = f32::INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 2: all elements are -inf
-            for i in 0..data.len() {
-                data[i] = f32::NEG_INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 3: add some +inf and -inf in the middle
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-            data[100] = f32::INFINITY;
-            data[200] = f32::NEG_INFINITY;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 200);
-            assert_eq!(argmax_index, 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 200);
-            assert_eq!(argmax_simd_index, 100);
-        }
-
-        #[test]
-        fn test_return_nans() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            let arr_len: usize = 1027;
-
-            // Case 1: NaN is the first element
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-            data[0] = f32::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 2: first 100 elements are NaN
-            for i in 0..100 {
-                data[i] = f32::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 3: NaN is the last element
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-            data[arr_len - 1] = f32::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 1026);
-            assert_eq!(argmax_index, 1026);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 1026);
-            assert_eq!(argmax_simd_index, 1026);
-
-            // Case 4: last 100 elements are NaN
-            for i in 0..100 {
-                data[arr_len - 1 - i] = f32::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, arr_len - 100);
-            assert_eq!(argmax_index, arr_len - 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, arr_len - 100);
-            assert_eq!(argmax_simd_index, arr_len - 100);
-
-            // Case 5: NaN is somewhere in the middle element
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-            data[123] = f32::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 123);
-            assert_eq!(argmax_index, 123);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 123);
-            assert_eq!(argmax_simd_index, 123);
-
-            // Case 6: NaN in the middle of the array and last 100 elements are NaN
-            for i in 0..100 {
-                data[arr_len - 1 - i] = f32::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 123);
-            assert_eq!(argmax_index, 123);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 123);
-            assert_eq!(argmax_simd_index, 123);
-
-            // Case 7: all elements are NaN
-            for i in 0..data.len() {
-                data[i] = f32::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 8: array exact multiple of LANE_SIZE and only 1 element is NaN
-            let mut data: Vec<f32> = get_array_f32(128);
-            data[17] = f32::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 17);
-            assert_eq!(argmax_index, 17);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 17);
-            assert_eq!(argmax_simd_index, 17);
-        }
-
-        #[test]
-        fn test_no_overflow() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            let n: usize = 1 << 25;
-            let data: &[f32] = &get_array_f32(n);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            for _ in 0..10_000 {
-                let data: &[f32] = &get_array_f32(32 * 8 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// ----------------------------------------- SSE -----------------------------------------
+// ---------------------------------------- SSE ----------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod sse {
@@ -470,230 +225,9 @@ mod sse {
             Self::_argminmax(data)
         }
     }
-
-    // ------------------------------------ TESTS --------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::{SIMDArgMinMax, SSE};
-        use crate::scalar::generic::scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_f32(n: usize) -> Vec<f32> {
-            utils::get_random_array(n, f32::MIN, f32::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            let data: &[f32] = &get_array_f32(1025);
-            assert_eq!(data.len() % 4, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            let data = [
-                10.,
-                f32::MAX,
-                6.,
-                f32::NEG_INFINITY,
-                f32::NEG_INFINITY,
-                f32::MAX,
-                10_000.0,
-            ];
-            let data: Vec<f32> = data.iter().map(|x| *x).collect();
-            let data: &[f32] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 3);
-            assert_eq!(argmax_index, 1);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-            assert_eq!(argmin_simd_index, 3);
-            assert_eq!(argmax_simd_index, 1);
-        }
-
-        #[test]
-        fn test_return_infs() {
-            let arr_len: usize = 1027;
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-
-            // Case 1: all elements are +inf
-            for i in 0..data.len() {
-                data[i] = f32::INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 2: all elements are -inf
-            for i in 0..data.len() {
-                data[i] = f32::NEG_INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 3: add some +inf and -inf in the middle
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-            data[100] = f32::INFINITY;
-            data[200] = f32::NEG_INFINITY;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 200);
-            assert_eq!(argmax_index, 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 200);
-            assert_eq!(argmax_simd_index, 100);
-        }
-
-        #[test]
-        fn test_return_nans() {
-            let arr_len: usize = 1027;
-
-            // Case 1: NaN is the first element
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-            data[0] = f32::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 2: first 100 elements are NaN
-            for i in 0..100 {
-                data[i] = f32::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 3: NaN is the last element
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-            data[arr_len - 1] = f32::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 1026);
-            assert_eq!(argmax_index, 1026);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 1026);
-            assert_eq!(argmax_simd_index, 1026);
-
-            // Case 4: last 100 elements are NaN
-            for i in 0..100 {
-                data[arr_len - 1 - i] = f32::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, arr_len - 100);
-            assert_eq!(argmax_index, arr_len - 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, arr_len - 100);
-            assert_eq!(argmax_simd_index, arr_len - 100);
-
-            // Case 5: NaN is somewhere in the middle element
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-            data[123] = f32::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 123);
-            assert_eq!(argmax_index, 123);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 123);
-            assert_eq!(argmax_simd_index, 123);
-
-            // Case 6: NaN in the middle of the array and last 100 elements are NaN
-            for i in 0..100 {
-                data[arr_len - 1 - i] = f32::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 123);
-            assert_eq!(argmax_index, 123);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 123);
-            assert_eq!(argmax_simd_index, 123);
-
-            // Case 7: all elements are NaN
-            for i in 0..data.len() {
-                data[i] = f32::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 8: array exact multiple of LANE_SIZE and only 1 element is NaN
-            let mut data: Vec<f32> = get_array_f32(128);
-            data[17] = f32::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 17);
-            assert_eq!(argmax_index, 17);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 17);
-            assert_eq!(argmax_simd_index, 17);
-        }
-
-        #[test]
-        fn test_no_overflow() {
-            let n: usize = 1 << 25;
-            let data: &[f32] = &get_array_f32(n);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            for _ in 0..10_000 {
-                let data: &[f32] = &get_array_f32(32 * 4 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// --------------------------------------- AVX512 ----------------------------------------
+// -------------------------------------- AVX512 ---------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod avx512 {
@@ -783,257 +317,12 @@ mod avx512 {
             Self::_argminmax(data)
         }
     }
-
-    // ------------------------------------ TESTS --------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::{SIMDArgMinMax, AVX512};
-        use crate::scalar::generic::scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_f32(n: usize) -> Vec<f32> {
-            utils::get_random_array(n, f32::MIN, f32::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            let data: &[f32] = &get_array_f32(1025);
-            assert_eq!(data.len() % 16, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            let data = [
-                10.,
-                f32::MAX,
-                6.,
-                f32::NEG_INFINITY,
-                f32::NEG_INFINITY,
-                f32::MAX,
-                10_000.0,
-            ];
-            let data: Vec<f32> = data.iter().map(|x| *x).collect();
-            let data: &[f32] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 3);
-            assert_eq!(argmax_index, 1);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-            assert_eq!(argmin_simd_index, 3);
-            assert_eq!(argmax_simd_index, 1);
-        }
-
-        #[test]
-        fn test_return_infs() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            let arr_len: usize = 1027;
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-
-            // Case 1: all elements are +inf
-            for i in 0..data.len() {
-                data[i] = f32::INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 2: all elements are -inf
-            for i in 0..data.len() {
-                data[i] = f32::NEG_INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 3: add some +inf and -inf in the middle
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-            data[100] = f32::INFINITY;
-            data[200] = f32::NEG_INFINITY;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 200);
-            assert_eq!(argmax_index, 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 200);
-            assert_eq!(argmax_simd_index, 100);
-        }
-
-        #[test]
-        fn test_return_nans() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            let arr_len: usize = 1027;
-
-            // Case 1: NaN is the first element
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-            data[0] = f32::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 2: first 100 elements are NaN
-            for i in 0..100 {
-                data[i] = f32::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 3: NaN is the last element
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-            data[arr_len - 1] = f32::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 1026);
-            assert_eq!(argmax_index, 1026);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 1026);
-            assert_eq!(argmax_simd_index, 1026);
-
-            // Case 4: last 100 elements are NaN
-            for i in 0..100 {
-                data[arr_len - 1 - i] = f32::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, arr_len - 100);
-            assert_eq!(argmax_index, arr_len - 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, arr_len - 100);
-            assert_eq!(argmax_simd_index, arr_len - 100);
-
-            // Case 5: NaN is somewhere in the middle element
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-            data[123] = f32::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 123);
-            assert_eq!(argmax_index, 123);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 123);
-            assert_eq!(argmax_simd_index, 123);
-
-            // Case 6: NaN in the middle of the array and last 100 elements are NaN
-            for i in 0..100 {
-                data[arr_len - 1 - i] = f32::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 123);
-            assert_eq!(argmax_index, 123);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 123);
-            assert_eq!(argmax_simd_index, 123);
-
-            // Case 7: all elements are NaN
-            for i in 0..data.len() {
-                data[i] = f32::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 8: array exact multiple of LANE_SIZE and only 1 element is NaN
-            let mut data: Vec<f32> = get_array_f32(128);
-            data[17] = f32::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 17);
-            assert_eq!(argmax_index, 17);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 17);
-            assert_eq!(argmax_simd_index, 17);
-        }
-
-        #[test]
-        fn test_no_overflow() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            let n: usize = 1 << 25;
-            let data: &[f32] = &get_array_f32(n);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            for _ in 0..10_000 {
-                let data: &[f32] = &get_array_f32(32 * 16 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// ---------------------------------------- NEON -----------------------------------------
+// --------------------------------------- NEON ----------------------------------------
 
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-mod neon_float_return_nan {
+mod neon {
     use super::super::config::NEON;
     use super::*;
 
@@ -1115,225 +404,147 @@ mod neon_float_return_nan {
             Self::_argminmax(data)
         }
     }
+}
 
-    // ------------------------------------ TESTS --------------------------------------
+// ======================================= TESTS =======================================
 
-    #[cfg(test)]
-    mod tests {
-        use super::{SIMDArgMinMax, NEON};
-        use crate::scalar::generic::scalar_argminmax;
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "arm",
+    target_arch = "aarch64",
+))]
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use rstest_reuse::{self, *};
 
-        extern crate dev_utils;
-        use dev_utils::utils;
+    use crate::scalar::generic::scalar_argminmax;
+    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    use crate::simd::config::NEON;
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    use crate::simd::config::{AVX2, AVX512, SSE};
+    use crate::SIMDArgMinMax;
 
-        fn get_array_f32(n: usize) -> Vec<f32> {
-            utils::get_random_array(n, f32::MIN, f32::MAX)
+    use super::super::test_utils::{test_long_array_argminmax, test_random_runs_argminmax};
+    // Float specific tests
+    use super::super::test_utils::{test_return_infs_argminmax, test_return_nans_argminmax};
+
+    use dev_utils::utils;
+
+    fn get_array_f32(n: usize) -> Vec<f32> {
+        utils::get_random_array(n, f32::MIN, f32::MAX)
+    }
+
+    // ------------ Template for x86 / x86_64 -------------
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[template]
+    #[rstest]
+    #[case::sse(SSE, is_x86_feature_detected!("sse4.1"))]
+    #[case::avx2(AVX2, is_x86_feature_detected!("avx"))]
+    #[case::avx512(AVX512, is_x86_feature_detected!("avx512f"))]
+    fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T,
+        #[case] simd_available: bool,
+    ) {
+    }
+
+    // ------------ Template for ARM / AArch64 ------------
+
+    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[template]
+    #[rstest]
+    #[case::neon(NEON, true)]
+    fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T,
+        #[case] simd_available: bool,
+    ) {
+    }
+
+    // ----------------- The actual tests -----------------
+
+    #[apply(simd_implementations)]
+    fn test_first_index_is_returned_when_identical_values_found<
+        T,
+        SIMDV,
+        SIMDM,
+        const LANE_SIZE: usize,
+    >(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMax<f32, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
         }
 
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            let data: &[f32] = &get_array_f32(1025);
-            assert_eq!(data.len() % 4, 1);
+        let data = [
+            10.,
+            f32::MAX,
+            6.,
+            f32::NEG_INFINITY,
+            f32::NEG_INFINITY,
+            f32::MAX,
+            10_000.0,
+        ];
+        let data: &[f32] = &data;
 
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
+        let (argmin_index, argmax_index) = scalar_argminmax(data);
+        assert_eq!(argmin_index, 3);
+        assert_eq!(argmax_index, 1);
+
+        let (argmin_simd_index, argmax_simd_index) = unsafe { T::argminmax(data) };
+        assert_eq!(argmin_simd_index, 3);
+        assert_eq!(argmax_simd_index, 1);
+    }
+
+    #[apply(simd_implementations)]
+    fn test_return_same_result<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMax<f32, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
         }
+        test_long_array_argminmax(get_array_f32, scalar_argminmax, T::argminmax);
+        test_random_runs_argminmax(get_array_f32, scalar_argminmax, T::argminmax);
+    }
 
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            let data = [
-                10.,
-                f32::MAX,
-                6.,
-                f32::NEG_INFINITY,
-                f32::NEG_INFINITY,
-                f32::MAX,
-                10_000.0,
-            ];
-            let data: Vec<f32> = data.iter().map(|x| *x).collect();
-            let data: &[f32] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 3);
-            assert_eq!(argmax_index, 1);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data) };
-            assert_eq!(argmin_simd_index, 3);
-            assert_eq!(argmax_simd_index, 1);
+    #[apply(simd_implementations)]
+    fn test_return_infs<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMax<f32, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
         }
+        test_return_infs_argminmax(get_array_f32, scalar_argminmax, T::argminmax);
+    }
 
-        #[test]
-        fn test_return_infs() {
-            let arr_len: usize = 1027;
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-
-            // Case 1: all elements are +inf
-            for i in 0..data.len() {
-                data[i] = f32::INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 2: all elements are -inf
-            for i in 0..data.len() {
-                data[i] = f32::NEG_INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 3: add some +inf and -inf in the middle
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-            data[100] = f32::INFINITY;
-            data[200] = f32::NEG_INFINITY;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 200);
-            assert_eq!(argmax_index, 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 200);
-            assert_eq!(argmax_simd_index, 100);
+    #[apply(simd_implementations)]
+    fn test_return_nans<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMax<f32, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
         }
-
-        #[test]
-        fn test_return_nans() {
-            let arr_len: usize = 1027;
-
-            // Case 1: NaN is the first element
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-            data[0] = f32::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 2: first 100 elements are NaN
-            for i in 0..100 {
-                data[i] = f32::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 3: NaN is the last element
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-            data[arr_len - 1] = f32::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 1026);
-            assert_eq!(argmax_index, 1026);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 1026);
-            assert_eq!(argmax_simd_index, 1026);
-
-            // Case 4: last 100 elements are NaN
-            for i in 0..100 {
-                data[arr_len - 1 - i] = f32::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, arr_len - 100);
-            assert_eq!(argmax_index, arr_len - 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(&data) };
-            assert_eq!(argmin_simd_index, arr_len - 100);
-            assert_eq!(argmax_simd_index, arr_len - 100);
-
-            // Case 5: NaN is somewhere in the middle element
-            let mut data: Vec<f32> = get_array_f32(arr_len);
-            data[123] = f32::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 123);
-            assert_eq!(argmax_index, 123);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 123);
-            assert_eq!(argmax_simd_index, 123);
-
-            // Case 6: NaN in the middle of the array and last 100 elements are NaN
-            for i in 0..100 {
-                data[arr_len - 1 - i] = f32::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 123);
-            assert_eq!(argmax_index, 123);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 123);
-            assert_eq!(argmax_simd_index, 123);
-
-            // Case 7: all elements are NaN
-            for i in 0..data.len() {
-                data[i] = f32::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 8: array exact multiple of LANE_SIZE and only 1 element is NaN
-            let mut data: Vec<f32> = get_array_f32(128);
-            data[17] = f32::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 17);
-            assert_eq!(argmax_index, 17);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 17);
-            assert_eq!(argmax_simd_index, 17);
-        }
-
-        #[test]
-        fn test_no_overflow() {
-            let n: usize = 1 << 25;
-            let data: &[f32] = &get_array_f32(n);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            for _ in 0..10_000 {
-                let data: &[f32] = &get_array_f32(32 * 4 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
+        test_return_nans_argminmax(get_array_f32, scalar_argminmax, T::argminmax);
     }
 }

--- a/src/simd/simd_f32_return_nan.rs
+++ b/src/simd/simd_f32_return_nan.rs
@@ -426,7 +426,10 @@ mod tests {
     use crate::simd::config::{AVX2, AVX512, SSE};
     use crate::SIMDArgMinMax;
 
-    use super::super::test_utils::{test_long_array_argminmax, test_random_runs_argminmax};
+    use super::super::test_utils::{
+        test_first_index_identical_values_argminmax, test_long_array_argminmax,
+        test_random_runs_argminmax,
+    };
     // Float specific tests
     use super::super::test_utils::{test_return_infs_argminmax, test_return_nans_argminmax};
 
@@ -481,25 +484,7 @@ mod tests {
         if !simd_available {
             return;
         }
-
-        let data = [
-            10.,
-            f32::MAX,
-            6.,
-            f32::NEG_INFINITY,
-            f32::NEG_INFINITY,
-            f32::MAX,
-            10_000.0,
-        ];
-        let data: &[f32] = &data;
-
-        let (argmin_index, argmax_index) = scalar_argminmax(data);
-        assert_eq!(argmin_index, 3);
-        assert_eq!(argmax_index, 1);
-
-        let (argmin_simd_index, argmax_simd_index) = unsafe { T::argminmax(data) };
-        assert_eq!(argmin_simd_index, 3);
-        assert_eq!(argmax_simd_index, 1);
+        test_first_index_identical_values_argminmax(scalar_argminmax, T::argminmax);
     }
 
     #[apply(simd_implementations)]

--- a/src/simd/simd_f64_ignore_nan.rs
+++ b/src/simd/simd_f64_ignore_nan.rs
@@ -245,7 +245,10 @@ mod tests {
     use crate::simd::config::{AVX2IgnoreNaN, AVX512IgnoreNaN, SSEIgnoreNaN};
     use crate::SIMDArgMinMaxIgnoreNaN; // todo use type-state pattern
 
-    use super::super::test_utils::{test_long_array_argminmax, test_random_runs_argminmax};
+    use super::super::test_utils::{
+        test_first_index_identical_values_argminmax, test_long_array_argminmax,
+        test_random_runs_argminmax,
+    };
     // Float specific tests
     use super::super::test_utils::{test_ignore_nans_argminmax, test_return_infs_argminmax};
 
@@ -287,27 +290,7 @@ mod tests {
         if !simd_available {
             return;
         }
-
-        // TODO: make sure that this is a proper multiple of the LANE_SIZE
-        // I think we - ideally - centralize this just as the other tests
-        let data = [
-            10.,
-            f64::MAX,
-            6.,
-            f64::NEG_INFINITY,
-            f64::NEG_INFINITY,
-            f64::MAX,
-            10_000.0,
-        ];
-        let data: &[f64] = &data;
-
-        let (argmin_index, argmax_index) = scalar_argminmax(data);
-        assert_eq!(argmin_index, 3);
-        assert_eq!(argmax_index, 1);
-
-        let (argmin_simd_index, argmax_simd_index) = unsafe { T::argminmax(data) };
-        assert_eq!(argmin_simd_index, 3);
-        assert_eq!(argmax_simd_index, 1);
+        test_first_index_identical_values_argminmax(scalar_argminmax, T::argminmax);
     }
 
     #[apply(simd_implementations)]

--- a/src/simd/simd_f64_ignore_nan.rs
+++ b/src/simd/simd_f64_ignore_nan.rs
@@ -26,10 +26,10 @@ const MAX_INDEX: usize = 1 << f64::MANTISSA_DIGITS;
 #[cfg(target_arch = "x86")] // https://stackoverflow.com/a/29592369
 const MAX_INDEX: usize = u32::MAX as usize;
 
-// ------------------------------------------ AVX2 ------------------------------------------
+// --------------------------------------- AVX2 ----------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-mod avx2_ignore_nan {
+mod avx_ignore_nan {
     use super::super::config::{AVX2IgnoreNaN, AVX2};
     use super::*;
 
@@ -86,215 +86,9 @@ mod avx2_ignore_nan {
             Self::_argminmax(data)
         }
     }
-
-    // ------------------------------------ TESTS --------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::AVX2IgnoreNaN as AVX2;
-        use super::SIMDArgMinMaxIgnoreNaN;
-        use crate::scalar::generic::scalar_argminmax_ignore_nans as scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_f64(n: usize) -> Vec<f64> {
-            utils::get_random_array(n, f64::MIN, f64::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            if !is_x86_feature_detected!("avx") {
-                return;
-            }
-
-            let data: &[f64] = &get_array_f64(1025);
-            assert_eq!(data.len() % 4, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            if !is_x86_feature_detected!("avx") {
-                return;
-            }
-
-            let data = [
-                10.,
-                f64::MAX,
-                6.,
-                f64::NEG_INFINITY,
-                f64::NEG_INFINITY,
-                f64::MAX,
-                10_000.0,
-            ];
-            let data: Vec<f64> = data.iter().map(|x| *x).collect();
-            let data: &[f64] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 3);
-            assert_eq!(argmax_index, 1);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-            assert_eq!(argmin_simd_index, 3);
-            assert_eq!(argmax_simd_index, 1);
-        }
-
-        #[test]
-        fn test_return_infs() {
-            if !is_x86_feature_detected!("avx") {
-                return;
-            }
-
-            let arr_len: usize = 1027;
-            let mut data: Vec<f64> = get_array_f64(arr_len);
-
-            // Case 1: all elements are +inf
-            for i in 0..data.len() {
-                data[i] = f64::INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 2: all elements are -inf
-            for i in 0..data.len() {
-                data[i] = f64::NEG_INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 3: add some +inf and -inf in the middle
-            let mut data: Vec<f64> = get_array_f64(arr_len);
-            data[100] = f64::INFINITY;
-            data[200] = f64::NEG_INFINITY;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 200);
-            assert_eq!(argmax_index, 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 200);
-            assert_eq!(argmax_simd_index, 100);
-        }
-
-        #[test]
-        fn test_ignore_nans() {
-            if !is_x86_feature_detected!("avx") {
-                return;
-            }
-
-            let arr_len: usize = 1027;
-
-            // Case 1: NaN is the first element
-            let mut data: Vec<f64> = get_array_f64(arr_len);
-            data[0] = f64::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert!(argmin_index != 0);
-            assert!(argmax_index != 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert!(argmin_simd_index != 0);
-            assert!(argmax_simd_index != 0);
-
-            // Case 2: first 100 elements are NaN
-            for i in 0..100 {
-                data[i] = f64::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert!(argmin_index > 99);
-            assert!(argmax_index > 99);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert!(argmin_simd_index > 99);
-            assert!(argmax_simd_index > 99);
-
-            // Case 3: NaN is the last element
-            let mut data: Vec<f64> = get_array_f64(arr_len);
-            data[arr_len - 1] = f64::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert!(argmin_index != 1026);
-            assert!(argmax_index != 1026);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert!(argmin_simd_index != 1026);
-            assert!(argmax_simd_index != 1026);
-
-            // Case 4: last 100 elements are NaN
-            for i in 0..100 {
-                data[arr_len - 1 - i] = f64::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert!(argmin_index < arr_len - 100);
-            assert!(argmax_index < arr_len - 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert!(argmin_simd_index < arr_len - 100);
-            assert!(argmax_simd_index < arr_len - 100);
-
-            // Case 5: NaN is somewhere in the middle element
-            let mut data: Vec<f64> = get_array_f64(arr_len);
-            data[123] = f64::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert!(argmin_index != 123);
-            assert!(argmax_index != 123);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert!(argmin_simd_index != 123);
-            assert!(argmax_simd_index != 123);
-
-            // Case 6: all elements are NaN
-            for i in 0..data.len() {
-                data[i] = f64::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            if !is_x86_feature_detected!("avx") {
-                return;
-            }
-
-            for _ in 0..10_000 {
-                let data: &[f64] = &get_array_f64(32 * 8 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// ----------------------------------------- SSE -----------------------------------------
+// ---------------------------------------- SSE ----------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod sse_ignore_nan {
@@ -353,195 +147,9 @@ mod sse_ignore_nan {
             Self::_argminmax(data)
         }
     }
-
-    // ------------------------------------ TESTS --------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::SIMDArgMinMaxIgnoreNaN;
-        use super::SSEIgnoreNaN as SSE;
-        use crate::scalar::generic::scalar_argminmax_ignore_nans as scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_f64(n: usize) -> Vec<f64> {
-            utils::get_random_array(n, f64::MIN, f64::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            let data: &[f64] = &get_array_f64(1025);
-            assert_eq!(data.len() % 2, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            let data = [
-                10.,
-                f64::MAX,
-                6.,
-                f64::NEG_INFINITY,
-                f64::NEG_INFINITY,
-                f64::MAX,
-                10_000.0,
-            ];
-            let data: Vec<f64> = data.iter().map(|x| *x).collect();
-            let data: &[f64] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 3);
-            assert_eq!(argmax_index, 1);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-            assert_eq!(argmin_simd_index, 3);
-            assert_eq!(argmax_simd_index, 1);
-        }
-
-        #[test]
-        fn test_return_infs() {
-            let arr_len: usize = 1027;
-            let mut data: Vec<f64> = get_array_f64(arr_len);
-
-            // Case 1: all elements are +inf
-            for i in 0..data.len() {
-                data[i] = f64::INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 2: all elements are -inf
-            for i in 0..data.len() {
-                data[i] = f64::NEG_INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 3: add some +inf and -inf in the middle
-            let mut data: Vec<f64> = get_array_f64(arr_len);
-            data[100] = f64::INFINITY;
-            data[200] = f64::NEG_INFINITY;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 200);
-            assert_eq!(argmax_index, 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 200);
-            assert_eq!(argmax_simd_index, 100);
-        }
-
-        #[test]
-        fn test_ignore_nans() {
-            let arr_len: usize = 1027;
-
-            // Case 1: NaN is the first element
-            let mut data: Vec<f64> = get_array_f64(arr_len);
-            data[0] = f64::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert!(argmin_index != 0);
-            assert!(argmax_index != 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert!(argmin_simd_index != 0);
-            assert!(argmax_simd_index != 0);
-
-            // Case 2: first 100 elements are NaN
-            for i in 0..100 {
-                data[i] = f64::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert!(argmin_index > 99);
-            assert!(argmax_index > 99);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert!(argmin_simd_index > 99);
-            assert!(argmax_simd_index > 99);
-
-            // Case 3: NaN is the last element
-            let mut data: Vec<f64> = get_array_f64(arr_len);
-            data[arr_len - 1] = f64::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert!(argmin_index != 1026);
-            assert!(argmax_index != 1026);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert!(argmin_simd_index != 1026);
-            assert!(argmax_simd_index != 1026);
-
-            // Case 4: last 100 elements are NaN
-            for i in 0..100 {
-                data[arr_len - 1 - i] = f64::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert!(argmin_index < arr_len - 100);
-            assert!(argmax_index < arr_len - 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert!(argmin_simd_index < arr_len - 100);
-            assert!(argmax_simd_index < arr_len - 100);
-
-            // Case 5: NaN is somewhere in the middle element
-            let mut data: Vec<f64> = get_array_f64(arr_len);
-            data[123] = f64::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert!(argmin_index != 123);
-            assert!(argmax_index != 123);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert!(argmin_simd_index != 123);
-            assert!(argmax_simd_index != 123);
-
-            // Case 6: all elements are NaN
-            for i in 0..data.len() {
-                data[i] = f64::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            for _ in 0..10_000 {
-                let data: &[f64] = &get_array_f64(32 * 2 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// --------------------------------------- AVX512 ----------------------------------------
+// -------------------------------------- AVX512 ---------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod avx512_ignore_nan {
@@ -604,215 +212,9 @@ mod avx512_ignore_nan {
             Self::_argminmax(data)
         }
     }
-
-    // ------------------------------------ TESTS --------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::AVX512IgnoreNaN as AVX512;
-        use super::SIMDArgMinMaxIgnoreNaN;
-        use crate::scalar::generic::scalar_argminmax_ignore_nans as scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_f64(n: usize) -> Vec<f64> {
-            utils::get_random_array(n, f64::MIN, f64::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            let data: &[f64] = &get_array_f64(1025);
-            assert_eq!(data.len() % 2, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            let data = [
-                10.,
-                f64::MAX,
-                6.,
-                f64::NEG_INFINITY,
-                f64::NEG_INFINITY,
-                f64::MAX,
-                10_000.0,
-            ];
-            let data: Vec<f64> = data.iter().map(|x| *x).collect();
-            let data: &[f64] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 3);
-            assert_eq!(argmax_index, 1);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-            assert_eq!(argmin_simd_index, 3);
-            assert_eq!(argmax_simd_index, 1);
-        }
-
-        #[test]
-        fn test_return_infs() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            let arr_len: usize = 1027;
-            let mut data: Vec<f64> = get_array_f64(arr_len);
-
-            // Case 1: all elements are +inf
-            for i in 0..data.len() {
-                data[i] = f64::INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 2: all elements are -inf
-            for i in 0..data.len() {
-                data[i] = f64::NEG_INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 3: add some +inf and -inf in the middle
-            let mut data: Vec<f64> = get_array_f64(arr_len);
-            data[100] = f64::INFINITY;
-            data[200] = f64::NEG_INFINITY;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 200);
-            assert_eq!(argmax_index, 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 200);
-            assert_eq!(argmax_simd_index, 100);
-        }
-
-        #[test]
-        fn test_ignore_nans() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            let arr_len: usize = 1027;
-
-            // Case 1: NaN is the first element
-            let mut data: Vec<f64> = get_array_f64(arr_len);
-            data[0] = f64::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert!(argmin_index != 0);
-            assert!(argmax_index != 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert!(argmin_simd_index != 0);
-            assert!(argmax_simd_index != 0);
-
-            // Case 2: first 100 elements are NaN
-            for i in 0..100 {
-                data[i] = f64::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert!(argmin_index > 99);
-            assert!(argmax_index > 99);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert!(argmin_simd_index > 99);
-            assert!(argmax_simd_index > 99);
-
-            // Case 3: NaN is the last element
-            let mut data: Vec<f64> = get_array_f64(arr_len);
-            data[arr_len - 1] = f64::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert!(argmin_index != 1026);
-            assert!(argmax_index != 1026);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert!(argmin_simd_index != 1026);
-            assert!(argmax_simd_index != 1026);
-
-            // Case 4: last 100 elements are NaN
-            for i in 0..100 {
-                data[arr_len - 1 - i] = f64::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert!(argmin_index < arr_len - 100);
-            assert!(argmax_index < arr_len - 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert!(argmin_simd_index < arr_len - 100);
-            assert!(argmax_simd_index < arr_len - 100);
-
-            // Case 5: NaN is somewhere in the middle element
-            let mut data: Vec<f64> = get_array_f64(arr_len);
-            data[123] = f64::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert!(argmin_index != 123);
-            assert!(argmax_index != 123);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert!(argmin_simd_index != 123);
-            assert!(argmax_simd_index != 123);
-
-            // Case 6: all elements are NaN
-            for i in 0..data.len() {
-                data[i] = f64::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            for _ in 0..10_000 {
-                let data: &[f64] = &get_array_f64(32 * 2 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// ---------------------------------------- NEON -----------------------------------------
+// --------------------------------------- NEON ----------------------------------------
 
 // There are no NEON intrinsics for f64, so we need to use the scalar version.
 //   although NEON intrinsics exist for i64 and u64, we cannot use them as
@@ -831,4 +233,126 @@ mod neon_ignore_nan {
     // > 64 bit data types.
     unimpl_SIMDOps!(f64, usize, NEONIgnoreNaN);
     unimpl_SIMDArgMinMaxIgnoreNaN!(f64, usize, NEONIgnoreNaN);
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use rstest_reuse::{self, *};
+
+    use crate::scalar::generic::scalar_argminmax_ignore_nans as scalar_argminmax;
+    use crate::simd::config::{AVX2IgnoreNaN, AVX512IgnoreNaN, SSEIgnoreNaN};
+    use crate::SIMDArgMinMaxIgnoreNaN; // todo use type-state pattern
+
+    use super::super::test_utils::{test_long_array_argminmax, test_random_runs_argminmax};
+    // Float specific tests
+    use super::super::test_utils::{test_ignore_nans_argminmax, test_return_infs_argminmax};
+
+    use dev_utils::utils;
+
+    fn get_array_f64(n: usize) -> Vec<f64> {
+        utils::get_random_array(n, f64::MIN, f64::MAX)
+    }
+
+    // ------------ Template for x86 / x86_64 -------------
+
+    #[template]
+    #[rstest]
+    #[case::sse(SSEIgnoreNaN, is_x86_feature_detected!("sse4.1"))]
+    #[case::avx2(AVX2IgnoreNaN, is_x86_feature_detected!("avx"))]
+    #[case::avx512(AVX512IgnoreNaN, is_x86_feature_detected!("avx512f"))]
+    fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T,
+        #[case] simd_available: bool,
+    ) {
+    }
+
+    // ----------------- The actual tests -----------------
+
+    #[apply(simd_implementations)]
+    fn test_first_index_is_returned_when_identical_values_found<
+        T,
+        SIMDV,
+        SIMDM,
+        const LANE_SIZE: usize,
+    >(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMaxIgnoreNaN<f64, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
+        }
+
+        // TODO: make sure that this is a proper multiple of the LANE_SIZE
+        // I think we - ideally - centralize this just as the other tests
+        let data = [
+            10.,
+            f64::MAX,
+            6.,
+            f64::NEG_INFINITY,
+            f64::NEG_INFINITY,
+            f64::MAX,
+            10_000.0,
+        ];
+        let data: &[f64] = &data;
+
+        let (argmin_index, argmax_index) = scalar_argminmax(data);
+        assert_eq!(argmin_index, 3);
+        assert_eq!(argmax_index, 1);
+
+        let (argmin_simd_index, argmax_simd_index) = unsafe { T::argminmax(data) };
+        assert_eq!(argmin_simd_index, 3);
+        assert_eq!(argmax_simd_index, 1);
+    }
+
+    #[apply(simd_implementations)]
+    fn test_return_same_result<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMaxIgnoreNaN<f64, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
+        }
+        test_long_array_argminmax(get_array_f64, scalar_argminmax, T::argminmax);
+        test_random_runs_argminmax(get_array_f64, scalar_argminmax, T::argminmax);
+    }
+
+    #[apply(simd_implementations)]
+    fn test_return_infs<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMaxIgnoreNaN<f64, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
+        }
+        test_return_infs_argminmax(get_array_f64, scalar_argminmax, T::argminmax);
+    }
+
+    #[apply(simd_implementations)]
+    fn test_ignore_nans<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMaxIgnoreNaN<f64, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
+        }
+        test_ignore_nans_argminmax(get_array_f64, scalar_argminmax, T::argminmax);
+    }
 }

--- a/src/simd/simd_f64_return_nan.rs
+++ b/src/simd/simd_f64_return_nan.rs
@@ -55,7 +55,7 @@ fn _i64ord_to_f64(ord_i64: i64) -> f64 {
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 const MAX_INDEX: usize = i64::MAX as usize;
 
-// ------------------------------------------ AVX2 ------------------------------------------
+// --------------------------------------- AVX2 ----------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod avx2 {
@@ -145,239 +145,9 @@ mod avx2 {
             Self::_argminmax(data)
         }
     }
-
-    // ------------------------------------ TESTS --------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::{SIMDArgMinMax, AVX2};
-        use crate::scalar::generic::scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_f64(n: usize) -> Vec<f64> {
-            utils::get_random_array(n, f64::MIN, f64::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            let data: &[f64] = &get_array_f64(1025);
-            assert_eq!(data.len() % 4, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            let data = [
-                10.,
-                f64::MAX,
-                6.,
-                f64::NEG_INFINITY,
-                f64::NEG_INFINITY,
-                f64::MAX,
-                10_000.0,
-            ];
-            let data: Vec<f64> = data.iter().map(|x| *x).collect();
-            let data: &[f64] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 3);
-            assert_eq!(argmax_index, 1);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-            assert_eq!(argmin_simd_index, 3);
-            assert_eq!(argmax_simd_index, 1);
-        }
-
-        #[test]
-        fn test_return_infs() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            let arr_len: usize = 1027;
-            let mut data: Vec<f64> = get_array_f64(arr_len);
-
-            // Case 1: all elements are +inf
-            for i in 0..data.len() {
-                data[i] = f64::INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 2: all elements are -inf
-            for i in 0..data.len() {
-                data[i] = f64::NEG_INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 3: add some +inf and -inf in the middle
-            let mut data: Vec<f64> = get_array_f64(arr_len);
-            data[100] = f64::INFINITY;
-            data[200] = f64::NEG_INFINITY;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 200);
-            assert_eq!(argmax_index, 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 200);
-            assert_eq!(argmax_simd_index, 100);
-        }
-
-        #[test]
-        fn test_return_nans() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            let arr_len: usize = 1027;
-
-            // Case 1: NaN is the first element
-            let mut data: Vec<f64> = get_array_f64(arr_len);
-            data[0] = f64::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 2: first 100 elements are NaN
-            for i in 0..100 {
-                data[i] = f64::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 3: NaN is the last element
-            let mut data: Vec<f64> = get_array_f64(arr_len);
-            data[arr_len - 1] = f64::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 1026);
-            assert_eq!(argmax_index, 1026);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 1026);
-            assert_eq!(argmax_simd_index, 1026);
-
-            // Case 4: last 100 elements are NaN
-            for i in 0..100 {
-                data[arr_len - 1 - i] = f64::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, arr_len - 100);
-            assert_eq!(argmax_index, arr_len - 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, arr_len - 100);
-            assert_eq!(argmax_simd_index, arr_len - 100);
-
-            // Case 5: NaN is somewhere in the middle element
-            let mut data: Vec<f64> = get_array_f64(arr_len);
-            data[123] = f64::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 123);
-            assert_eq!(argmax_index, 123);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 123);
-            assert_eq!(argmax_simd_index, 123);
-
-            // Case 6: NaN in the middle of the array and last 100 elements are NaN
-            for i in 0..100 {
-                data[arr_len - 1 - i] = f64::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 123);
-            assert_eq!(argmax_index, 123);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 123);
-            assert_eq!(argmax_simd_index, 123);
-
-            // Case 7: all elements are NaN
-            for i in 0..data.len() {
-                data[i] = f64::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 8: array exact multiple of LANE_SIZE and only 1 element is NaN
-            let mut data: Vec<f64> = get_array_f64(128);
-            data[17] = f64::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 17);
-            assert_eq!(argmax_index, 17);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 17);
-            assert_eq!(argmax_simd_index, 17);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            for _ in 0..10_000 {
-                let data: &[f64] = &get_array_f64(32 * 8 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// ----------------------------------------- SSE -----------------------------------------
+// ---------------------------------------- SSE ----------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod sse {
@@ -467,219 +237,9 @@ mod sse {
             Self::_argminmax(data)
         }
     }
-
-    // ------------------------------------ TESTS --------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::{SIMDArgMinMax, SSE};
-        use crate::scalar::generic::scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_f64(n: usize) -> Vec<f64> {
-            utils::get_random_array(n, f64::MIN, f64::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            let data: &[f64] = &get_array_f64(1025);
-            assert_eq!(data.len() % 2, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            let data = [
-                10.,
-                f64::MAX,
-                6.,
-                f64::NEG_INFINITY,
-                f64::NEG_INFINITY,
-                f64::MAX,
-                10_000.0,
-            ];
-            let data: Vec<f64> = data.iter().map(|x| *x).collect();
-            let data: &[f64] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 3);
-            assert_eq!(argmax_index, 1);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-            assert_eq!(argmin_simd_index, 3);
-            assert_eq!(argmax_simd_index, 1);
-        }
-
-        #[test]
-        fn test_return_infs() {
-            let arr_len: usize = 1027;
-            let mut data: Vec<f64> = get_array_f64(arr_len);
-
-            // Case 1: all elements are +inf
-            for i in 0..data.len() {
-                data[i] = f64::INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 2: all elements are -inf
-            for i in 0..data.len() {
-                data[i] = f64::NEG_INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 3: add some +inf and -inf in the middle
-            let mut data: Vec<f64> = get_array_f64(arr_len);
-            data[100] = f64::INFINITY;
-            data[200] = f64::NEG_INFINITY;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 200);
-            assert_eq!(argmax_index, 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 200);
-            assert_eq!(argmax_simd_index, 100);
-        }
-
-        #[test]
-        fn test_return_nans() {
-            let arr_len: usize = 1027;
-
-            // Case 1: NaN is the first element
-            let mut data: Vec<f64> = get_array_f64(arr_len);
-            data[0] = f64::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 2: first 100 elements are NaN
-            for i in 0..100 {
-                data[i] = f64::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 3: NaN is the last element
-            let mut data: Vec<f64> = get_array_f64(arr_len);
-            data[arr_len - 1] = f64::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 1026);
-            assert_eq!(argmax_index, 1026);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 1026);
-            assert_eq!(argmax_simd_index, 1026);
-
-            // Case 4: last 100 elements are NaN
-            for i in 0..100 {
-                data[arr_len - 1 - i] = f64::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, arr_len - 100);
-            assert_eq!(argmax_index, arr_len - 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, arr_len - 100);
-            assert_eq!(argmax_simd_index, arr_len - 100);
-
-            // Case 5: NaN is somewhere in the middle element
-            let mut data: Vec<f64> = get_array_f64(arr_len);
-            data[123] = f64::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 123);
-            assert_eq!(argmax_index, 123);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 123);
-            assert_eq!(argmax_simd_index, 123);
-
-            // Case 6: NaN in the middle of the array and last 100 elements are NaN
-            for i in 0..100 {
-                data[arr_len - 1 - i] = f64::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 123);
-            assert_eq!(argmax_index, 123);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 123);
-            assert_eq!(argmax_simd_index, 123);
-
-            // Case 7: all elements are NaN
-            for i in 0..data.len() {
-                data[i] = f64::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 8: array exact multiple of LANE_SIZE and only 1 element is NaN
-            let mut data: Vec<f64> = get_array_f64(128);
-            data[17] = f64::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 17);
-            assert_eq!(argmax_index, 17);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 17);
-            assert_eq!(argmax_simd_index, 17);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            for _ in 0..10_000 {
-                let data: &[f64] = &get_array_f64(32 * 2 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// --------------------------------------- AVX512 ----------------------------------------
+// -------------------------------------- AVX512 ---------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod avx512 {
@@ -765,239 +325,9 @@ mod avx512 {
             Self::_argminmax(data)
         }
     }
-
-    // ------------------------------------ TESTS --------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::{SIMDArgMinMax, AVX512};
-        use crate::scalar::generic::scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_f64(n: usize) -> Vec<f64> {
-            utils::get_random_array(n, f64::MIN, f64::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            let data: &[f64] = &get_array_f64(1025);
-            assert_eq!(data.len() % 2, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            let data = [
-                10.,
-                f64::MAX,
-                6.,
-                f64::NEG_INFINITY,
-                f64::NEG_INFINITY,
-                f64::MAX,
-                10_000.0,
-            ];
-            let data: Vec<f64> = data.iter().map(|x| *x).collect();
-            let data: &[f64] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 3);
-            assert_eq!(argmax_index, 1);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-            assert_eq!(argmin_simd_index, 3);
-            assert_eq!(argmax_simd_index, 1);
-        }
-
-        #[test]
-        fn test_return_infs() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            let arr_len: usize = 1027;
-            let mut data: Vec<f64> = get_array_f64(arr_len);
-
-            // Case 1: all elements are +inf
-            for i in 0..data.len() {
-                data[i] = f64::INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 2: all elements are -inf
-            for i in 0..data.len() {
-                data[i] = f64::NEG_INFINITY;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 3: add some +inf and -inf in the middle
-            let mut data: Vec<f64> = get_array_f64(arr_len);
-            data[100] = f64::INFINITY;
-            data[200] = f64::NEG_INFINITY;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 200);
-            assert_eq!(argmax_index, 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 200);
-            assert_eq!(argmax_simd_index, 100);
-        }
-
-        #[test]
-        fn test_return_nans() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            let arr_len: usize = 1027;
-
-            // Case 1: NaN is the first element
-            let mut data: Vec<f64> = get_array_f64(arr_len);
-            data[0] = f64::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 2: first 100 elements are NaN
-            for i in 0..100 {
-                data[i] = f64::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 3: NaN is the last element
-            let mut data: Vec<f64> = get_array_f64(arr_len);
-            data[arr_len - 1] = f64::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 1026);
-            assert_eq!(argmax_index, 1026);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 1026);
-            assert_eq!(argmax_simd_index, 1026);
-
-            // Case 4: last 100 elements are NaN
-            for i in 0..100 {
-                data[arr_len - 1 - i] = f64::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, arr_len - 100);
-            assert_eq!(argmax_index, arr_len - 100);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, arr_len - 100);
-            assert_eq!(argmax_simd_index, arr_len - 100);
-
-            // Case 5: NaN is somewhere in the middle element
-            let mut data: Vec<f64> = get_array_f64(arr_len);
-            data[123] = f64::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 123);
-            assert_eq!(argmax_index, 123);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 123);
-            assert_eq!(argmax_simd_index, 123);
-
-            // Case 6: NaN in the middle of the array and last 100 elements are NaN
-            for i in 0..100 {
-                data[arr_len - 1 - i] = f64::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 123);
-            assert_eq!(argmax_index, 123);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 123);
-            assert_eq!(argmax_simd_index, 123);
-
-            // Case 7: all elements are NaN
-            for i in 0..data.len() {
-                data[i] = f64::NAN;
-            }
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 0);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 0);
-
-            // Case 8: array exact multiple of LANE_SIZE and only 1 element is NaN
-            let mut data: Vec<f64> = get_array_f64(128);
-            data[17] = f64::NAN;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(&data);
-            assert_eq!(argmin_index, 17);
-            assert_eq!(argmax_index, 17);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(&data) };
-            assert_eq!(argmin_simd_index, 17);
-            assert_eq!(argmax_simd_index, 17);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            for _ in 0..10_000 {
-                let data: &[f64] = &get_array_f64(32 * 2 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// ---------------------------------------- NEON -----------------------------------------
+// --------------------------------------- NEON ----------------------------------------
 
 // There are no NEON intrinsics for f64, so we need to use the scalar version.
 //   although NEON intrinsics exist for i64 and u64, we cannot use them as
@@ -1016,4 +346,126 @@ mod neon {
     // > 64 bit data types.
     unimpl_SIMDOps!(f64, usize, NEON);
     unimpl_SIMDArgMinMax!(f64, usize, NEON);
+}
+
+// ======================================= TESTS =======================================
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use rstest_reuse::{self, *};
+
+    use crate::scalar::generic::scalar_argminmax;
+    use crate::simd::config::{AVX2, AVX512, SSE};
+    use crate::SIMDArgMinMax;
+
+    use super::super::test_utils::{test_long_array_argminmax, test_random_runs_argminmax};
+    // Float specific tests
+    use super::super::test_utils::{test_return_infs_argminmax, test_return_nans_argminmax};
+
+    use dev_utils::utils;
+
+    fn get_array_f64(n: usize) -> Vec<f64> {
+        utils::get_random_array(n, f64::MIN, f64::MAX)
+    }
+
+    // ------------ Template for x86 / x86_64 -------------
+
+    #[template]
+    #[rstest]
+    #[case::sse(SSE, is_x86_feature_detected!("sse4.2"))]
+    #[case::avx2(AVX2, is_x86_feature_detected!("avx2"))]
+    #[case::avx512(AVX512, is_x86_feature_detected!("avx512f"))]
+    fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T,
+        #[case] simd_available: bool,
+    ) {
+    }
+
+    // ----------------- The actual tests -----------------
+
+    #[apply(simd_implementations)]
+    fn test_first_index_is_returned_when_identical_values_found<
+        T,
+        SIMDV,
+        SIMDM,
+        const LANE_SIZE: usize,
+    >(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMax<f64, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
+        }
+
+        let data = [
+            10.,
+            f64::MAX,
+            6.,
+            f64::NEG_INFINITY,
+            f64::NEG_INFINITY,
+            f64::MAX,
+            10_000.0,
+        ];
+        let data: &[f64] = &data;
+
+        let (argmin_index, argmax_index) = scalar_argminmax(data);
+        assert_eq!(argmin_index, 3);
+        assert_eq!(argmax_index, 1);
+
+        let (argmin_simd_index, argmax_simd_index) = unsafe { T::argminmax(data) };
+        assert_eq!(argmin_simd_index, 3);
+        assert_eq!(argmax_simd_index, 1);
+    }
+
+    #[apply(simd_implementations)]
+    fn test_return_same_result<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMax<f64, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
+        }
+        test_long_array_argminmax(get_array_f64, scalar_argminmax, T::argminmax);
+        test_random_runs_argminmax(get_array_f64, scalar_argminmax, T::argminmax);
+    }
+
+    #[apply(simd_implementations)]
+    fn test_return_infs<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMax<f64, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
+        }
+        test_return_infs_argminmax(get_array_f64, scalar_argminmax, T::argminmax);
+    }
+
+    #[apply(simd_implementations)]
+    fn test_return_nans<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMax<f64, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
+        }
+        test_return_nans_argminmax(get_array_f64, scalar_argminmax, T::argminmax);
+    }
 }

--- a/src/simd/simd_f64_return_nan.rs
+++ b/src/simd/simd_f64_return_nan.rs
@@ -360,7 +360,10 @@ mod tests {
     use crate::simd::config::{AVX2, AVX512, SSE};
     use crate::SIMDArgMinMax;
 
-    use super::super::test_utils::{test_long_array_argminmax, test_random_runs_argminmax};
+    use super::super::test_utils::{
+        test_first_index_identical_values_argminmax, test_long_array_argminmax,
+        test_random_runs_argminmax,
+    };
     // Float specific tests
     use super::super::test_utils::{test_return_infs_argminmax, test_return_nans_argminmax};
 
@@ -402,25 +405,7 @@ mod tests {
         if !simd_available {
             return;
         }
-
-        let data = [
-            10.,
-            f64::MAX,
-            6.,
-            f64::NEG_INFINITY,
-            f64::NEG_INFINITY,
-            f64::MAX,
-            10_000.0,
-        ];
-        let data: &[f64] = &data;
-
-        let (argmin_index, argmax_index) = scalar_argminmax(data);
-        assert_eq!(argmin_index, 3);
-        assert_eq!(argmax_index, 1);
-
-        let (argmin_simd_index, argmax_simd_index) = unsafe { T::argminmax(data) };
-        assert_eq!(argmin_simd_index, 3);
-        assert_eq!(argmax_simd_index, 1);
+        test_first_index_identical_values_argminmax(scalar_argminmax, T::argminmax);
     }
 
     #[apply(simd_implementations)]

--- a/src/simd/simd_i16.rs
+++ b/src/simd/simd_i16.rs
@@ -11,7 +11,7 @@ use std::arch::x86_64::*;
 
 const MAX_INDEX: usize = i16::MAX as usize;
 
-// ------------------------------------------ AVX2 ------------------------------------------
+// --------------------------------------- AVX2 ----------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod avx2 {
@@ -128,88 +128,9 @@ mod avx2 {
             Self::_argminmax(data)
         }
     }
-
-    // ------------------------------------ TESTS --------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::{SIMDArgMinMax, AVX2};
-        use crate::scalar::generic::scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_i16(n: usize) -> Vec<i16> {
-            utils::get_random_array(n, i16::MIN, i16::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            let data: &[i16] = &get_array_i16(513);
-            assert_eq!(data.len() % 16, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            let data = [10, i16::MIN, 6, 9, 9, 22, i16::MAX, 4, i16::MAX];
-            let data: Vec<i16> = data.iter().map(|x| *x).collect();
-            let data: &[i16] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 1);
-            assert_eq!(argmax_index, 6);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-            assert_eq!(argmin_simd_index, 1);
-            assert_eq!(argmax_simd_index, 6);
-        }
-
-        #[test]
-        fn test_no_overflow() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            let n: usize = 1 << 18;
-            let data: &[i16] = &get_array_i16(n);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            for _ in 0..10_000 {
-                let data: &[i16] = &get_array_i16(32 * 2 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// ----------------------------------------- SSE -----------------------------------------
+// ---------------------------------------- SSE ----------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod sse {
@@ -318,72 +239,9 @@ mod sse {
             Self::_argminmax(data)
         }
     }
-
-    // ------------------------------------ TESTS --------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::{SIMDArgMinMax, SSE};
-        use crate::scalar::generic::scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_i16(n: usize) -> Vec<i16> {
-            utils::get_random_array(n, i16::MIN, i16::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            let data: &[i16] = &get_array_i16(513);
-            assert_eq!(data.len() % 8, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            let data = [10, i16::MIN, 6, 9, 9, 22, i16::MAX, 4, i16::MAX];
-            let data: Vec<i16> = data.iter().map(|x| *x).collect();
-            let data: &[i16] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 1);
-            assert_eq!(argmax_index, 6);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-            assert_eq!(argmin_simd_index, 1);
-            assert_eq!(argmax_simd_index, 6);
-        }
-
-        #[test]
-        fn test_no_overflow() {
-            let n: usize = 1 << 18;
-            let data: &[i16] = &get_array_i16(n);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            for _ in 0..10_000 {
-                let data: &[i16] = &get_array_i16(8 * 2 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// --------------------------------------- AVX512 ----------------------------------------
+// -------------------------------------- AVX512 ---------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod avx512 {
@@ -505,88 +363,9 @@ mod avx512 {
             Self::_argminmax(data)
         }
     }
-
-    // ------------------------------------ TESTS --------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::{SIMDArgMinMax, AVX512};
-        use crate::scalar::generic::scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_i16(n: usize) -> Vec<i16> {
-            utils::get_random_array(n, i16::MIN, i16::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            if !is_x86_feature_detected!("avx512bw") {
-                return;
-            }
-
-            let data: &[i16] = &get_array_i16(513);
-            assert_eq!(data.len() % 8, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            if !is_x86_feature_detected!("avx512bw") {
-                return;
-            }
-
-            let data = [10, i16::MIN, 6, 9, 9, 22, i16::MAX, 4, i16::MAX];
-            let data: Vec<i16> = data.iter().map(|x| *x).collect();
-            let data: &[i16] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 1);
-            assert_eq!(argmax_index, 6);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-            assert_eq!(argmin_simd_index, 1);
-            assert_eq!(argmax_simd_index, 6);
-        }
-
-        #[test]
-        fn test_no_overflow() {
-            if !is_x86_feature_detected!("avx512bw") {
-                return;
-            }
-
-            let n: usize = 1 << 18;
-            let data: &[i16] = &get_array_i16(n);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            if !is_x86_feature_detected!("avx512bw") {
-                return;
-            }
-
-            for _ in 0..10_000 {
-                let data: &[i16] = &get_array_i16(1025);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// ---------------------------------------- NEON -----------------------------------------
+// --------------------------------------- NEON ----------------------------------------
 
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 mod neon {
@@ -695,67 +474,124 @@ mod neon {
             Self::_argminmax(data)
         }
     }
+}
 
-    // ------------------------------------ TESTS --------------------------------------
+// ======================================= TESTS =======================================
 
-    #[cfg(test)]
-    mod tests {
-        use super::{SIMDArgMinMax, NEON};
-        use crate::scalar::generic::scalar_argminmax;
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "arm",
+    target_arch = "aarch64",
+))]
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use rstest_reuse::{self, *};
 
-        extern crate dev_utils;
-        use dev_utils::utils;
+    use crate::scalar::generic::scalar_argminmax;
+    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    use crate::simd::config::NEON;
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    use crate::simd::config::{AVX2, AVX512, SSE};
+    use crate::SIMDArgMinMax;
 
-        fn get_array_i16(n: usize) -> Vec<i16> {
-            utils::get_random_array(n, i16::MIN, i16::MAX)
+    use super::super::test_utils::{
+        test_long_array_argminmax, test_no_overflow_argminmax, test_random_runs_argminmax,
+    };
+
+    use dev_utils::utils;
+
+    fn get_array_i16(n: usize) -> Vec<i16> {
+        utils::get_random_array(n, i16::MIN, i16::MAX)
+    }
+
+    // ------------ Template for x86 / x86_64 -------------
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[template]
+    #[rstest]
+    #[case::sse(SSE, is_x86_feature_detected!("sse4.1"))]
+    #[case::avx2(AVX2, is_x86_feature_detected!("avx2"))]
+    #[case::avx512(AVX512, is_x86_feature_detected!("avx512bw"))]
+    fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T,
+        #[case] simd_available: bool,
+    ) {
+    }
+
+    // ------------ Template for ARM / AArch64 ------------
+
+    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[template]
+    #[rstest]
+    #[case::neon(NEON, true)]
+    fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T,
+        #[case] simd_available: bool,
+    ) {
+    }
+
+    // ----------------- The actual tests -----------------
+
+    #[apply(simd_implementations)]
+    fn test_first_index_is_returned_when_identical_values_found<
+        T,
+        SIMDV,
+        SIMDM,
+        const LANE_SIZE: usize,
+    >(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMax<i16, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
         }
 
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            let data: &[i16] = &get_array_i16(513);
-            assert_eq!(data.len() % 8, 1);
+        let data = [i16::MIN, i16::MIN, 4, 6, 9, i16::MAX, 22, i16::MAX];
+        let data: &[i16] = &data;
 
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
+        let (argmin_index, argmax_index) = scalar_argminmax(data);
+        assert_eq!(argmin_index, 0);
+        assert_eq!(argmax_index, 5);
+
+        let (argmin_simd_index, argmax_simd_index) = unsafe { T::argminmax(data) };
+        assert_eq!(argmin_simd_index, 0);
+        assert_eq!(argmax_simd_index, 5);
+    }
+
+    #[apply(simd_implementations)]
+    fn test_return_same_result<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMax<i16, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
         }
+        test_long_array_argminmax(get_array_i16, scalar_argminmax, T::argminmax);
+        test_random_runs_argminmax(get_array_i16, scalar_argminmax, T::argminmax);
+    }
 
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            let data = [10, i16::MIN, 6, 9, 9, 22, i16::MAX, 4, i16::MAX];
-            let data: Vec<i16> = data.iter().map(|x| *x).collect();
-            let data: &[i16] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 1);
-            assert_eq!(argmax_index, 6);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data) };
-            assert_eq!(argmin_simd_index, 1);
-            assert_eq!(argmax_simd_index, 6);
+    #[apply(simd_implementations)]
+    fn test_no_overflow<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMax<i16, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
         }
-
-        #[test]
-        fn test_no_overflow() {
-            let n: usize = 1 << 18;
-            let data: &[i16] = &get_array_i16(n);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            for _ in 0..10_000 {
-                let data: &[i16] = &get_array_i16(16 * 8 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
+        test_no_overflow_argminmax(get_array_i16, scalar_argminmax, T::argminmax, None);
     }
 }

--- a/src/simd/simd_i16.rs
+++ b/src/simd/simd_i16.rs
@@ -497,7 +497,8 @@ mod tests {
     use crate::SIMDArgMinMax;
 
     use super::super::test_utils::{
-        test_long_array_argminmax, test_no_overflow_argminmax, test_random_runs_argminmax,
+        test_first_index_identical_values_argminmax, test_long_array_argminmax,
+        test_no_overflow_argminmax, test_random_runs_argminmax,
     };
 
     use dev_utils::utils;
@@ -551,17 +552,7 @@ mod tests {
         if !simd_available {
             return;
         }
-
-        let data = [i16::MIN, i16::MIN, 4, 6, 9, i16::MAX, 22, i16::MAX];
-        let data: &[i16] = &data;
-
-        let (argmin_index, argmax_index) = scalar_argminmax(data);
-        assert_eq!(argmin_index, 0);
-        assert_eq!(argmax_index, 5);
-
-        let (argmin_simd_index, argmax_simd_index) = unsafe { T::argminmax(data) };
-        assert_eq!(argmin_simd_index, 0);
-        assert_eq!(argmax_simd_index, 5);
+        test_first_index_identical_values_argminmax(scalar_argminmax, T::argminmax);
     }
 
     #[apply(simd_implementations)]

--- a/src/simd/simd_i32.rs
+++ b/src/simd/simd_i32.rs
@@ -253,7 +253,10 @@ mod tests {
     use crate::simd::config::{AVX2, AVX512, SSE};
     use crate::SIMDArgMinMax;
 
-    use super::super::test_utils::{test_long_array_argminmax, test_random_runs_argminmax};
+    use super::super::test_utils::{
+        test_first_index_identical_values_argminmax, test_long_array_argminmax,
+        test_random_runs_argminmax,
+    };
 
     use dev_utils::utils;
 
@@ -306,17 +309,7 @@ mod tests {
         if !simd_available {
             return;
         }
-
-        let data = [i32::MIN, i32::MIN, 4, 6, 9, i32::MAX, 22, i32::MAX];
-        let data: &[i32] = &data;
-
-        let (argmin_index, argmax_index) = scalar_argminmax(data);
-        assert_eq!(argmin_index, 0);
-        assert_eq!(argmax_index, 5);
-
-        let (argmin_simd_index, argmax_simd_index) = unsafe { T::argminmax(data) };
-        assert_eq!(argmin_simd_index, 0);
-        assert_eq!(argmax_simd_index, 5);
+        test_first_index_identical_values_argminmax(scalar_argminmax, T::argminmax);
     }
 
     #[apply(simd_implementations)]

--- a/src/simd/simd_i32.rs
+++ b/src/simd/simd_i32.rs
@@ -11,7 +11,7 @@ use std::arch::x86_64::*;
 
 const MAX_INDEX: usize = i32::MAX as usize;
 
-// ------------------------------------------ AVX2 ------------------------------------------
+// --------------------------------------- AVX2 ----------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod avx2 {
@@ -64,73 +64,9 @@ mod avx2 {
             Self::_argminmax(data)
         }
     }
-
-    // ------------------------------------ TESTS --------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::{SIMDArgMinMax, AVX2};
-        use crate::scalar::generic::scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_i32(n: usize) -> Vec<i32> {
-            utils::get_random_array(n, i32::MIN, i32::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            let data: &[i32] = &get_array_i32(1025);
-            assert_eq!(data.len() % 8, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            let data = [i32::MIN, i32::MIN, 4, 6, 9, i32::MAX, 22, i32::MAX];
-            let data: Vec<i32> = data.iter().map(|x| *x).collect();
-            let data: &[i32] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 5);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 5);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            for _ in 0..10_000 {
-                let data: &[i32] = &get_array_i32(32 * 8 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// ----------------------------------------- SSE -----------------------------------------
+// ---------------------------------------- SSE ----------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod sse {
@@ -182,61 +118,9 @@ mod sse {
             Self::_argminmax(data)
         }
     }
-
-    // ------------------------------------ TESTS --------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::{SIMDArgMinMax, SSE};
-        use crate::scalar::generic::scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_i32(n: usize) -> Vec<i32> {
-            utils::get_random_array(n, i32::MIN, i32::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            let data: &[i32] = &get_array_i32(1025);
-            assert_eq!(data.len() % 4, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            let data = [i32::MIN, i32::MIN, 4, 6, 9, i32::MAX, 22, i32::MAX];
-            let data: Vec<i32> = data.iter().map(|x| *x).collect();
-            let data: &[i32] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 5);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 5);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            for _ in 0..10_000 {
-                let data: &[i32] = &get_array_i32(32 * 4 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// --------------------------------------- AVX512 ----------------------------------------
+// -------------------------------------- AVX512 ---------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod avx512 {
@@ -293,73 +177,9 @@ mod avx512 {
             Self::_argminmax(data)
         }
     }
-
-    // ------------------------------------ TESTS --------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::{SIMDArgMinMax, AVX512};
-        use crate::scalar::generic::scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_i32(n: usize) -> Vec<i32> {
-            utils::get_random_array(n, i32::MIN, i32::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            let data: &[i32] = &get_array_i32(1025);
-            assert_eq!(data.len() % 8, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            let data = [i32::MIN, i32::MIN, 4, 6, 9, i32::MAX, 22, i32::MAX];
-            let data: Vec<i32> = data.iter().map(|x| *x).collect();
-            let data: &[i32] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 5);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 5);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            for _ in 0..10_000 {
-                let data: &[i32] = &get_array_i32(32 * 8 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// ---------------------------------------- NEON -----------------------------------------
+// --------------------------------------- NEON ----------------------------------------
 
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 mod neon {
@@ -411,56 +231,107 @@ mod neon {
             Self::_argminmax(data)
         }
     }
+}
 
-    // ------------------------------------ TESTS --------------------------------------
+// ======================================= TESTS =======================================
 
-    #[cfg(test)]
-    mod tests {
-        use super::{SIMDArgMinMax, NEON};
-        use crate::scalar::generic::scalar_argminmax;
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "arm",
+    target_arch = "aarch64",
+))]
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use rstest_reuse::{self, *};
 
-        extern crate dev_utils;
-        use dev_utils::utils;
+    use crate::scalar::generic::scalar_argminmax;
+    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    use crate::simd::config::NEON;
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    use crate::simd::config::{AVX2, AVX512, SSE};
+    use crate::SIMDArgMinMax;
 
-        fn get_array_i32(n: usize) -> Vec<i32> {
-            utils::get_random_array(n, i32::MIN, i32::MAX)
+    use super::super::test_utils::{test_long_array_argminmax, test_random_runs_argminmax};
+
+    use dev_utils::utils;
+
+    fn get_array_i32(n: usize) -> Vec<i32> {
+        utils::get_random_array(n, i32::MIN, i32::MAX)
+    }
+
+    // ------------ Template for x86 / x86_64 -------------
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[template]
+    #[rstest]
+    #[case::sse(SSE, is_x86_feature_detected!("sse4.1"))]
+    #[case::avx2(AVX2, is_x86_feature_detected!("avx2"))]
+    #[case::avx512(AVX512, is_x86_feature_detected!("avx512f"))]
+    fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T,
+        #[case] simd_available: bool,
+    ) {
+    }
+
+    // ------------ Template for ARM / AArch64 ------------
+
+    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[template]
+    #[rstest]
+    #[case::neon(NEON, true)]
+    fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T,
+        #[case] simd_available: bool,
+    ) {
+    }
+
+    // ----------------- The actual tests -----------------
+
+    #[apply(simd_implementations)]
+    fn test_first_index_is_returned_when_identical_values_found<
+        T,
+        SIMDV,
+        SIMDM,
+        const LANE_SIZE: usize,
+    >(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMax<i32, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
         }
 
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            let data: &[i32] = &get_array_i32(1025);
-            assert_eq!(data.len() % 4, 1);
+        let data = [i32::MIN, i32::MIN, 4, 6, 9, i32::MAX, 22, i32::MAX];
+        let data: &[i32] = &data;
 
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
+        let (argmin_index, argmax_index) = scalar_argminmax(data);
+        assert_eq!(argmin_index, 0);
+        assert_eq!(argmax_index, 5);
+
+        let (argmin_simd_index, argmax_simd_index) = unsafe { T::argminmax(data) };
+        assert_eq!(argmin_simd_index, 0);
+        assert_eq!(argmax_simd_index, 5);
+    }
+
+    #[apply(simd_implementations)]
+    fn test_return_same_result<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMax<i32, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
         }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            let data = [i32::MIN, i32::MIN, 4, 6, 9, i32::MAX, 22, i32::MAX];
-            let data: Vec<i32> = data.iter().map(|x| *x).collect();
-            let data: &[i32] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 5);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 5);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            for _ in 0..10_000 {
-                let data: &[i32] = &get_array_i32(32 * 4 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
+        test_long_array_argminmax(get_array_i32, scalar_argminmax, T::argminmax);
+        test_random_runs_argminmax(get_array_i32, scalar_argminmax, T::argminmax);
     }
 }

--- a/src/simd/simd_i64.rs
+++ b/src/simd/simd_i64.rs
@@ -205,7 +205,10 @@ mod tests {
     use crate::simd::config::{AVX2, AVX512, SSE};
     use crate::SIMDArgMinMax;
 
-    use super::super::test_utils::{test_long_array_argminmax, test_random_runs_argminmax};
+    use super::super::test_utils::{
+        test_first_index_identical_values_argminmax, test_long_array_argminmax,
+        test_random_runs_argminmax,
+    };
 
     use dev_utils::utils;
 
@@ -245,17 +248,7 @@ mod tests {
         if !simd_available {
             return;
         }
-
-        let data = [i64::MIN, i64::MIN, 4, 6, 9, i64::MAX, 22, i64::MAX];
-        let data: &[i64] = &data;
-
-        let (argmin_index, argmax_index) = scalar_argminmax(data);
-        assert_eq!(argmin_index, 0);
-        assert_eq!(argmax_index, 5);
-
-        let (argmin_simd_index, argmax_simd_index) = unsafe { T::argminmax(data) };
-        assert_eq!(argmin_simd_index, 0);
-        assert_eq!(argmax_simd_index, 5);
+        test_first_index_identical_values_argminmax(scalar_argminmax, T::argminmax);
     }
 
     #[apply(simd_implementations)]

--- a/src/simd/simd_i64.rs
+++ b/src/simd/simd_i64.rs
@@ -9,7 +9,7 @@ use std::arch::x86_64::*;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 const MAX_INDEX: usize = i64::MAX as usize;
 
-// ------------------------------------------ AVX2 ------------------------------------------
+// --------------------------------------- AVX2 ----------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod avx2 {
@@ -61,73 +61,9 @@ mod avx2 {
             Self::_argminmax(data)
         }
     }
-
-    // ------------------------------------ TESTS --------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::{SIMDArgMinMax, AVX2};
-        use crate::scalar::generic::scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_i64(n: usize) -> Vec<i64> {
-            utils::get_random_array(n, i64::MIN, i64::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            let data: &[i64] = &get_array_i64(1025);
-            assert_eq!(data.len() % 4, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            let data = [i64::MIN, i64::MIN, 4, 6, 9, i64::MAX, 22, i64::MAX];
-            let data: Vec<i64> = data.iter().map(|x| *x).collect();
-            let data: &[i64] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 5);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 5);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            for _ in 0..10_000 {
-                let data: &[i64] = &get_array_i64(32 * 8 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// ----------------------------------------- SSE -----------------------------------------
+// ---------------------------------------- SSE ----------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod sse {
@@ -179,61 +115,9 @@ mod sse {
             Self::_argminmax(data)
         }
     }
-
-    // ------------------------------------ TESTS --------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::{SIMDArgMinMax, SSE};
-        use crate::scalar::generic::scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_i64(n: usize) -> Vec<i64> {
-            utils::get_random_array(n, i64::MIN, i64::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            let data: &[i64] = &get_array_i64(1025);
-            assert_eq!(data.len() % 2, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            let data = [i64::MIN, i64::MIN, 4, 6, 9, i64::MAX, 22, i64::MAX];
-            let data: Vec<i64> = data.iter().map(|x| *x).collect();
-            let data: &[i64] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 5);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 5);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            for _ in 0..10_000 {
-                let data: &[i64] = &get_array_i64(16 * 2 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// --------------------------------------- AVX512 ----------------------------------------
+// -------------------------------------- AVX512 ---------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod avx512 {
@@ -286,73 +170,9 @@ mod avx512 {
             Self::_argminmax(data)
         }
     }
-
-    // ------------------------------------ TESTS --------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::{SIMDArgMinMax, AVX512};
-        use crate::scalar::generic::scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_i64(n: usize) -> Vec<i64> {
-            utils::get_random_array(n, i64::MIN, i64::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            let data: &[i64] = &get_array_i64(1025);
-            assert_eq!(data.len() % 4, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            let data = [i64::MIN, i64::MIN, 4, 6, 9, i64::MAX, 22, i64::MAX];
-            let data: Vec<i64> = data.iter().map(|x| *x).collect();
-            let data: &[i64] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 0);
-            assert_eq!(argmax_index, 5);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-            assert_eq!(argmin_simd_index, 0);
-            assert_eq!(argmax_simd_index, 5);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            for _ in 0..10_000 {
-                let data: &[i64] = &get_array_i64(16 * 2 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// ---------------------------------------- NEON -----------------------------------------
+// --------------------------------------- NEON ----------------------------------------
 
 // There are no NEON intrinsics for f64, so we need to use the scalar version.
 //   although NEON intrinsics exist for i64 and u64, we cannot use them as
@@ -371,4 +191,86 @@ mod neon {
     // > 64 bit data types.
     unimpl_SIMDOps!(i64, usize, NEON);
     unimpl_SIMDArgMinMax!(i64, usize, NEON);
+}
+
+// ======================================= TESTS =======================================
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use rstest_reuse::{self, *};
+
+    use crate::scalar::generic::scalar_argminmax;
+    use crate::simd::config::{AVX2, AVX512, SSE};
+    use crate::SIMDArgMinMax;
+
+    use super::super::test_utils::{test_long_array_argminmax, test_random_runs_argminmax};
+
+    use dev_utils::utils;
+
+    fn get_array_i64(n: usize) -> Vec<i64> {
+        utils::get_random_array(n, i64::MIN, i64::MAX)
+    }
+
+    // ------------ Template for x86 / x86_64 -------------
+
+    #[template]
+    #[rstest]
+    #[case::sse(SSE, is_x86_feature_detected!("sse4.2"))]
+    #[case::avx2(AVX2, is_x86_feature_detected!("avx2"))]
+    #[case::avx512(AVX512, is_x86_feature_detected!("avx512f"))]
+    fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T,
+        #[case] simd_available: bool,
+    ) {
+    }
+
+    // ----------------- The actual tests -----------------
+
+    #[apply(simd_implementations)]
+    fn test_first_index_is_returned_when_identical_values_found<
+        T,
+        SIMDV,
+        SIMDM,
+        const LANE_SIZE: usize,
+    >(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMax<i64, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
+        }
+
+        let data = [i64::MIN, i64::MIN, 4, 6, 9, i64::MAX, 22, i64::MAX];
+        let data: &[i64] = &data;
+
+        let (argmin_index, argmax_index) = scalar_argminmax(data);
+        assert_eq!(argmin_index, 0);
+        assert_eq!(argmax_index, 5);
+
+        let (argmin_simd_index, argmax_simd_index) = unsafe { T::argminmax(data) };
+        assert_eq!(argmin_simd_index, 0);
+        assert_eq!(argmax_simd_index, 5);
+    }
+
+    #[apply(simd_implementations)]
+    fn test_return_same_result<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMax<i64, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
+        }
+        test_long_array_argminmax(get_array_i64, scalar_argminmax, T::argminmax);
+        test_random_runs_argminmax(get_array_i64, scalar_argminmax, T::argminmax);
+    }
 }

--- a/src/simd/simd_i8.rs
+++ b/src/simd/simd_i8.rs
@@ -11,7 +11,7 @@ use std::arch::x86_64::*;
 
 const MAX_INDEX: usize = i8::MAX as usize;
 
-// ------------------------------------------ AVX2 ------------------------------------------
+// --------------------------------------- AVX2 ----------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod avx2 {
@@ -133,88 +133,8 @@ mod avx2 {
             Self::_argminmax(data)
         }
     }
-
-    // ------------------------------------ TESTS --------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::{SIMDArgMinMax, AVX2};
-        use crate::scalar::generic::scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_i8(n: usize) -> Vec<i8> {
-            utils::get_random_array(n, i8::MIN, i8::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            let data: &[i8] = &get_array_i8(513);
-            assert_eq!(data.len() % 16, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            let data = [10, i8::MIN, 6, 9, 9, 22, i8::MAX, 4, i8::MAX];
-            let data: Vec<i8> = data.iter().map(|x| *x).collect();
-            let data: &[i8] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 1);
-            assert_eq!(argmax_index, 6);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-            assert_eq!(argmin_simd_index, 1);
-            assert_eq!(argmax_simd_index, 6);
-        }
-
-        #[test]
-        fn test_no_overflow() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            let n: usize = 1 << 10;
-            let data: &[i8] = &get_array_i8(n);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            for _ in 0..10_000 {
-                let data: &[i8] = &get_array_i8(8 * 32 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
-
-// ----------------------------------------- SSE -----------------------------------------
+// ---------------------------------------- SSE ----------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod sse {
@@ -331,72 +251,9 @@ mod sse {
             Self::_argminmax(data)
         }
     }
-
-    // ------------------------------------ TESTS --------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::{SIMDArgMinMax, SSE};
-        use crate::scalar::generic::scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_i8(n: usize) -> Vec<i8> {
-            utils::get_random_array(n, i8::MIN, i8::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            let data: &[i8] = &get_array_i8(513);
-            assert_eq!(data.len() % 8, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            let data = [10, i8::MIN, 6, 9, 9, 22, i8::MAX, 4, i8::MAX];
-            let data: Vec<i8> = data.iter().map(|x| *x).collect();
-            let data: &[i8] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 1);
-            assert_eq!(argmax_index, 6);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-            assert_eq!(argmin_simd_index, 1);
-            assert_eq!(argmax_simd_index, 6);
-        }
-
-        #[test]
-        fn test_no_overflow() {
-            let n: usize = 1 << 10;
-            let data: &[i8] = &get_array_i8(n);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            for _ in 0..10_000 {
-                let data: &[i8] = &get_array_i8(8 * 32 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// --------------------------------------- AVX512 ----------------------------------------
+// -------------------------------------- AVX512 ---------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod avx512 {
@@ -524,88 +381,9 @@ mod avx512 {
             Self::_argminmax(data)
         }
     }
-
-    // ------------------------------------ TESTS --------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::{SIMDArgMinMax, AVX512};
-        use crate::scalar::generic::scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_i8(n: usize) -> Vec<i8> {
-            utils::get_random_array(n, i8::MIN, i8::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            if !is_x86_feature_detected!("avx512bw") {
-                return;
-            }
-
-            let data: &[i8] = &get_array_i8(513);
-            assert_eq!(data.len() % 8, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            if !is_x86_feature_detected!("avx512bw") {
-                return;
-            }
-
-            let data = [10, i8::MIN, 6, 9, 9, 22, i8::MAX, 4, i8::MAX];
-            let data: Vec<i8> = data.iter().map(|x| *x).collect();
-            let data: &[i8] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 1);
-            assert_eq!(argmax_index, 6);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-            assert_eq!(argmin_simd_index, 1);
-            assert_eq!(argmax_simd_index, 6);
-        }
-
-        #[test]
-        fn test_no_overflow() {
-            if !is_x86_feature_detected!("avx512bw") {
-                return;
-            }
-
-            let n: usize = 1 << 10;
-            let data: &[i8] = &get_array_i8(n);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            if !is_x86_feature_detected!("avx512bw") {
-                return;
-            }
-
-            for _ in 0..10_000 {
-                let data: &[i8] = &get_array_i8(1025);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// ---------------------------------------- NEON -----------------------------------------
+// --------------------------------------- NEON ----------------------------------------
 
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 mod neon {
@@ -723,67 +501,124 @@ mod neon {
             Self::_argminmax(data)
         }
     }
+}
 
-    // ------------------------------------ TESTS --------------------------------------
+// ======================================= TESTS =======================================
 
-    #[cfg(test)]
-    mod tests {
-        use super::{SIMDArgMinMax, NEON};
-        use crate::scalar::generic::scalar_argminmax;
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "arm",
+    target_arch = "aarch64",
+))]
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use rstest_reuse::{self, *};
 
-        extern crate dev_utils;
-        use dev_utils::utils;
+    use crate::scalar::generic::scalar_argminmax;
+    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    use crate::simd::config::NEON;
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    use crate::simd::config::{AVX2, AVX512, SSE};
+    use crate::SIMDArgMinMax;
 
-        fn get_array_i8(n: usize) -> Vec<i8> {
-            utils::get_random_array(n, i8::MIN, i8::MAX)
+    use super::super::test_utils::{
+        test_long_array_argminmax, test_no_overflow_argminmax, test_random_runs_argminmax,
+    };
+
+    use dev_utils::utils;
+
+    fn get_array_i8(n: usize) -> Vec<i8> {
+        utils::get_random_array(n, i8::MIN, i8::MAX)
+    }
+
+    // ------------ Template for x86 / x86_64 -------------
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[template]
+    #[rstest]
+    #[case::sse(SSE, is_x86_feature_detected!("sse4.1"))]
+    #[case::avx2(AVX2, is_x86_feature_detected!("avx2"))]
+    #[case::avx512(AVX512, is_x86_feature_detected!("avx512bw"))]
+    fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T,
+        #[case] simd_available: bool,
+    ) {
+    }
+
+    // ------------ Template for ARM / AArch64 ------------
+
+    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[template]
+    #[rstest]
+    #[case::neon(NEON, true)]
+    fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T,
+        #[case] simd_available: bool,
+    ) {
+    }
+
+    // ----------------- The actual tests -----------------
+
+    #[apply(simd_implementations)]
+    fn test_first_index_is_returned_when_identical_values_found<
+        T,
+        SIMDV,
+        SIMDM,
+        const LANE_SIZE: usize,
+    >(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMax<i8, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
         }
 
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            let data: &[i8] = &get_array_i8(513);
-            assert_eq!(data.len() % 8, 1);
+        let data = [i8::MIN, i8::MIN, 4, 6, 9, i8::MAX, 22, i8::MAX];
+        let data: &[i8] = &data;
 
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
+        let (argmin_index, argmax_index) = scalar_argminmax(data);
+        assert_eq!(argmin_index, 0);
+        assert_eq!(argmax_index, 5);
+
+        let (argmin_simd_index, argmax_simd_index) = unsafe { T::argminmax(data) };
+        assert_eq!(argmin_simd_index, 0);
+        assert_eq!(argmax_simd_index, 5);
+    }
+
+    #[apply(simd_implementations)]
+    fn test_return_same_result<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMax<i8, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
         }
+        test_long_array_argminmax(get_array_i8, scalar_argminmax, T::argminmax);
+        test_random_runs_argminmax(get_array_i8, scalar_argminmax, T::argminmax);
+    }
 
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            let data = [10, i8::MIN, 6, 9, 9, 22, i8::MAX, 4, i8::MAX];
-            let data: Vec<i8> = data.iter().map(|x| *x).collect();
-            let data: &[i8] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 1);
-            assert_eq!(argmax_index, 6);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data) };
-            assert_eq!(argmin_simd_index, 1);
-            assert_eq!(argmax_simd_index, 6);
+    #[apply(simd_implementations)]
+    fn test_no_overflow<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMax<i8, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
         }
-
-        #[test]
-        fn test_no_overflow() {
-            let n: usize = 1 << 10;
-            let data: &[i8] = &get_array_i8(n);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            for _ in 0..10_000 {
-                let data: &[i8] = &get_array_i8(16 * 8 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
+        test_no_overflow_argminmax(get_array_i8, scalar_argminmax, T::argminmax, None);
     }
 }

--- a/src/simd/simd_i8.rs
+++ b/src/simd/simd_i8.rs
@@ -524,7 +524,8 @@ mod tests {
     use crate::SIMDArgMinMax;
 
     use super::super::test_utils::{
-        test_long_array_argminmax, test_no_overflow_argminmax, test_random_runs_argminmax,
+        test_first_index_identical_values_argminmax, test_long_array_argminmax,
+        test_no_overflow_argminmax, test_random_runs_argminmax,
     };
 
     use dev_utils::utils;
@@ -578,17 +579,7 @@ mod tests {
         if !simd_available {
             return;
         }
-
-        let data = [i8::MIN, i8::MIN, 4, 6, 9, i8::MAX, 22, i8::MAX];
-        let data: &[i8] = &data;
-
-        let (argmin_index, argmax_index) = scalar_argminmax(data);
-        assert_eq!(argmin_index, 0);
-        assert_eq!(argmax_index, 5);
-
-        let (argmin_simd_index, argmax_simd_index) = unsafe { T::argminmax(data) };
-        assert_eq!(argmin_simd_index, 0);
-        assert_eq!(argmax_simd_index, 5);
+        test_first_index_identical_values_argminmax(scalar_argminmax, T::argminmax);
     }
 
     #[apply(simd_implementations)]

--- a/src/simd/simd_u16.rs
+++ b/src/simd/simd_u16.rs
@@ -555,7 +555,8 @@ mod tests {
     use crate::SIMDArgMinMax;
 
     use super::super::test_utils::{
-        test_long_array_argminmax, test_no_overflow_argminmax, test_random_runs_argminmax,
+        test_first_index_identical_values_argminmax, test_long_array_argminmax,
+        test_no_overflow_argminmax, test_random_runs_argminmax,
     };
 
     use dev_utils::utils;
@@ -609,17 +610,7 @@ mod tests {
         if !simd_available {
             return;
         }
-
-        let data = [u16::MIN, u16::MIN, 4, 6, 9, u16::MAX, 22, u16::MAX];
-        let data: &[u16] = &data;
-
-        let (argmin_index, argmax_index) = scalar_argminmax(data);
-        assert_eq!(argmin_index, 0);
-        assert_eq!(argmax_index, 5);
-
-        let (argmin_simd_index, argmax_simd_index) = unsafe { T::argminmax(data) };
-        assert_eq!(argmin_simd_index, 0);
-        assert_eq!(argmax_simd_index, 5);
+        test_first_index_identical_values_argminmax(scalar_argminmax, T::argminmax);
     }
 
     #[apply(simd_implementations)]

--- a/src/simd/simd_u16.rs
+++ b/src/simd/simd_u16.rs
@@ -21,7 +21,7 @@ fn _i16ord_to_u16(ord_i16: i16) -> u16 {
 
 const MAX_INDEX: usize = i16::MAX as usize;
 
-// ------------------------------------------ AVX2 ------------------------------------------
+// --------------------------------------- AVX2 ----------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod avx2 {
@@ -154,88 +154,9 @@ mod avx2 {
             Self::_argminmax(data)
         }
     }
-
-    // ------------------------------------ TESTS --------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::{SIMDArgMinMax, AVX2};
-        use crate::scalar::generic::scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_u16(n: usize) -> Vec<u16> {
-            utils::get_random_array(n, u16::MIN, u16::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            let data: &[u16] = &get_array_u16(513);
-            assert_eq!(data.len() % 16, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (simd_argmin_index, simd_argmax_index) = unsafe { AVX2::argminmax(data) };
-            assert_eq!(argmin_index, simd_argmin_index);
-            assert_eq!(argmax_index, simd_argmax_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            let data = [10, u16::MIN, 6, 9, 9, 22, u16::MAX, 4, u16::MAX];
-            let data: Vec<u16> = data.iter().map(|x| *x).collect();
-            let data: &[u16] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 1);
-            assert_eq!(argmax_index, 6);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-            assert_eq!(argmin_simd_index, 1);
-            assert_eq!(argmax_simd_index, 6);
-        }
-
-        #[test]
-        fn test_no_overflow() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            let n: usize = 1 << 18;
-            let data: &[u16] = &get_array_u16(n);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            for _ in 0..10_000 {
-                let data: &[u16] = &get_array_u16(32 * 2 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// ----------------------------------------- SSE -----------------------------------------
+// ---------------------------------------- SSE ----------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod sse {
@@ -360,72 +281,9 @@ mod sse {
             Self::_argminmax(data)
         }
     }
-
-    // ----------------------------------------- TESTS -----------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::{SIMDArgMinMax, SSE};
-        use crate::scalar::generic::scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_u16(n: usize) -> Vec<u16> {
-            utils::get_random_array(n, u16::MIN, u16::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            let data: &[u16] = &get_array_u16(513);
-            assert_eq!(data.len() % 16, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (simd_argmin_index, simd_argmax_index) = unsafe { SSE::argminmax(data) };
-            assert_eq!(argmin_index, simd_argmin_index);
-            assert_eq!(argmax_index, simd_argmax_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            let data = [10, u16::MIN, 6, 9, 9, 22, u16::MAX, 4, u16::MAX];
-            let data: Vec<u16> = data.iter().map(|x| *x).collect();
-            let data: &[u16] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 1);
-            assert_eq!(argmax_index, 6);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-            assert_eq!(argmin_simd_index, 1);
-            assert_eq!(argmax_simd_index, 6);
-        }
-
-        #[test]
-        fn test_no_overflow() {
-            let n: usize = 1 << 18;
-            let data: &[u16] = &get_array_u16(n);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            for _ in 0..10_000 {
-                let data: &[u16] = &get_array_u16(32 * 2 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// --------------------------------------- AVX512 ----------------------------------------
+// -------------------------------------- AVX512 ---------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod avx512 {
@@ -563,89 +421,9 @@ mod avx512 {
             Self::_argminmax(data)
         }
     }
-
-    // ----------------------------------------- TESTS -----------------------------------------
-
-    #[cfg(test)]
-
-    mod tests {
-        use super::{SIMDArgMinMax, AVX512};
-        use crate::scalar::generic::scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_u16(n: usize) -> Vec<u16> {
-            utils::get_random_array(n, u16::MIN, u16::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            if !is_x86_feature_detected!("avx512bw") {
-                return;
-            }
-
-            let data: &[u16] = &get_array_u16(513);
-            assert_eq!(data.len() % 16, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (simd_argmin_index, simd_argmax_index) = unsafe { AVX512::argminmax(data) };
-            assert_eq!(argmin_index, simd_argmin_index);
-            assert_eq!(argmax_index, simd_argmax_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            if !is_x86_feature_detected!("avx512bw") {
-                return;
-            }
-
-            let data = [10, u16::MIN, 6, 9, 9, 22, u16::MAX, 4, u16::MAX];
-            let data: Vec<u16> = data.iter().map(|x| *x).collect();
-            let data: &[u16] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 1);
-            assert_eq!(argmax_index, 6);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-            assert_eq!(argmin_simd_index, 1);
-            assert_eq!(argmax_simd_index, 6);
-        }
-
-        #[test]
-        fn test_no_overflow() {
-            if !is_x86_feature_detected!("avx512bw") {
-                return;
-            }
-
-            let n: usize = 1 << 18;
-            let data: &[u16] = &get_array_u16(n);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            if !is_x86_feature_detected!("avx512bw") {
-                return;
-            }
-
-            for _ in 0..10_000 {
-                let data: &[u16] = &get_array_u16(32 * 4 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// ---------------------------------------- NEON -----------------------------------------
+// --------------------------------------- NEON ----------------------------------------
 
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 mod neon {
@@ -754,67 +532,124 @@ mod neon {
             Self::_argminmax(data)
         }
     }
+}
 
-    // ----------------------------------------- TESTS -----------------------------------------
+// ======================================= TESTS =======================================
 
-    #[cfg(test)]
-    mod tests {
-        use super::{SIMDArgMinMax, NEON};
-        use crate::scalar::generic::scalar_argminmax;
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "arm",
+    target_arch = "aarch64",
+))]
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use rstest_reuse::{self, *};
 
-        extern crate dev_utils;
-        use dev_utils::utils;
+    use crate::scalar::generic::scalar_argminmax;
+    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    use crate::simd::config::NEON;
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    use crate::simd::config::{AVX2, AVX512, SSE};
+    use crate::SIMDArgMinMax;
 
-        fn get_array_u16(n: usize) -> Vec<u16> {
-            utils::get_random_array(n, u16::MIN, u16::MAX)
+    use super::super::test_utils::{
+        test_long_array_argminmax, test_no_overflow_argminmax, test_random_runs_argminmax,
+    };
+
+    use dev_utils::utils;
+
+    fn get_array_u16(n: usize) -> Vec<u16> {
+        utils::get_random_array(n, u16::MIN, u16::MAX)
+    }
+
+    // ------------ Template for x86 / x86_64 -------------
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[template]
+    #[rstest]
+    #[case::sse(SSE, is_x86_feature_detected!("sse4.1"))]
+    #[case::avx2(AVX2, is_x86_feature_detected!("avx2"))]
+    #[case::avx512(AVX512, is_x86_feature_detected!("avx512bw"))]
+    fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T,
+        #[case] simd_available: bool,
+    ) {
+    }
+
+    // ------------ Template for ARM / AArch64 ------------
+
+    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[template]
+    #[rstest]
+    #[case::neon(NEON, true)]
+    fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T,
+        #[case] simd_available: bool,
+    ) {
+    }
+
+    // ----------------- The actual tests -----------------
+
+    #[apply(simd_implementations)]
+    fn test_first_index_is_returned_when_identical_values_found<
+        T,
+        SIMDV,
+        SIMDM,
+        const LANE_SIZE: usize,
+    >(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMax<u16, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
         }
 
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            let data: &[u16] = &get_array_u16(513);
-            assert_eq!(data.len() % 16, 1);
+        let data = [u16::MIN, u16::MIN, 4, 6, 9, u16::MAX, 22, u16::MAX];
+        let data: &[u16] = &data;
 
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (simd_argmin_index, simd_argmax_index) = unsafe { NEON::argminmax(data) };
-            assert_eq!(argmin_index, simd_argmin_index);
-            assert_eq!(argmax_index, simd_argmax_index);
+        let (argmin_index, argmax_index) = scalar_argminmax(data);
+        assert_eq!(argmin_index, 0);
+        assert_eq!(argmax_index, 5);
+
+        let (argmin_simd_index, argmax_simd_index) = unsafe { T::argminmax(data) };
+        assert_eq!(argmin_simd_index, 0);
+        assert_eq!(argmax_simd_index, 5);
+    }
+
+    #[apply(simd_implementations)]
+    fn test_return_same_result<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMax<u16, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
         }
+        test_long_array_argminmax(get_array_u16, scalar_argminmax, T::argminmax);
+        test_random_runs_argminmax(get_array_u16, scalar_argminmax, T::argminmax);
+    }
 
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            let data = [10, u16::MIN, 6, 9, 9, 22, u16::MAX, 4, u16::MAX];
-            let data: Vec<u16> = data.iter().map(|x| *x).collect();
-            let data: &[u16] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 1);
-            assert_eq!(argmax_index, 6);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data) };
-            assert_eq!(argmin_simd_index, 1);
-            assert_eq!(argmax_simd_index, 6);
+    #[apply(simd_implementations)]
+    fn test_no_overflow<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMax<u16, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
         }
-
-        #[test]
-        fn test_no_overflow() {
-            let n: usize = 1 << 18;
-            let data: &[u16] = &get_array_u16(n);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            for _ in 0..10_000 {
-                let data: &[u16] = &get_array_u16(32 * 2 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
+        test_no_overflow_argminmax(get_array_u16, scalar_argminmax, T::argminmax, None);
     }
 }

--- a/src/simd/simd_u32.rs
+++ b/src/simd/simd_u32.rs
@@ -362,7 +362,10 @@ mod tests {
     use crate::simd::config::{AVX2, AVX512, SSE};
     use crate::SIMDArgMinMax;
 
-    use super::super::test_utils::{test_long_array_argminmax, test_random_runs_argminmax};
+    use super::super::test_utils::{
+        test_first_index_identical_values_argminmax, test_long_array_argminmax,
+        test_random_runs_argminmax,
+    };
 
     use dev_utils::utils;
 
@@ -415,17 +418,7 @@ mod tests {
         if !simd_available {
             return;
         }
-
-        let data = [u32::MIN, u32::MIN, 4, 6, 9, u32::MAX, 22, u32::MAX];
-        let data: &[u32] = &data;
-
-        let (argmin_index, argmax_index) = scalar_argminmax(data);
-        assert_eq!(argmin_index, 0);
-        assert_eq!(argmax_index, 5);
-
-        let (argmin_simd_index, argmax_simd_index) = unsafe { T::argminmax(data) };
-        assert_eq!(argmin_simd_index, 0);
-        assert_eq!(argmax_simd_index, 5);
+        test_first_index_identical_values_argminmax(scalar_argminmax, T::argminmax);
     }
 
     #[apply(simd_implementations)]

--- a/src/simd/simd_u32.rs
+++ b/src/simd/simd_u32.rs
@@ -24,7 +24,7 @@ fn _i32ord_to_u32(ord_i32: i32) -> u32 {
 
 const MAX_INDEX: usize = i32::MAX as usize;
 
-// ------------------------------------------ AVX2 ------------------------------------------
+// --------------------------------------- AVX2 ----------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod avx2 {
@@ -109,73 +109,9 @@ mod avx2 {
             Self::_argminmax(data)
         }
     }
-
-    // ------------------------------------ TESTS --------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::{SIMDArgMinMax, AVX2};
-        use crate::scalar::generic::scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_u32(n: usize) -> Vec<u32> {
-            utils::get_random_array(n, u32::MIN, u32::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            let data: &[u32] = &get_array_u32(513);
-            assert_eq!(data.len() % 16, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (simd_argmin_index, simd_argmax_index) = unsafe { AVX2::argminmax(data) };
-            assert_eq!(argmin_index, simd_argmin_index);
-            assert_eq!(argmax_index, simd_argmax_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            let data = [10, u32::MIN, 6, 9, 9, 22, u32::MAX, 4, u32::MAX];
-            let data: Vec<u32> = data.iter().map(|x| *x).collect();
-            let data: &[u32] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 1);
-            assert_eq!(argmax_index, 6);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-            assert_eq!(argmin_simd_index, 1);
-            assert_eq!(argmax_simd_index, 6);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            for _ in 0..10_000 {
-                let data: &[u32] = &get_array_u32(32 * 8 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// ----------------------------------------- SSE -----------------------------------------
+// ---------------------------------------- SSE ----------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod sse {
@@ -259,61 +195,9 @@ mod sse {
             Self::_argminmax(data)
         }
     }
-
-    // ----------------------------------------- TESTS -----------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::{SIMDArgMinMax, SSE};
-        use crate::scalar::generic::scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_u32(n: usize) -> Vec<u32> {
-            utils::get_random_array(n, u32::MIN, u32::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            let data: &[u32] = &get_array_u32(513);
-            assert_eq!(data.len() % 16, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (simd_argmin_index, simd_argmax_index) = unsafe { SSE::argminmax(data) };
-            assert_eq!(argmin_index, simd_argmin_index);
-            assert_eq!(argmax_index, simd_argmax_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            let data = [10, u32::MIN, 6, 9, 9, 22, u32::MAX, 4, u32::MAX];
-            let data: Vec<u32> = data.iter().map(|x| *x).collect();
-            let data: &[u32] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 1);
-            assert_eq!(argmax_index, 6);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-            assert_eq!(argmin_simd_index, 1);
-            assert_eq!(argmax_simd_index, 6);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            for _ in 0..10_000 {
-                let data: &[u32] = &get_array_u32(32 * 8 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// --------------------------------------- AVX512 ----------------------------------------
+// -------------------------------------- AVX512 ---------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod avx512 {
@@ -402,73 +286,9 @@ mod avx512 {
             Self::_argminmax(data)
         }
     }
-
-    // ------------------------------------ TESTS --------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::{SIMDArgMinMax, AVX512};
-        use crate::scalar::generic::scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_u32(n: usize) -> Vec<u32> {
-            utils::get_random_array(n, u32::MIN, u32::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            let data: &[u32] = &get_array_u32(513);
-            assert_eq!(data.len() % 16, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (simd_argmin_index, simd_argmax_index) = unsafe { AVX512::argminmax(data) };
-            assert_eq!(argmin_index, simd_argmin_index);
-            assert_eq!(argmax_index, simd_argmax_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            let data = [10, u32::MIN, 6, 9, 9, 22, u32::MAX, 4, u32::MAX];
-            let data: Vec<u32> = data.iter().map(|x| *x).collect();
-            let data: &[u32] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 1);
-            assert_eq!(argmax_index, 6);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-            assert_eq!(argmin_simd_index, 1);
-            assert_eq!(argmax_simd_index, 6);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            for _ in 0..10_000 {
-                let data: &[u32] = &get_array_u32(32 * 8 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// ---------------------------------------- NEON -----------------------------------------
+// --------------------------------------- NEON ----------------------------------------
 
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 mod neon {
@@ -520,56 +340,107 @@ mod neon {
             Self::_argminmax(data)
         }
     }
+}
 
-    // ----------------------------------------- TESTS -----------------------------------------
+// ======================================= TESTS =======================================
 
-    #[cfg(test)]
-    mod tests {
-        use super::{SIMDArgMinMax, NEON};
-        use crate::scalar::generic::scalar_argminmax;
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "arm",
+    target_arch = "aarch64",
+))]
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use rstest_reuse::{self, *};
 
-        extern crate dev_utils;
-        use dev_utils::utils;
+    use crate::scalar::generic::scalar_argminmax;
+    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    use crate::simd::config::NEON;
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    use crate::simd::config::{AVX2, AVX512, SSE};
+    use crate::SIMDArgMinMax;
 
-        fn get_array_u32(n: usize) -> Vec<u32> {
-            utils::get_random_array(n, u32::MIN, u32::MAX)
+    use super::super::test_utils::{test_long_array_argminmax, test_random_runs_argminmax};
+
+    use dev_utils::utils;
+
+    fn get_array_u32(n: usize) -> Vec<u32> {
+        utils::get_random_array(n, u32::MIN, u32::MAX)
+    }
+
+    // ------------ Template for x86 / x86_64 -------------
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[template]
+    #[rstest]
+    #[case::sse(SSE, is_x86_feature_detected!("sse4.1"))]
+    #[case::avx2(AVX2, is_x86_feature_detected!("avx2"))]
+    #[case::avx512(AVX512, is_x86_feature_detected!("avx512f"))]
+    fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T,
+        #[case] simd_available: bool,
+    ) {
+    }
+
+    // ------------ Template for ARM / AArch64 ------------
+
+    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[template]
+    #[rstest]
+    #[case::neon(NEON, true)]
+    fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T,
+        #[case] simd_available: bool,
+    ) {
+    }
+
+    // ----------------- The actual tests -----------------
+
+    #[apply(simd_implementations)]
+    fn test_first_index_is_returned_when_identical_values_found<
+        T,
+        SIMDV,
+        SIMDM,
+        const LANE_SIZE: usize,
+    >(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMax<u32, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
         }
 
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            let data: &[u32] = &get_array_u32(513);
-            assert_eq!(data.len() % 16, 1);
+        let data = [u32::MIN, u32::MIN, 4, 6, 9, u32::MAX, 22, u32::MAX];
+        let data: &[u32] = &data;
 
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (simd_argmin_index, simd_argmax_index) = unsafe { NEON::argminmax(data) };
-            assert_eq!(argmin_index, simd_argmin_index);
-            assert_eq!(argmax_index, simd_argmax_index);
+        let (argmin_index, argmax_index) = scalar_argminmax(data);
+        assert_eq!(argmin_index, 0);
+        assert_eq!(argmax_index, 5);
+
+        let (argmin_simd_index, argmax_simd_index) = unsafe { T::argminmax(data) };
+        assert_eq!(argmin_simd_index, 0);
+        assert_eq!(argmax_simd_index, 5);
+    }
+
+    #[apply(simd_implementations)]
+    fn test_return_same_result<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMax<u32, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
         }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            let data = [10, u32::MIN, 6, 9, 9, 22, u32::MAX, 4, u32::MAX];
-            let data: Vec<u32> = data.iter().map(|x| *x).collect();
-            let data: &[u32] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 1);
-            assert_eq!(argmax_index, 6);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data) };
-            assert_eq!(argmin_simd_index, 1);
-            assert_eq!(argmax_simd_index, 6);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            for _ in 0..10_000 {
-                let data: &[u32] = &get_array_u32(32 * 8 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
+        test_long_array_argminmax(get_array_u32, scalar_argminmax, T::argminmax);
+        test_random_runs_argminmax(get_array_u32, scalar_argminmax, T::argminmax);
     }
 }

--- a/src/simd/simd_u64.rs
+++ b/src/simd/simd_u64.rs
@@ -22,7 +22,7 @@ fn _i64ord_to_u64(ord_i64: i64) -> u64 {
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 const MAX_INDEX: usize = i64::MAX as usize;
 
-// ------------------------------------------ AVX2 ------------------------------------------
+// --------------------------------------- AVX2 ----------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod avx2 {
@@ -106,73 +106,9 @@ mod avx2 {
             Self::_argminmax(data)
         }
     }
-
-    // ------------------------------------ TESTS --------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::{SIMDArgMinMax, AVX2};
-        use crate::scalar::generic::scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_u64(n: usize) -> Vec<u64> {
-            utils::get_random_array(n, u64::MIN, u64::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            let data: &[u64] = &get_array_u64(1025);
-            assert_eq!(data.len() % 16, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (simd_argmin_index, simd_argmax_index) = unsafe { AVX2::argminmax(data) };
-            assert_eq!(argmin_index, simd_argmin_index);
-            assert_eq!(argmax_index, simd_argmax_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            let data = [10, u64::MIN, 6, 9, 9, 22, u64::MAX, 4, u64::MAX];
-            let data: Vec<u64> = data.iter().map(|x| *x).collect();
-            let data: &[u64] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 1);
-            assert_eq!(argmax_index, 6);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-            assert_eq!(argmin_simd_index, 1);
-            assert_eq!(argmax_simd_index, 6);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            for _ in 0..10_000 {
-                let data: &[u64] = &get_array_u64(32 * 8 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// ----------------------------------------- SSE -----------------------------------------
+// ---------------------------------------- SSE ----------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod sse {
@@ -256,61 +192,9 @@ mod sse {
             Self::_argminmax(data)
         }
     }
-
-    // ----------------------------------------- TESTS -----------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::{SIMDArgMinMax, SSE};
-        use crate::scalar::generic::scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_u64(n: usize) -> Vec<u64> {
-            utils::get_random_array(n, u64::MIN, u64::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            let data: &[u64] = &get_array_u64(1025);
-            assert_eq!(data.len() % 16, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (simd_argmin_index, simd_argmax_index) = unsafe { SSE::argminmax(data) };
-            assert_eq!(argmin_index, simd_argmin_index);
-            assert_eq!(argmax_index, simd_argmax_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            let data = [10, u64::MIN, 6, 9, 9, 22, u64::MAX, 4, u64::MAX];
-            let data: Vec<u64> = data.iter().map(|x| *x).collect();
-            let data: &[u64] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 1);
-            assert_eq!(argmax_index, 6);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-            assert_eq!(argmin_simd_index, 1);
-            assert_eq!(argmax_simd_index, 6);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            for _ in 0..10_000 {
-                let data: &[u64] = &get_array_u64(32 * 8 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// --------------------------------------- AVX512 ----------------------------------------
+// -------------------------------------- AVX512 ---------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod avx512 {
@@ -395,73 +279,9 @@ mod avx512 {
             Self::_argminmax(data)
         }
     }
-
-    // ------------------------------------ TESTS --------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::{SIMDArgMinMax, AVX512};
-        use crate::scalar::generic::scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_u64(n: usize) -> Vec<u64> {
-            utils::get_random_array(n, u64::MIN, u64::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            let data: &[u64] = &get_array_u64(1025);
-            assert_eq!(data.len() % 16, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (simd_argmin_index, simd_argmax_index) = unsafe { AVX512::argminmax(data) };
-            assert_eq!(argmin_index, simd_argmin_index);
-            assert_eq!(argmax_index, simd_argmax_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            let data = [10, u64::MIN, 6, 9, 9, 22, u64::MAX, 4, u64::MAX];
-            let data: Vec<u64> = data.iter().map(|x| *x).collect();
-            let data: &[u64] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 1);
-            assert_eq!(argmax_index, 6);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-            assert_eq!(argmin_simd_index, 1);
-            assert_eq!(argmax_simd_index, 6);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            if !is_x86_feature_detected!("avx512f") {
-                return;
-            }
-
-            for _ in 0..10_000 {
-                let data: &[u64] = &get_array_u64(1025);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// ---------------------------------------- NEON -----------------------------------------
+// --------------------------------------- NEON ----------------------------------------
 
 // There are no NEON intrinsics for f64, so we need to use the scalar version.
 //   although NEON intrinsics exist for i64 and u64, we cannot use them as
@@ -480,4 +300,87 @@ mod neon {
     // > 64 bit data types.
     unimpl_SIMDOps!(u64, usize, NEON);
     unimpl_SIMDArgMinMax!(u64, usize, NEON);
+}
+
+// ======================================= TESTS =======================================
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use rstest_reuse::{self, *};
+
+    use crate::scalar::generic::scalar_argminmax;
+    use crate::simd::config::{AVX2, AVX512, SSE};
+    use crate::SIMDArgMinMax;
+
+    use super::super::test_utils::{test_long_array_argminmax, test_random_runs_argminmax};
+
+    use dev_utils::utils;
+
+    fn get_array_u64(n: usize) -> Vec<u64> {
+        utils::get_random_array(n, u64::MIN, u64::MAX)
+    }
+
+    // ------------ Template for x86 / x86_64 -------------
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[template]
+    #[rstest]
+    #[case::sse(SSE, is_x86_feature_detected!("sse4.2"))]
+    #[case::avx2(AVX2, is_x86_feature_detected!("avx2"))]
+    #[case::avx512(AVX512, is_x86_feature_detected!("avx512f"))]
+    fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T,
+        #[case] simd_available: bool,
+    ) {
+    }
+
+    // ----------------- The actual tests -----------------
+
+    #[apply(simd_implementations)]
+    fn test_first_index_is_returned_when_identical_values_found<
+        T,
+        SIMDV,
+        SIMDM,
+        const LANE_SIZE: usize,
+    >(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMax<u64, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
+        }
+
+        let data = [u64::MIN, u64::MIN, 4, 6, 9, u64::MAX, 22, u64::MAX];
+        let data: &[u64] = &data;
+
+        let (argmin_index, argmax_index) = scalar_argminmax(data);
+        assert_eq!(argmin_index, 0);
+        assert_eq!(argmax_index, 5);
+
+        let (argmin_simd_index, argmax_simd_index) = unsafe { T::argminmax(data) };
+        assert_eq!(argmin_simd_index, 0);
+        assert_eq!(argmax_simd_index, 5);
+    }
+
+    #[apply(simd_implementations)]
+    fn test_return_same_result<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMax<u64, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
+        }
+        test_long_array_argminmax(get_array_u64, scalar_argminmax, T::argminmax);
+        test_random_runs_argminmax(get_array_u64, scalar_argminmax, T::argminmax);
+    }
 }

--- a/src/simd/simd_u64.rs
+++ b/src/simd/simd_u64.rs
@@ -314,7 +314,10 @@ mod tests {
     use crate::simd::config::{AVX2, AVX512, SSE};
     use crate::SIMDArgMinMax;
 
-    use super::super::test_utils::{test_long_array_argminmax, test_random_runs_argminmax};
+    use super::super::test_utils::{
+        test_first_index_identical_values_argminmax, test_long_array_argminmax,
+        test_random_runs_argminmax,
+    };
 
     use dev_utils::utils;
 
@@ -355,17 +358,7 @@ mod tests {
         if !simd_available {
             return;
         }
-
-        let data = [u64::MIN, u64::MIN, 4, 6, 9, u64::MAX, 22, u64::MAX];
-        let data: &[u64] = &data;
-
-        let (argmin_index, argmax_index) = scalar_argminmax(data);
-        assert_eq!(argmin_index, 0);
-        assert_eq!(argmax_index, 5);
-
-        let (argmin_simd_index, argmax_simd_index) = unsafe { T::argminmax(data) };
-        assert_eq!(argmin_simd_index, 0);
-        assert_eq!(argmax_simd_index, 5);
+        test_first_index_identical_values_argminmax(scalar_argminmax, T::argminmax);
     }
 
     #[apply(simd_implementations)]

--- a/src/simd/simd_u8.rs
+++ b/src/simd/simd_u8.rs
@@ -582,7 +582,8 @@ mod tests {
     use crate::SIMDArgMinMax;
 
     use super::super::test_utils::{
-        test_long_array_argminmax, test_no_overflow_argminmax, test_random_runs_argminmax,
+        test_first_index_identical_values_argminmax, test_long_array_argminmax,
+        test_no_overflow_argminmax, test_random_runs_argminmax,
     };
 
     use dev_utils::utils;
@@ -636,17 +637,7 @@ mod tests {
         if !simd_available {
             return;
         }
-
-        let data = [u8::MIN, u8::MIN, 4, 6, 9, u8::MAX, 22, u8::MAX];
-        let data: &[u8] = &data;
-
-        let (argmin_index, argmax_index) = scalar_argminmax(data);
-        assert_eq!(argmin_index, 0);
-        assert_eq!(argmax_index, 5);
-
-        let (argmin_simd_index, argmax_simd_index) = unsafe { T::argminmax(data) };
-        assert_eq!(argmin_simd_index, 0);
-        assert_eq!(argmax_simd_index, 5);
+        test_first_index_identical_values_argminmax(scalar_argminmax, T::argminmax);
     }
 
     #[apply(simd_implementations)]

--- a/src/simd/simd_u8.rs
+++ b/src/simd/simd_u8.rs
@@ -21,7 +21,7 @@ fn _i8ord_to_u8(ord_i8: i8) -> u8 {
 
 const MAX_INDEX: usize = i8::MAX as usize;
 
-// ------------------------------------------ AVX2 ------------------------------------------
+// --------------------------------------- AVX2 ----------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod avx2 {
@@ -159,88 +159,9 @@ mod avx2 {
             Self::_argminmax(data)
         }
     }
-
-    // ------------------------------------ TESTS --------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::{SIMDArgMinMax, AVX2};
-        use crate::scalar::generic::scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_u8(n: usize) -> Vec<u8> {
-            utils::get_random_array(n, u8::MIN, u8::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            let data: &[u8] = &get_array_u8(65);
-            assert_eq!(data.len() % 16, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (simd_argmin_index, simd_argmax_index) = unsafe { AVX2::argminmax(data) };
-            assert_eq!(argmin_index, simd_argmin_index);
-            assert_eq!(argmax_index, simd_argmax_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            let data = [10, u8::MIN, 6, 9, 9, 22, u8::MAX, 4, u8::MAX];
-            let data: Vec<u8> = data.iter().map(|x| *x).collect();
-            let data: &[u8] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 1);
-            assert_eq!(argmax_index, 6);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-            assert_eq!(argmin_simd_index, 1);
-            assert_eq!(argmax_simd_index, 6);
-        }
-
-        #[test]
-        fn test_no_overflow() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            let n: usize = 1 << 10;
-            let data: &[u8] = &get_array_u8(n);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            if !is_x86_feature_detected!("avx2") {
-                return;
-            }
-
-            for _ in 0..10_000 {
-                let data: &[u8] = &get_array_u8(32 * 2 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { AVX2::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// ----------------------------------------- SSE -----------------------------------------
+// ---------------------------------------- SSE ----------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod sse {
@@ -373,72 +294,9 @@ mod sse {
             Self::_argminmax(data)
         }
     }
-
-    // ----------------------------------------- TESTS -----------------------------------------
-
-    #[cfg(test)]
-    mod tests {
-        use super::{SIMDArgMinMax, SSE};
-        use crate::scalar::generic::scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_u8(n: usize) -> Vec<u8> {
-            utils::get_random_array(n, u8::MIN, u8::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            let data: &[u8] = &get_array_u8(65);
-            assert_eq!(data.len() % 16, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (simd_argmin_index, simd_argmax_index) = unsafe { SSE::argminmax(data) };
-            assert_eq!(argmin_index, simd_argmin_index);
-            assert_eq!(argmax_index, simd_argmax_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            let data = [10, u8::MIN, 6, 9, 9, 22, u8::MAX, 4, u8::MAX];
-            let data: Vec<u8> = data.iter().map(|x| *x).collect();
-            let data: &[u8] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 1);
-            assert_eq!(argmax_index, 6);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-            assert_eq!(argmin_simd_index, 1);
-            assert_eq!(argmax_simd_index, 6);
-        }
-
-        #[test]
-        fn test_no_overflow() {
-            let n: usize = 1 << 10;
-            let data: &[u8] = &get_array_u8(n);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            for _ in 0..10_000 {
-                let data: &[u8] = &get_array_u8(32 * 2 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { SSE::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// --------------------------------------- AVX512 ----------------------------------------
+// -------------------------------------- AVX512 ---------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod avx512 {
@@ -582,89 +440,9 @@ mod avx512 {
             Self::_argminmax(data)
         }
     }
-
-    // ----------------------------------------- TESTS -----------------------------------------
-
-    #[cfg(test)]
-
-    mod tests {
-        use super::{SIMDArgMinMax, AVX512};
-        use crate::scalar::generic::scalar_argminmax;
-
-        extern crate dev_utils;
-        use dev_utils::utils;
-
-        fn get_array_u8(n: usize) -> Vec<u8> {
-            utils::get_random_array(n, u8::MIN, u8::MAX)
-        }
-
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            if !is_x86_feature_detected!("avx512bw") {
-                return;
-            }
-
-            let data: &[u8] = &get_array_u8(65);
-            assert_eq!(data.len() % 16, 1);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (simd_argmin_index, simd_argmax_index) = unsafe { AVX512::argminmax(data) };
-            assert_eq!(argmin_index, simd_argmin_index);
-            assert_eq!(argmax_index, simd_argmax_index);
-        }
-
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            if !is_x86_feature_detected!("avx512bw") {
-                return;
-            }
-
-            let data = [10, u8::MIN, 6, 9, 9, 22, u8::MAX, 4, u8::MAX];
-            let data: Vec<u8> = data.iter().map(|x| *x).collect();
-            let data: &[u8] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 1);
-            assert_eq!(argmax_index, 6);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-            assert_eq!(argmin_simd_index, 1);
-            assert_eq!(argmax_simd_index, 6);
-        }
-
-        #[test]
-        fn test_no_overflow() {
-            if !is_x86_feature_detected!("avx512bw") {
-                return;
-            }
-
-            let n: usize = 1 << 10;
-            let data: &[u8] = &get_array_u8(n);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            if !is_x86_feature_detected!("avx512bw") {
-                return;
-            }
-
-            for _ in 0..10_000 {
-                let data: &[u8] = &get_array_u8(32 * 4 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { AVX512::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
-    }
 }
 
-// ---------------------------------------- NEON -----------------------------------------
+// --------------------------------------- NEON ----------------------------------------
 
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 mod neon {
@@ -781,67 +559,124 @@ mod neon {
             Self::_argminmax(data)
         }
     }
+}
 
-    // ----------------------------------------- TESTS -----------------------------------------
+// ======================================= TESTS =======================================
 
-    #[cfg(test)]
-    mod tests {
-        use super::{SIMDArgMinMax, NEON};
-        use crate::scalar::generic::scalar_argminmax;
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "arm",
+    target_arch = "aarch64",
+))]
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use rstest_reuse::{self, *};
 
-        extern crate dev_utils;
-        use dev_utils::utils;
+    use crate::scalar::generic::scalar_argminmax;
+    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    use crate::simd::config::NEON;
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    use crate::simd::config::{AVX2, AVX512, SSE};
+    use crate::SIMDArgMinMax;
 
-        fn get_array_u8(n: usize) -> Vec<u8> {
-            utils::get_random_array(n, u8::MIN, u8::MAX)
+    use super::super::test_utils::{
+        test_long_array_argminmax, test_no_overflow_argminmax, test_random_runs_argminmax,
+    };
+
+    use dev_utils::utils;
+
+    fn get_array_u8(n: usize) -> Vec<u8> {
+        utils::get_random_array(n, u8::MIN, u8::MAX)
+    }
+
+    // ------------ Template for x86 / x86_64 -------------
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[template]
+    #[rstest]
+    #[case::sse(SSE, is_x86_feature_detected!("sse4.1"))]
+    #[case::avx2(AVX2, is_x86_feature_detected!("avx2"))]
+    #[case::avx512(AVX512, is_x86_feature_detected!("avx512bw"))]
+    fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T,
+        #[case] simd_available: bool,
+    ) {
+    }
+
+    // ------------ Template for ARM / AArch64 ------------
+
+    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[template]
+    #[rstest]
+    #[case::neon(NEON, true)]
+    fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T,
+        #[case] simd_available: bool,
+    ) {
+    }
+
+    // ----------------- The actual tests -----------------
+
+    #[apply(simd_implementations)]
+    fn test_first_index_is_returned_when_identical_values_found<
+        T,
+        SIMDV,
+        SIMDM,
+        const LANE_SIZE: usize,
+    >(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMax<u8, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
         }
 
-        #[test]
-        fn test_both_versions_return_the_same_results() {
-            let data: &[u8] = &get_array_u8(513);
-            assert_eq!(data.len() % 16, 1);
+        let data = [u8::MIN, u8::MIN, 4, 6, 9, u8::MAX, 22, u8::MAX];
+        let data: &[u8] = &data;
 
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (simd_argmin_index, simd_argmax_index) = unsafe { NEON::argminmax(data) };
-            assert_eq!(argmin_index, simd_argmin_index);
-            assert_eq!(argmax_index, simd_argmax_index);
+        let (argmin_index, argmax_index) = scalar_argminmax(data);
+        assert_eq!(argmin_index, 0);
+        assert_eq!(argmax_index, 5);
+
+        let (argmin_simd_index, argmax_simd_index) = unsafe { T::argminmax(data) };
+        assert_eq!(argmin_simd_index, 0);
+        assert_eq!(argmax_simd_index, 5);
+    }
+
+    #[apply(simd_implementations)]
+    fn test_return_same_result<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMax<u8, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
         }
+        test_long_array_argminmax(get_array_u8, scalar_argminmax, T::argminmax);
+        test_random_runs_argminmax(get_array_u8, scalar_argminmax, T::argminmax);
+    }
 
-        #[test]
-        fn test_first_index_is_returned_when_identical_values_found() {
-            let data = [10, u8::MIN, 6, 9, 9, 22, u8::MAX, 4, u8::MAX];
-            let data: Vec<u8> = data.iter().map(|x| *x).collect();
-            let data: &[u8] = &data;
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            assert_eq!(argmin_index, 1);
-            assert_eq!(argmax_index, 6);
-
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data) };
-            assert_eq!(argmin_simd_index, 1);
-            assert_eq!(argmax_simd_index, 6);
+    #[apply(simd_implementations)]
+    fn test_no_overflow<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd_available: bool,
+    ) where
+        T: SIMDArgMinMax<u8, SIMDV, SIMDM, LANE_SIZE>,
+        SIMDV: Copy,
+        SIMDM: Copy,
+    {
+        if !simd_available {
+            return;
         }
-
-        #[test]
-        fn test_no_overflow() {
-            let n: usize = 1 << 10;
-            let data: &[u8] = &get_array_u8(n);
-
-            let (argmin_index, argmax_index) = scalar_argminmax(data);
-            let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data) };
-            assert_eq!(argmin_index, argmin_simd_index);
-            assert_eq!(argmax_index, argmax_simd_index);
-        }
-
-        #[test]
-        fn test_many_random_runs() {
-            for _ in 0..10_000 {
-                let data: &[u8] = &get_array_u8(32 * 2 + 1);
-                let (argmin_index, argmax_index) = scalar_argminmax(data);
-                let (argmin_simd_index, argmax_simd_index) = unsafe { NEON::argminmax(data) };
-                assert_eq!(argmin_index, argmin_simd_index);
-                assert_eq!(argmax_index, argmax_simd_index);
-            }
-        }
+        test_no_overflow_argminmax(get_array_u8, scalar_argminmax, T::argminmax, None);
     }
 }

--- a/src/simd/test_utils.rs
+++ b/src/simd/test_utils.rs
@@ -1,0 +1,325 @@
+use num_traits::AsPrimitive;
+use num_traits::Float;
+
+// ------- Generic tests for argminmax
+
+/// The generic tests check whether the scalar and SIMD function return the same result.
+
+#[cfg(test)]
+const LONG_ARR_LEN: usize = 8193; // 8192 + 1
+
+/// Test for a long array of random DType values whether the scalar and SIMD function
+/// return the same result.
+#[cfg(test)]
+pub(crate) fn test_long_array_argminmax<DType>(
+    get_data: fn(usize) -> Vec<DType>,
+    scalar_f: fn(&[DType]) -> (usize, usize),
+    simd_f: unsafe fn(&[DType]) -> (usize, usize),
+) where
+    DType: Copy + PartialOrd + AsPrimitive<usize>,
+{
+    let data: &[DType] = &get_data(LONG_ARR_LEN);
+    assert_eq!(data.len() % 64, 1); // assert that data does not fully fit in a register
+
+    let (argmin_index, argmax_index) = scalar_f(data);
+    let (argmin_simd_index, argmax_simd_index) = unsafe { simd_f(data) };
+    assert_eq!(argmin_index, argmin_simd_index);
+    assert_eq!(argmax_index, argmax_simd_index);
+}
+
+#[cfg(test)]
+const NB_RUNS: usize = 10_000;
+#[cfg(test)]
+const RANDOM_RUN_ARR_LEN: usize = 32 * 4 + 1;
+
+/// Test for many arrays of random DType values whether the scalar and SIMD function
+/// return the same result.
+#[cfg(test)]
+pub(crate) fn test_random_runs_argminmax<DType>(
+    get_data: fn(usize) -> Vec<DType>,
+    scalar_f: fn(&[DType]) -> (usize, usize),
+    simd_f: unsafe fn(&[DType]) -> (usize, usize),
+) where
+    DType: Copy + PartialOrd + AsPrimitive<usize>,
+{
+    for _ in 0..NB_RUNS {
+        let data: &[DType] = &get_data(RANDOM_RUN_ARR_LEN);
+        let (argmin_index, argmax_index) = scalar_f(data);
+        let (argmin_simd_index, argmax_simd_index) = unsafe { simd_f(data) };
+        assert_eq!(argmin_index, argmin_simd_index);
+        assert_eq!(argmax_index, argmax_simd_index);
+    }
+}
+
+// ------- Overflow test
+
+#[cfg(test)]
+pub(crate) fn test_no_overflow_argminmax<DType>(
+    get_data: fn(usize) -> Vec<DType>,
+    scalar_f: fn(&[DType]) -> (usize, usize),
+    simd_f: unsafe fn(&[DType]) -> (usize, usize),
+    arr_len: Option<usize>,
+) where
+    DType: Copy + PartialOrd + AsPrimitive<usize>,
+{
+    let arr_len = arr_len.unwrap_or(1 << (std::mem::size_of::<DType>() * 8 + 1));
+    let data: &[DType] = &get_data(arr_len);
+
+    let (argmin_index, argmax_index) = scalar_f(data);
+    let (argmin_simd_index, argmax_simd_index) = unsafe { simd_f(data) };
+    assert_eq!(argmin_index, argmin_simd_index);
+    assert_eq!(argmax_index, argmax_simd_index);
+}
+
+// ------- Float tests for argminmax
+
+#[cfg(test)]
+const FLOAT_ARR_LEN: usize = 1024 + 3;
+
+#[cfg(test)]
+pub(crate) fn test_return_infs_argminmax<DType>(
+    get_data: fn(usize) -> Vec<DType>,
+    scalar_f: fn(&[DType]) -> (usize, usize),
+    simd_f: unsafe fn(&[DType]) -> (usize, usize),
+) where
+    DType: Float + AsPrimitive<usize>,
+{
+    let mut data: Vec<DType> = get_data(FLOAT_ARR_LEN);
+    // Case 1: all elements are +inf
+    for i in 0..data.len() {
+        data[i] = DType::infinity();
+    }
+
+    let (argmin_index, argmax_index) = scalar_f(&data);
+    assert_eq!(argmin_index, 0);
+    assert_eq!(argmax_index, 0);
+
+    let (argmin_simd_index, argmax_simd_index) = unsafe { simd_f(&data) };
+    assert_eq!(argmin_simd_index, 0);
+    assert_eq!(argmax_simd_index, 0);
+
+    // Case 2: all elements are -inf
+    for i in 0..data.len() {
+        data[i] = DType::neg_infinity();
+    }
+
+    let (argmin_index, argmax_index) = scalar_f(&data);
+    assert_eq!(argmin_index, 0);
+    assert_eq!(argmax_index, 0);
+
+    let (argmin_simd_index, argmax_simd_index) = unsafe { simd_f(&data) };
+    assert_eq!(argmin_simd_index, 0);
+    assert_eq!(argmax_simd_index, 0);
+
+    // Case 3: add some +inf and -inf in the middle
+    let mut data: Vec<DType> = get_data(FLOAT_ARR_LEN);
+    data[100] = DType::infinity();
+    data[200] = DType::neg_infinity();
+
+    let (argmin_index, argmax_index) = scalar_f(&data);
+    assert_eq!(argmin_index, 200);
+    assert_eq!(argmax_index, 100);
+
+    let (argmin_simd_index, argmax_simd_index) = unsafe { simd_f(&data) };
+    assert_eq!(argmin_simd_index, 200);
+    assert_eq!(argmax_simd_index, 100);
+}
+
+#[cfg(test)]
+pub(crate) fn test_ignore_nans_argminmax<DType>(
+    get_data: fn(usize) -> Vec<DType>,
+    scalar_f: fn(&[DType]) -> (usize, usize),
+    simd_f: unsafe fn(&[DType]) -> (usize, usize),
+) where
+    DType: Float + AsPrimitive<usize>,
+{
+    // Case 1: NaN is the first element
+    let mut data: Vec<DType> = get_data(FLOAT_ARR_LEN);
+    data[0] = DType::nan();
+
+    let (argmin_index, argmax_index) = scalar_f(&data);
+    assert!(argmin_index != 0);
+    assert!(argmax_index != 0);
+
+    let (argmin_simd_index, argmax_simd_index) = unsafe { simd_f(&data) };
+    assert!(argmin_simd_index != 0);
+    assert!(argmax_simd_index != 0);
+
+    assert_eq!(argmin_index, argmin_simd_index);
+    assert_eq!(argmax_index, argmax_simd_index);
+
+    // Case 2: first 100 elements are NaN
+    for i in 0..100 {
+        data[i] = DType::nan();
+    }
+
+    let (argmin_index, argmax_index) = scalar_f(&data);
+    assert!(argmin_index > 99);
+    assert!(argmax_index > 99);
+
+    let (argmin_simd_index, argmax_simd_index) = unsafe { simd_f(&data) };
+    assert!(argmin_simd_index > 99);
+    assert!(argmax_simd_index > 99);
+
+    assert_eq!(argmin_index, argmin_simd_index);
+    assert_eq!(argmax_index, argmax_simd_index);
+
+    // Case 3: NaN is the last element
+    let mut data: Vec<DType> = get_data(FLOAT_ARR_LEN);
+    data[FLOAT_ARR_LEN - 1] = DType::nan();
+
+    let (argmin_index, argmax_index) = scalar_f(&data);
+    assert!(argmin_index != 1026);
+    assert!(argmax_index != 1026);
+
+    let (argmin_simd_index, argmax_simd_index) = unsafe { simd_f(&data) };
+    assert!(argmin_simd_index != 1026);
+    assert!(argmax_simd_index != 1026);
+
+    // Case 4: last 100 elements are NaN
+    for i in 0..100 {
+        data[FLOAT_ARR_LEN - 1 - i] = DType::nan();
+    }
+
+    let (argmin_index, argmax_index) = scalar_f(&data);
+    assert!(argmin_index < FLOAT_ARR_LEN - 100);
+    assert!(argmax_index < FLOAT_ARR_LEN - 100);
+
+    let (argmin_simd_index, argmax_simd_index) = unsafe { simd_f(&data) };
+    assert!(argmin_simd_index < FLOAT_ARR_LEN - 100);
+    assert!(argmax_simd_index < FLOAT_ARR_LEN - 100);
+
+    // Case 5: NaN is somewhere in the middle element
+    let mut data: Vec<DType> = get_data(FLOAT_ARR_LEN);
+    data[123] = DType::nan();
+
+    let (argmin_index, argmax_index) = scalar_f(&data);
+    assert!(argmin_index != 123);
+    assert!(argmax_index != 123);
+
+    let (argmin_simd_index, argmax_simd_index) = unsafe { simd_f(&data) };
+    assert!(argmin_simd_index != 123);
+    assert!(argmax_simd_index != 123);
+
+    // Case 6: all elements are NaN
+    for i in 0..data.len() {
+        data[i] = DType::nan();
+    }
+
+    let (argmin_index, argmax_index) = scalar_f(&data);
+    assert_eq!(argmin_index, 0);
+    assert_eq!(argmax_index, 0);
+
+    let (argmin_simd_index, argmax_simd_index) = unsafe { simd_f(&data) };
+    assert_eq!(argmin_simd_index, 0);
+    assert_eq!(argmax_simd_index, 0);
+}
+
+#[cfg(test)]
+pub(crate) fn test_return_nans_argminmax<DType>(
+    get_data: fn(usize) -> Vec<DType>,
+    scalar_f: fn(&[DType]) -> (usize, usize),
+    simd_f: unsafe fn(&[DType]) -> (usize, usize),
+) where
+    DType: Float + AsPrimitive<usize>,
+{
+    // Case 1: NaN is the first element
+    let mut data: Vec<DType> = get_data(FLOAT_ARR_LEN);
+    data[0] = DType::nan();
+
+    let (argmin_index, argmax_index) = scalar_f(&data);
+    assert_eq!(argmin_index, 0);
+    assert_eq!(argmax_index, 0);
+
+    let (argmin_simd_index, argmax_simd_index) = unsafe { simd_f(&data) };
+    assert_eq!(argmin_simd_index, 0);
+    assert_eq!(argmax_simd_index, 0);
+
+    // Case 2: first 100 elements are NaN
+    for i in 0..100 {
+        data[i] = DType::nan();
+    }
+
+    let (argmin_index, argmax_index) = scalar_f(&data);
+    assert_eq!(argmin_index, 0);
+    assert_eq!(argmax_index, 0);
+
+    let (argmin_simd_index, argmax_simd_index) = unsafe { simd_f(&data) };
+    assert_eq!(argmin_simd_index, 0);
+    assert_eq!(argmax_simd_index, 0);
+
+    // Case 3: NaN is the last element
+    let mut data: Vec<DType> = get_data(FLOAT_ARR_LEN);
+    data[FLOAT_ARR_LEN - 1] = DType::nan();
+
+    let (argmin_index, argmax_index) = scalar_f(&data);
+    assert_eq!(argmin_index, 1026);
+    assert_eq!(argmax_index, 1026);
+
+    let (argmin_simd_index, argmax_simd_index) = unsafe { simd_f(&data) };
+    assert_eq!(argmin_simd_index, 1026);
+    assert_eq!(argmax_simd_index, 1026);
+
+    // Case 4: last 100 elements are NaN
+    for i in 0..100 {
+        data[FLOAT_ARR_LEN - 1 - i] = DType::nan();
+    }
+
+    let (argmin_index, argmax_index) = scalar_f(&data);
+    assert_eq!(argmin_index, FLOAT_ARR_LEN - 100);
+    assert_eq!(argmax_index, FLOAT_ARR_LEN - 100);
+
+    let (argmin_simd_index, argmax_simd_index) = unsafe { simd_f(&data) };
+    assert_eq!(argmin_simd_index, FLOAT_ARR_LEN - 100);
+    assert_eq!(argmax_simd_index, FLOAT_ARR_LEN - 100);
+
+    // Case 5: NaN is somewhere in the middle element
+    let mut data: Vec<DType> = get_data(FLOAT_ARR_LEN);
+    data[123] = DType::nan();
+
+    let (argmin_index, argmax_index) = scalar_f(&data);
+    assert_eq!(argmin_index, 123);
+    assert_eq!(argmax_index, 123);
+
+    let (argmin_simd_index, argmax_simd_index) = unsafe { simd_f(&data) };
+    assert_eq!(argmin_simd_index, 123);
+    assert_eq!(argmax_simd_index, 123);
+
+    // Case 6: NaN in the middle of the array and last 100 elements are NaN
+    for i in 0..100 {
+        data[FLOAT_ARR_LEN - 1 - i] = DType::nan();
+    }
+
+    let (argmin_index, argmax_index) = scalar_f(&data);
+    assert_eq!(argmin_index, 123);
+    assert_eq!(argmax_index, 123);
+
+    let (argmin_simd_index, argmax_simd_index) = unsafe { simd_f(&data) };
+    assert_eq!(argmin_simd_index, 123);
+    assert_eq!(argmax_simd_index, 123);
+
+    // Case 7: all elements are NaN
+    for i in 0..data.len() {
+        data[i] = DType::nan();
+    }
+
+    let (argmin_index, argmax_index) = scalar_f(&data);
+    assert_eq!(argmin_index, 0);
+    assert_eq!(argmax_index, 0);
+
+    let (argmin_simd_index, argmax_simd_index) = unsafe { simd_f(&data) };
+    assert_eq!(argmin_simd_index, 0);
+    assert_eq!(argmax_simd_index, 0);
+
+    // Case 8: array exact multiple of LANE_SIZE and only 1 element is NaN
+    let mut data: Vec<DType> = get_data(128);
+    data[17] = DType::nan();
+
+    let (argmin_index, argmax_index) = scalar_f(&data);
+    assert_eq!(argmin_index, 17);
+    assert_eq!(argmax_index, 17);
+
+    let (argmin_simd_index, argmax_simd_index) = unsafe { simd_f(&data) };
+    assert_eq!(argmin_simd_index, 17);
+    assert_eq!(argmax_simd_index, 17);
+}

--- a/tests/argminmax_test.rs
+++ b/tests/argminmax_test.rs
@@ -1,24 +1,63 @@
 use argminmax::ArgMinMax;
-use dev_utils::utils;
 
-#[cfg(feature = "arrow")]
-use arrow::array::Float32Array;
-#[cfg(feature = "ndarray")]
-use ndarray::Array1;
+use rstest::rstest;
+use rstest_reuse::{self, *};
+
+use dev_utils::utils;
+extern crate rand;
 
 const ARRAY_LENGTH: usize = 100_000;
 
-#[test]
-fn test_argminmax_slice() {
+use num_traits::{AsPrimitive, FromPrimitive};
+
+#[template]
+#[rstest]
+// #[case::float16(f16::MIN, f16::MAX)] // TODO
+#[case::float32(f32::MIN, f32::MAX)]
+#[case::float64(f64::MIN, f64::MAX)]
+#[case::int8(i8::MIN, i8::MAX)]
+#[case::int16(i16::MIN, i16::MAX)]
+#[case::int32(i32::MIN, i32::MAX)]
+#[case::int64(i64::MIN, i64::MAX)]
+#[case::uint8(u8::MIN, u8::MAX)]
+#[case::uint16(u16::MIN, u16::MAX)]
+#[case::uint32(u32::MIN, u32::MAX)]
+#[case::uint64(u64::MIN, u64::MAX)]
+fn dtypes<T>(#[case] min: T, #[case] max: T) {}
+
+/// Returns a monotonic array of type T with length ARRAY_LENGTH and step size 1
+/// The values are within the range of T and are cyclic if the range of T is smaller
+/// than ARRAY_LENGTH
+///
+/// max_index is the max value that can be represented by T
+fn get_monotonic_array<T>(n: usize, max_index: usize) -> Vec<T>
+where
+    T: Copy + FromPrimitive + AsPrimitive<usize>,
+{
+    (0..n)
+        .into_iter()
+        // modulo max_index to ensure that the values are within the range of T
+        .map(|x| T::from_usize(x % max_index).unwrap())
+        .collect::<Vec<T>>()
+}
+
+#[apply(dtypes)]
+fn test_argminmax_slice<T>(#[case] _min: T, #[case] max: T)
+where
+    T: Copy + FromPrimitive + AsPrimitive<usize>,
+    for<'a> &'a [T]: ArgMinMax,
+{
+    // max_index is the max value that can be represented by T
+    let max_index: usize = std::cmp::min(ARRAY_LENGTH, max.as_());
+    let data: &[T] = &get_monotonic_array(ARRAY_LENGTH, max_index);
     // Test slice (aka the base implementation)
-    let data: &[f32] = &(0..ARRAY_LENGTH).map(|x| x as f32).collect::<Vec<f32>>();
     let (min, max) = data.argminmax();
     assert_eq!(min, 0);
-    assert_eq!(max, ARRAY_LENGTH - 1);
+    assert_eq!(max, max_index - 1);
     // Borrowed slice
     let (min, max) = (&data).argminmax();
     assert_eq!(min, 0);
-    assert_eq!(max, ARRAY_LENGTH - 1);
+    assert_eq!(max, max_index - 1);
 }
 
 // TODO: this is currently not supported yet
@@ -31,87 +70,165 @@ fn test_argminmax_slice() {
 //     assert_eq!(max, ARRAY_LENGTH - 1);
 // }
 
-#[test]
-fn test_argminmax_vec() {
-    let data: Vec<f32> = (0..ARRAY_LENGTH).map(|x| x as f32).collect();
+#[apply(dtypes)]
+fn test_argminmax_vec<T>(#[case] _min: T, #[case] max: T)
+where
+    T: Copy + FromPrimitive + AsPrimitive<usize>,
+    for<'a> &'a [T]: ArgMinMax,
+{
+    // max_index is the max value that can be represented by T
+    let max_index: usize = std::cmp::min(ARRAY_LENGTH, max.as_());
+    let data: Vec<T> = get_monotonic_array(ARRAY_LENGTH, max_index);
     // Test owned vec
     let (min, max) = data.argminmax();
     assert_eq!(min, 0);
-    assert_eq!(max, ARRAY_LENGTH - 1);
+    assert_eq!(max, max_index - 1);
     // Test borrowed vec
     let (min, max) = (&data).argminmax();
     assert_eq!(min, 0);
-    assert_eq!(max, ARRAY_LENGTH - 1);
+    assert_eq!(max, max_index - 1);
 }
 
 #[cfg(feature = "ndarray")]
-#[test]
-fn test_argminmax_ndarray() {
-    let data: Array1<f32> = Array1::from((0..ARRAY_LENGTH).map(|x| x as f32).collect::<Vec<f32>>());
-    // --- Array1
-    // Test owned Array1
-    let (min, max) = data.argminmax();
-    assert_eq!(min, 0);
-    assert_eq!(max, ARRAY_LENGTH - 1);
-    // Test borrowed Array1
-    let (min, max) = (&data).argminmax();
-    assert_eq!(min, 0);
-    assert_eq!(max, ARRAY_LENGTH - 1);
-    // --- ArrayView1
-    // Test owened ArrayView1
-    let (min, max) = data.view().argminmax();
-    assert_eq!(min, 0);
-    assert_eq!(max, ARRAY_LENGTH - 1);
-    // Test borrowed ArrayView1
-    let (min, max) = (&data.view()).argminmax();
-    assert_eq!(min, 0);
-    assert_eq!(max, ARRAY_LENGTH - 1);
+mod ndarray_tests {
+    use super::*;
+
+    use ndarray::Array1;
+
+    #[apply(dtypes)]
+    fn test_argminmax_ndarray<T>(#[case] _min: T, #[case] max: T)
+    where
+        T: Copy + FromPrimitive + AsPrimitive<usize>,
+        for<'a> &'a [T]: ArgMinMax,
+    {
+        // max_index is the max value that can be represented by T
+        let max_index: usize = std::cmp::min(ARRAY_LENGTH, max.as_());
+        let data: Array1<T> = Array1::from(get_monotonic_array(ARRAY_LENGTH, max_index));
+        // --- Array1
+        // Test owned Array1
+        let (min, max) = data.argminmax();
+        assert_eq!(min, 0);
+        assert_eq!(max, max_index - 1);
+        // Test borrowed Array1
+        let (min, max) = (&data).argminmax();
+        assert_eq!(min, 0);
+        assert_eq!(max, max_index - 1);
+        // --- ArrayView1
+        // Test owened ArrayView1
+        let (min, max) = data.view().argminmax();
+        assert_eq!(min, 0);
+        assert_eq!(max, max_index - 1);
+        // Test borrowed ArrayView1
+        let (min, max) = (&data.view()).argminmax();
+        assert_eq!(min, 0);
+        assert_eq!(max, max_index - 1);
+    }
+
+    #[apply(dtypes)]
+    fn test_argminmax_many_random_runs_ndarray<T>(#[case] min: T, #[case] max: T)
+    where
+        T: Copy + FromPrimitive + AsPrimitive<usize> + rand::distributions::uniform::SampleUniform,
+        for<'a> &'a [T]: ArgMinMax,
+    {
+        for _ in 0..500 {
+            let data: Vec<T> = utils::get_random_array::<T>(5_000, min, max);
+            // Slice
+            let slice: &[T] = &data;
+            let (min_slice, max_slice) = slice.argminmax();
+            // Vec
+            let (min_vec, max_vec) = data.argminmax();
+            // Array1
+            let array: Array1<T> = Array1::from_vec(slice.to_vec());
+            let (min_array, max_array) = array.argminmax();
+
+            // Check
+            assert_eq!(min_slice, min_vec);
+            assert_eq!(max_slice, max_vec);
+            assert_eq!(min_slice, min_array);
+            assert_eq!(max_slice, max_array);
+        }
+    }
 }
 
 #[cfg(feature = "arrow")]
-#[test]
-fn test_argminmax_arrow() {
-    let data: Float32Array =
-        Float32Array::from((0..ARRAY_LENGTH).map(|x| x as f32).collect::<Vec<f32>>());
-    // Test owned Float32Array
-    let (min, max) = data.argminmax();
-    assert_eq!(min, 0);
-    assert_eq!(max, ARRAY_LENGTH - 1);
-    // Test borrowed Float32Array
-    let (min, max) = (&data).argminmax();
-    assert_eq!(min, 0);
-    assert_eq!(max, ARRAY_LENGTH - 1);
-}
+#[cfg(test)]
+mod arrow_tests {
+    use super::*;
 
-#[test]
-fn test_argminmax_many_random_runs() {
-    for _ in 0..500 {
-        let data: Vec<f32> = utils::get_random_array::<f32>(5_000, f32::MIN, f32::MAX);
-        // Slice
-        let slice: &[f32] = &data;
-        let (min_slice, max_slice) = slice.argminmax();
-        // Vec
-        let (min_vec, max_vec) = data.argminmax();
-        // Array1
-        #[cfg(feature = "ndarray")]
-        let array: Array1<f32> = Array1::from_vec(slice.to_vec());
-        #[cfg(feature = "ndarray")]
-        let (min_array, max_array) = array.argminmax();
-        // Arrow
-        #[cfg(feature = "arrow")]
-        let arrow: Float32Array = Float32Array::from(slice.to_vec());
-        #[cfg(feature = "arrow")]
-        let (min_arrow, max_arrow) = arrow.argminmax();
-        // Assert
-        assert_eq!(min_slice, min_vec);
-        assert_eq!(max_slice, max_vec);
-        #[cfg(feature = "ndarray")]
-        assert_eq!(min_slice, min_array);
-        #[cfg(feature = "ndarray")]
-        assert_eq!(max_slice, max_array);
-        #[cfg(feature = "arrow")]
-        assert_eq!(min_slice, min_arrow);
-        #[cfg(feature = "arrow")]
-        assert_eq!(max_slice, max_arrow);
+    use arrow::array::PrimitiveArray;
+    use arrow::datatypes::*;
+
+    #[template]
+    #[rstest]
+    #[case::float32(Float32Type {}, f32::MIN, f32::MAX)]
+    #[case::float64(Float64Type {}, f64::MIN, f64::MAX)]
+    #[case::int8(Int8Type {}, i8::MIN, i8::MAX)]
+    #[case::int16(Int16Type {}, i16::MIN, i16::MAX)]
+    #[case::int32(Int32Type {}, i32::MIN, i32::MAX)]
+    #[case::int64(Int64Type {}, i64::MIN, i64::MAX)]
+    #[case::uint8(UInt8Type {}, u8::MIN, u8::MAX)]
+    #[case::uint16(UInt16Type {}, u16::MIN, u16::MAX)]
+    #[case::uint32(UInt32Type {}, u32::MIN, u32::MAX)]
+    #[case::uint64(UInt64Type {}, u64::MIN, u64::MAX)]
+    fn dtypes_arrow<T, ArrowDataType>(
+        #[case] _arrow_type: ArrowDataType,
+        #[case] min: T,
+        #[case] max: T,
+    ) {
+    }
+
+    #[apply(dtypes_arrow)]
+    fn test_argminmax_arrow<T, ArrowDataType>(
+        #[case] _dtype: ArrowDataType, // used to infer the arrow data type
+        #[case] _min: T,
+        #[case] max: T,
+    ) where
+        T: Copy + FromPrimitive + AsPrimitive<usize>,
+        for<'a> &'a [T]: ArgMinMax,
+        ArrowDataType: ArrowPrimitiveType<Native = T> + ArrowNumericType,
+        PrimitiveArray<ArrowDataType>: From<Vec<T>>,
+    {
+        // max_index is the max value that can be represented by T
+        let max_index: usize = std::cmp::min(ARRAY_LENGTH, max.as_());
+        let data: PrimitiveArray<ArrowDataType> =
+            PrimitiveArray::from(get_monotonic_array(ARRAY_LENGTH, max_index));
+        // Test owned PrimitiveArray
+        let (min, max) = data.argminmax();
+        assert_eq!(min, 0);
+        assert_eq!(max, max_index - 1);
+        // Test borrowed PrimitiveArray
+        let (min, max) = (&data).argminmax();
+        assert_eq!(min, 0);
+        assert_eq!(max, max_index - 1);
+    }
+
+    #[apply(dtypes_arrow)]
+    fn test_argminmax_many_random_runs_arrow<T, ArrowDataType>(
+        #[case] _dtype: ArrowDataType, // used to infer the arrow data type
+        #[case] min: T,
+        #[case] max: T,
+    ) where
+        T: Copy + FromPrimitive + AsPrimitive<usize> + rand::distributions::uniform::SampleUniform,
+        for<'a> &'a [T]: ArgMinMax,
+        ArrowDataType: ArrowPrimitiveType<Native = T> + ArrowNumericType,
+        PrimitiveArray<ArrowDataType>: From<Vec<T>>,
+    {
+        for _ in 0..500 {
+            let data: Vec<T> = utils::get_random_array::<T>(5_000, min, max);
+            // Slice
+            let slice: &[T] = &data;
+            let (min_slice, max_slice) = slice.argminmax();
+            // Vec
+            let (min_vec, max_vec) = data.argminmax();
+            // Arrow
+            let arrow: PrimitiveArray<ArrowDataType> = PrimitiveArray::from(data);
+            let (min_arrow, max_arrow) = arrow.argminmax();
+
+            // Check
+            assert_eq!(min_slice, min_vec);
+            assert_eq!(max_slice, max_vec);
+            assert_eq!(min_slice, min_arrow);
+            assert_eq!(max_slice, max_arrow);
+        }
     }
 }


### PR DESCRIPTION
Closes #30, should in general "remove" a lot of duplicate unit test code :)

- [x] parameterize unit tests
  - [x] limit duplicate code using generic functions from `test_utils.rs`
  - [x] place unit tests at the bottom of each file (instead of between the code - at the end of the sub-mods)
- [x] parameterize integration tests

Decided to keep the tests in each file as this seems the best practice in Rust - see [quote from the book](https://doc.rust-lang.org/book/ch11-03-test-organization.html#unit-tests)
> You’ll put unit tests in the _src_ directory in each file with the code that they’re testing. The convention is to create a module named tests in each file to contain the test functions and to annotate the module with `cfg(test)`.

However, I placed the tests at the bottom of each file (which should significantly enhance the code readability) + limited duplication of tests through using parameterization & centralized generic code (in `test_utils.rs`).

Long story short, this PR should improve the maintainability & flexibility of the tests!