### PR TITLE
refactor: architecture - use type-state pattern

### DIFF
--- a/benches/bench_f16_return_nan.rs
+++ b/benches/bench_f16_return_nan.rs
@@ -6,9 +6,9 @@ use codspeed_criterion_compat::*;
 use dev_utils::{config, utils};
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-use argminmax::{SIMDArgMinMax, AVX2, AVX512, SSE};
+use argminmax::{FloatReturnNaN, SIMDArgMinMax, AVX2, AVX512, SSE};
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-use argminmax::{SIMDArgMinMax, NEON};
+use argminmax::{FloatReturnNaN, SIMDArgMinMax, NEON};
 use argminmax::{ScalarArgMinMax, SCALAR};
 
 #[cfg(feature = "half")]
@@ -44,31 +44,31 @@ fn argminmax_rn_f16_random_array_long(c: &mut Criterion) {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     if is_x86_feature_detected!("sse4.1") {
         c.bench_function("sse_f16_argminmax_rn", |b| {
-            b.iter(|| unsafe { SSE::argminmax(black_box(data)) })
+            b.iter(|| unsafe { SSE::<FloatReturnNaN>::argminmax(black_box(data)) })
         });
     }
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     if is_x86_feature_detected!("avx2") {
         c.bench_function("avx2_f16_argminmax_rn", |b| {
-            b.iter(|| unsafe { AVX2::argminmax(black_box(data)) })
+            b.iter(|| unsafe { AVX2::<FloatReturnNaN>::argminmax(black_box(data)) })
         });
     }
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     if is_x86_feature_detected!("avx512bw") {
         c.bench_function("avx512_f16_argminmax_rn", |b| {
-            b.iter(|| unsafe { AVX512::argminmax(black_box(data)) })
+            b.iter(|| unsafe { AVX512::<FloatReturnNaN>::argminmax(black_box(data)) })
         });
     }
     #[cfg(target_arch = "arm")]
     if std::arch::is_arm_feature_detected!("neon") {
         c.bench_function("neon_f16_argminmax_rn", |b| {
-            b.iter(|| unsafe { NEON::argminmax(black_box(data)) })
+            b.iter(|| unsafe { NEON::<FloatReturnNaN>::argminmax(black_box(data)) })
         });
     }
     #[cfg(target_arch = "aarch64")]
     if std::arch::is_aarch64_feature_detected!("neon") {
         c.bench_function("neon_f16_argminmax_rn", |b| {
-            b.iter(|| unsafe { NEON::argminmax(black_box(data)) })
+            b.iter(|| unsafe { NEON::<FloatReturnNaN>::argminmax(black_box(data)) })
         });
     }
     c.bench_function("impl_f16_argminmax_rn", |b| {

--- a/benches/bench_f16_return_nan.rs
+++ b/benches/bench_f16_return_nan.rs
@@ -39,7 +39,7 @@ fn argminmax_rn_f16_random_array_long(c: &mut Criterion) {
     let n = config::ARRAY_LENGTH_LONG;
     let data: &[f16] = &get_random_f16_array(n);
     c.bench_function("scalar_f16_argminmax_rn", |b| {
-        b.iter(|| SCALAR::argminmax(black_box(data)))
+        b.iter(|| SCALAR::<FloatReturnNaN>::argminmax(black_box(data)))
     });
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     if is_x86_feature_detected!("sse4.1") {

--- a/benches/bench_f32_ignore_nan.rs
+++ b/benches/bench_f32_ignore_nan.rs
@@ -8,7 +8,7 @@ use dev_utils::{config, utils};
 use argminmax::{FloatIgnoreNaN, SIMDArgMinMax, AVX2, AVX512, SSE};
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 use argminmax::{FloatIgnoreNaN, SIMDArgMinMax, NEON};
-use argminmax::{SCALARIgnoreNaN, ScalarArgMinMax};
+use argminmax::{ScalarArgMinMax, SCALAR};
 
 // _in stands for "ignore nan"
 
@@ -16,7 +16,7 @@ fn argminmax_in_f32_random_array_long(c: &mut Criterion) {
     let n = config::ARRAY_LENGTH_LONG;
     let data: &[f32] = &utils::get_random_array::<f32>(n, f32::MIN, f32::MAX);
     c.bench_function("scalar_f32_argminmax_in", |b| {
-        b.iter(|| SCALARIgnoreNaN::argminmax(black_box(data)))
+        b.iter(|| SCALAR::<FloatIgnoreNaN>::argminmax(black_box(data)))
     });
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     if is_x86_feature_detected!("sse4.1") {

--- a/benches/bench_f32_ignore_nan.rs
+++ b/benches/bench_f32_ignore_nan.rs
@@ -5,9 +5,9 @@ use codspeed_criterion_compat::*;
 use dev_utils::{config, utils};
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-use argminmax::{AVX2IgnoreNaN, AVX512IgnoreNaN, SIMDArgMinMaxIgnoreNaN, SSEIgnoreNaN};
+use argminmax::{FloatIgnoreNaN, SIMDArgMinMax, AVX2, AVX512, SSE};
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-use argminmax::{NEONIgnoreNaN, SIMDArgMinMaxIgnoreNaN};
+use argminmax::{FloatIgnoreNaN, SIMDArgMinMax, NEON};
 use argminmax::{SCALARIgnoreNaN, ScalarArgMinMax};
 
 // _in stands for "ignore nan"
@@ -21,31 +21,31 @@ fn argminmax_in_f32_random_array_long(c: &mut Criterion) {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     if is_x86_feature_detected!("sse4.1") {
         c.bench_function("sse_f32_argminmax_in", |b| {
-            b.iter(|| unsafe { SSEIgnoreNaN::argminmax(black_box(data)) })
+            b.iter(|| unsafe { SSE::<FloatIgnoreNaN>::argminmax(black_box(data)) })
         });
     }
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     if is_x86_feature_detected!("avx") {
         c.bench_function("avx_f32_argminmax_in", |b| {
-            b.iter(|| unsafe { AVX2IgnoreNaN::argminmax(black_box(data)) })
+            b.iter(|| unsafe { AVX2::<FloatIgnoreNaN>::argminmax(black_box(data)) })
         });
     }
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     if is_x86_feature_detected!("avx512f") {
         c.bench_function("avx512_f32_argminmax_in", |b| {
-            b.iter(|| unsafe { AVX512IgnoreNaN::argminmax(black_box(data)) })
+            b.iter(|| unsafe { AVX512::<FloatIgnoreNaN>::argminmax(black_box(data)) })
         });
     }
     #[cfg(target_arch = "arm")]
     if std::arch::is_arm_feature_detected!("neon") {
         c.bench_function("neon_f32_argminmax_in", |b| {
-            b.iter(|| unsafe { NEONIgnoreNaN::argminmax(black_box(data)) })
+            b.iter(|| unsafe { NEON::<FloatIgnoreNaN>::argminmax(black_box(data)) })
         });
     }
     #[cfg(target_arch = "aarch64")]
     if std::arch::is_aarch64_feature_detected!("neon") {
         c.bench_function("neon_f32_argminmax_in", |b| {
-            b.iter(|| unsafe { NEONIgnoreNaN::argminmax(black_box(data)) })
+            b.iter(|| unsafe { NEON::<FloatIgnoreNaN>::argminmax(black_box(data)) })
         });
     }
     c.bench_function("impl_f32_argminmax_in", |b| {

--- a/benches/bench_f32_return_nan.rs
+++ b/benches/bench_f32_return_nan.rs
@@ -5,9 +5,9 @@ use codspeed_criterion_compat::*;
 use dev_utils::{config, utils};
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-use argminmax::{SIMDArgMinMax, AVX2, AVX512, SSE};
+use argminmax::{FloatReturnNaN, SIMDArgMinMax, AVX2, AVX512, SSE};
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-use argminmax::{SIMDArgMinMax, NEON};
+use argminmax::{FloatReturnNaN, SIMDArgMinMax, NEON};
 use argminmax::{ScalarArgMinMax, SCALAR};
 
 // _rn stands for "return nan"
@@ -21,31 +21,31 @@ fn argminmax_rn_f32_random_array_long(c: &mut Criterion) {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     if is_x86_feature_detected!("sse4.1") {
         c.bench_function("sse_f32_argminmax_rn", |b| {
-            b.iter(|| unsafe { SSE::argminmax(black_box(data)) })
+            b.iter(|| unsafe { SSE::<FloatReturnNaN>::argminmax(black_box(data)) })
         });
     }
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     if is_x86_feature_detected!("avx2") {
         c.bench_function("avx2_f32_argminmax_rn", |b| {
-            b.iter(|| unsafe { AVX2::argminmax(black_box(data)) })
+            b.iter(|| unsafe { AVX2::<FloatReturnNaN>::argminmax(black_box(data)) })
         });
     }
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     if is_x86_feature_detected!("avx512f") {
         c.bench_function("avx512_f32_argminmax_rn", |b| {
-            b.iter(|| unsafe { AVX512::argminmax(black_box(data)) })
+            b.iter(|| unsafe { AVX512::<FloatReturnNaN>::argminmax(black_box(data)) })
         });
     }
     #[cfg(target_arch = "arm")]
     if std::arch::is_arm_feature_detected!("neon") {
         c.bench_function("neon_f32_argminmax_rn", |b| {
-            b.iter(|| unsafe { NEON::argminmax(black_box(data)) })
+            b.iter(|| unsafe { NEON::<FloatReturnNaN>::argminmax(black_box(data)) })
         });
     }
     #[cfg(target_arch = "aarch64")]
     if std::arch::is_aarch64_feature_detected!("neon") {
         c.bench_function("neon_f32_argminmax_rn", |b| {
-            b.iter(|| unsafe { NEON::argminmax(black_box(data)) })
+            b.iter(|| unsafe { NEON::<FloatReturnNaN>::argminmax(black_box(data)) })
         });
     }
     c.bench_function("impl_f32_argminmax_rn", |b| {

--- a/benches/bench_f32_return_nan.rs
+++ b/benches/bench_f32_return_nan.rs
@@ -16,7 +16,7 @@ fn argminmax_rn_f32_random_array_long(c: &mut Criterion) {
     let n = config::ARRAY_LENGTH_LONG;
     let data: &[f32] = &utils::get_random_array::<f32>(n, f32::MIN, f32::MAX);
     c.bench_function("scalar_f32_argminmax_rn", |b| {
-        b.iter(|| SCALAR::argminmax(black_box(data)))
+        b.iter(|| SCALAR::<FloatReturnNaN>::argminmax(black_box(data)))
     });
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     if is_x86_feature_detected!("sse4.1") {

--- a/benches/bench_f64_ignore_nan.rs
+++ b/benches/bench_f64_ignore_nan.rs
@@ -5,7 +5,7 @@ use codspeed_criterion_compat::*;
 use dev_utils::{config, utils};
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-use argminmax::{AVX2IgnoreNaN, AVX512IgnoreNaN, SIMDArgMinMaxIgnoreNaN, SSEIgnoreNaN};
+use argminmax::{FloatIgnoreNaN, SIMDArgMinMax, AVX2, AVX512, SSE};
 use argminmax::{SCALARIgnoreNaN, ScalarArgMinMax};
 
 // _in stands for "ignore nan"
@@ -19,19 +19,19 @@ fn argminmax_in_f64_random_array_long(c: &mut Criterion) {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     if is_x86_feature_detected!("sse4.1") {
         c.bench_function("sse_f64_argminmax_in", |b| {
-            b.iter(|| unsafe { SSEIgnoreNaN::argminmax(black_box(data)) })
+            b.iter(|| unsafe { SSE::<FloatIgnoreNaN>::argminmax(black_box(data)) })
         });
     }
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     if is_x86_feature_detected!("avx") {
         c.bench_function("avx_f64_argminmax_in", |b| {
-            b.iter(|| unsafe { AVX2IgnoreNaN::argminmax(black_box(data)) })
+            b.iter(|| unsafe { AVX2::<FloatIgnoreNaN>::argminmax(black_box(data)) })
         });
     }
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     if is_x86_feature_detected!("avx512f") {
         c.bench_function("avx512_f64_argminmax_in", |b| {
-            b.iter(|| unsafe { AVX512IgnoreNaN::argminmax(black_box(data)) })
+            b.iter(|| unsafe { AVX512::<FloatIgnoreNaN>::argminmax(black_box(data)) })
         });
     }
     c.bench_function("impl_f64_argminmax_in", |b| {

--- a/benches/bench_f64_ignore_nan.rs
+++ b/benches/bench_f64_ignore_nan.rs
@@ -4,9 +4,9 @@ use argminmax::ArgMinMax;
 use codspeed_criterion_compat::*;
 use dev_utils::{config, utils};
 
+use argminmax::{FloatIgnoreNaN, ScalarArgMinMax, SCALAR};
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-use argminmax::{FloatIgnoreNaN, SIMDArgMinMax, AVX2, AVX512, SSE};
-use argminmax::{ScalarArgMinMax, SCALAR};
+use argminmax::{SIMDArgMinMax, AVX2, AVX512, SSE};
 
 // _in stands for "ignore nan"
 

--- a/benches/bench_f64_ignore_nan.rs
+++ b/benches/bench_f64_ignore_nan.rs
@@ -6,7 +6,7 @@ use dev_utils::{config, utils};
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use argminmax::{FloatIgnoreNaN, SIMDArgMinMax, AVX2, AVX512, SSE};
-use argminmax::{SCALARIgnoreNaN, ScalarArgMinMax};
+use argminmax::{ScalarArgMinMax, SCALAR};
 
 // _in stands for "ignore nan"
 
@@ -14,7 +14,7 @@ fn argminmax_in_f64_random_array_long(c: &mut Criterion) {
     let n = config::ARRAY_LENGTH_LONG;
     let data: &[f64] = &utils::get_random_array::<f64>(n, f64::MIN, f64::MAX);
     c.bench_function("scalar_f64_argminmax_in", |b| {
-        b.iter(|| SCALARIgnoreNaN::argminmax(black_box(data)))
+        b.iter(|| SCALAR::<FloatIgnoreNaN>::argminmax(black_box(data)))
     });
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     if is_x86_feature_detected!("sse4.1") {

--- a/benches/bench_f64_return_nan.rs
+++ b/benches/bench_f64_return_nan.rs
@@ -5,7 +5,7 @@ use codspeed_criterion_compat::*;
 use dev_utils::{config, utils};
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-use argminmax::{SIMDArgMinMax, AVX2, AVX512, SSE};
+use argminmax::{FloatReturnNaN, SIMDArgMinMax, AVX2, AVX512, SSE};
 use argminmax::{ScalarArgMinMax, SCALAR};
 
 // _rn stands for "return nan"
@@ -19,19 +19,19 @@ fn argminmax_rn_f64_random_array_long(c: &mut Criterion) {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     if is_x86_feature_detected!("sse4.2") {
         c.bench_function("sse_f64_argminmax_rn", |b| {
-            b.iter(|| unsafe { SSE::argminmax(black_box(data)) })
+            b.iter(|| unsafe { SSE::<FloatReturnNaN>::argminmax(black_box(data)) })
         });
     }
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     if is_x86_feature_detected!("avx2") {
         c.bench_function("avx2_f64_argminmax_rn", |b| {
-            b.iter(|| unsafe { AVX2::argminmax(black_box(data)) })
+            b.iter(|| unsafe { AVX2::<FloatReturnNaN>::argminmax(black_box(data)) })
         });
     }
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     if is_x86_feature_detected!("avx512f") {
         c.bench_function("avx512_f64_argminmax_rn", |b| {
-            b.iter(|| unsafe { AVX512::argminmax(black_box(data)) })
+            b.iter(|| unsafe { AVX512::<FloatReturnNaN>::argminmax(black_box(data)) })
         });
     }
     c.bench_function("impl_f64_argminmax_rn", |b| {

--- a/benches/bench_f64_return_nan.rs
+++ b/benches/bench_f64_return_nan.rs
@@ -14,7 +14,7 @@ fn argminmax_rn_f64_random_array_long(c: &mut Criterion) {
     let n = config::ARRAY_LENGTH_LONG;
     let data: &[f64] = &utils::get_random_array::<f64>(n, f64::MIN, f64::MAX);
     c.bench_function("scalar_f64_argminmax_rn", |b| {
-        b.iter(|| SCALAR::argminmax(black_box(data)))
+        b.iter(|| SCALAR::<FloatReturnNaN>::argminmax(black_box(data)))
     });
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     if is_x86_feature_detected!("sse4.2") {

--- a/benches/bench_f64_return_nan.rs
+++ b/benches/bench_f64_return_nan.rs
@@ -4,9 +4,9 @@ use argminmax::ArgMinMax;
 use codspeed_criterion_compat::*;
 use dev_utils::{config, utils};
 
+use argminmax::{FloatReturnNaN, ScalarArgMinMax, SCALAR};
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-use argminmax::{FloatReturnNaN, SIMDArgMinMax, AVX2, AVX512, SSE};
-use argminmax::{ScalarArgMinMax, SCALAR};
+use argminmax::{SIMDArgMinMax, AVX2, AVX512, SSE};
 
 // _rn stands for "return nan"
 

--- a/src/dtype_strategy.rs
+++ b/src/dtype_strategy.rs
@@ -1,0 +1,5 @@
+/// The strategy that is used to handle the data type.
+
+pub(crate) struct Int; // Signed & Unsigned Integers
+pub(crate) struct FloatIgnoreNaN; // Floats, ignoring NaNs
+pub(crate) struct FloatReturnNaN; // Floats, returning NaNs

--- a/src/dtype_strategy.rs
+++ b/src/dtype_strategy.rs
@@ -1,5 +1,5 @@
 /// The strategy that is used to handle the data type.
 
-pub(crate) struct Int; // Signed & Unsigned Integers
-pub(crate) struct FloatIgnoreNaN; // Floats, ignoring NaNs
-pub(crate) struct FloatReturnNaN; // Floats, returning NaNs
+pub struct Int; // Signed & Unsigned Integers
+pub struct FloatIgnoreNaN; // Floats, ignoring NaNs
+pub struct FloatReturnNaN; // Floats, returning NaNs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,8 @@ mod dtype_strategy;
 mod scalar;
 mod simd;
 
-pub(crate) use dtype_strategy::{FloatIgnoreNaN, FloatReturnNaN, Int};
-pub use scalar::{SCALARIgnoreNaN, ScalarArgMinMax, SCALAR};
+pub use dtype_strategy::{FloatIgnoreNaN, FloatReturnNaN, Int};
+pub use scalar::{SCALARIgnoreNaN, ScalarArgMinMax, SCALAR}; // TODO: use typestate pattern
 pub use simd::{SIMDArgMinMax, AVX2, AVX512, NEON, SSE};
 
 #[cfg(feature = "half")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,13 +10,12 @@ use rstest_reuse;
 // #[macro_use]
 // extern crate lazy_static;
 
+mod dtype_strategy;
 mod scalar;
 mod simd;
 
+pub(crate) use dtype_strategy::{FloatIgnoreNaN, FloatReturnNaN, Int};
 pub use scalar::{SCALARIgnoreNaN, ScalarArgMinMax, SCALAR};
-pub use simd::{
-    AVX2IgnoreNaN, AVX512IgnoreNaN, NEONIgnoreNaN, SIMDArgMinMaxIgnoreNaN, SSEIgnoreNaN,
-};
 pub use simd::{SIMDArgMinMax, AVX2, AVX512, NEON, SSE};
 
 #[cfg(feature = "half")]
@@ -87,28 +86,28 @@ macro_rules! impl_argminmax_non_float {
                     {
                         if is_x86_feature_detected!("sse4.1") & (<$int_type>::NB_BITS == 8) {
                             // 8-bit numbers are best handled by SSE4.1
-                            return unsafe { SSE::argminmax(self) }
+                            return unsafe { SSE::<Int>::argminmax(self) }
                         } else if is_x86_feature_detected!("avx512bw") & (<$int_type>::NB_BITS <= 16) {
                             // BW (ByteWord) instructions are needed for 8 or 16-bit avx512
-                            return unsafe { AVX512::argminmax(self) }
+                            return unsafe { AVX512::<Int>::argminmax(self) }
                         } else if is_x86_feature_detected!("avx512f") {  // TODO: check if avx512bw is included in avx512f
-                            return unsafe { AVX512::argminmax(self) }
+                            return unsafe { AVX512::<Int>::argminmax(self) }
                         } else if is_x86_feature_detected!("avx2") {
-                            return unsafe { AVX2::argminmax(self) }
+                            return unsafe { AVX2::<Int>::argminmax(self) }
                         // SKIP SSE4.2 bc scalar is faster or equivalent for 64 bit numbers
                         // // } else if is_x86_feature_detected!("sse4.2") & (<$int_type>::NB_BITS == 64) & (<$int_type>::IS_FLOAT == false) {
                         //     // SSE4.2 is needed for comparing 64-bit integers
                         //     return unsafe { SSE::argminmax(self) }
                         } else if is_x86_feature_detected!("sse4.1") & (<$int_type>::NB_BITS < 64) {
                             // Scalar is faster for 64-bit numbers
-                            return unsafe { SSE::argminmax(self) }
+                            return unsafe { SSE::<Int>::argminmax(self) }
                         }
                     }
                     #[cfg(target_arch = "aarch64")]
                     {
                         if std::arch::is_aarch64_feature_detected!("neon") & (<$int_type>::NB_BITS < 64) {
                             // We miss some NEON instructions for 64-bit numbers
-                            return unsafe { NEON::argminmax(self) }
+                            return unsafe { NEON::<Int>::argminmax(self) }
                         }
                     }
                     #[cfg(target_arch = "arm")]
@@ -116,7 +115,7 @@ macro_rules! impl_argminmax_non_float {
                         if std::arch::is_arm_feature_detected!("neon") & (<$int_type>::NB_BITS < 64) {
                             // TODO: requires v7?
                             // We miss some NEON instructions for 64-bit numbers
-                            return unsafe { NEON::argminmax(self) }
+                            return unsafe { NEON::<Int>::argminmax(self) }
                         }
                     }
                     SCALAR::argminmax(self)
@@ -143,26 +142,26 @@ macro_rules! impl_argminmax_float {
                     {
                         if is_x86_feature_detected!("sse4.1") & (<$float_type>::NB_BITS == 8) {
                             // 8-bit numbers are best handled by SSE4.1
-                            return unsafe { SSE::argminmax(self) }
+                            return unsafe { SSE::<FloatReturnNaN>::argminmax(self) }
                         } else if is_x86_feature_detected!("avx512bw") & (<$float_type>::NB_BITS <= 16) {
                             // BW (ByteWord) instructions are needed for 8 or 16-bit avx512
-                            return unsafe { AVX512::argminmax(self) }
+                            return unsafe { AVX512::<FloatReturnNaN>::argminmax(self) }
                         } else if is_x86_feature_detected!("avx512f") {  // TODO: check if avx512bw is included in avx512f
-                            return unsafe { AVX512::argminmax(self) }
+                            return unsafe { AVX512::<FloatReturnNaN>::argminmax(self) }
                         } else if is_x86_feature_detected!("avx2") {
-                            return unsafe { AVX2::argminmax(self) }
+                            return unsafe { AVX2::<FloatReturnNaN>::argminmax(self) }
                         // SKIP SSE4.2 bc scalar is faster or equivalent for 64 bit numbers
                         } else if is_x86_feature_detected!("sse4.1") & (<$float_type>::NB_BITS < 64) {
                             // Scalar is faster for 64-bit numbers
                             // TODO: double check this (observed different things for new float implementation)
-                            return unsafe { SSE::argminmax(self) }
+                            return unsafe { SSE::<FloatReturnNaN>::argminmax(self) }
                         }
                     }
                     #[cfg(target_arch = "aarch64")]
                     {
                         if std::arch::is_aarch64_feature_detected!("neon") & (<$float_type>::NB_BITS < 64) {
                             // We miss some NEON instructions for 64-bit numbers
-                            return unsafe { NEON::argminmax(self) }
+                            return unsafe { NEON::<FloatReturnNaN>::argminmax(self) }
                         }
                     }
                     #[cfg(target_arch = "arm")]
@@ -170,7 +169,7 @@ macro_rules! impl_argminmax_float {
                         if std::arch::is_arm_feature_detected!("neon") & (<$float_type>::NB_BITS < 64) {
                             // TODO: requires v7?
                             // We miss some NEON instructions for 64-bit numbers
-                            return unsafe { NEON::argminmax(self) }
+                            return unsafe { NEON::<FloatReturnNaN>::argminmax(self) }
                         }
                     }
                     SCALAR::argminmax(self)
@@ -182,20 +181,20 @@ macro_rules! impl_argminmax_float {
                             // TODO: f16 IgnoreNaN is not yet SIMD-optimized
                             // do nothing (defaults to scalar)
                         } else if is_x86_feature_detected!("avx512f") {
-                            return unsafe { AVX512IgnoreNaN::argminmax(self) }
+                            return unsafe { AVX512::<FloatIgnoreNaN>::argminmax(self) }
                         } else if is_x86_feature_detected!("avx") {
                             // f32 and f64 do not require avx2
-                            return unsafe { AVX2IgnoreNaN::argminmax(self) }
+                            return unsafe { AVX2::<FloatIgnoreNaN>::argminmax(self) }
                         } else if is_x86_feature_detected!("sse4.1") & (<$float_type>::NB_BITS < 64) {
                             // Scalar is faster for 64-bit numbers
-                            return unsafe { SSEIgnoreNaN::argminmax(self) }
+                            return unsafe { SSE::<FloatIgnoreNaN>::argminmax(self) }
                         }
                     }
                     #[cfg(target_arch = "aarch64")]
                     {
                         if std::arch::is_aarch64_feature_detected!("neon") & (<$float_type>::NB_BITS < 64) {
                             // We miss some NEON instructions for 64-bit numbers
-                            return unsafe { NEONIgnoreNaN::argminmax(self) }
+                            return unsafe { NEON::<FloatIgnoreNaN>::argminmax(self) }
                         }
                     }
                     #[cfg(target_arch = "arm")]
@@ -203,7 +202,7 @@ macro_rules! impl_argminmax_float {
                         if std::arch::is_arm_feature_detected!("neon") & (<$float_type>::NB_BITS < 64) {
                             // TODO: requires v7?
                             // We miss some NEON instructions for 64-bit numbers
-                            return unsafe { NEONIgnoreNaN::argminmax(self) }
+                            return unsafe { NEON::<FloatIgnoreNaN>::argminmax(self) }
                         }
                     }
                     SCALARIgnoreNaN::argminmax(self)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ mod scalar;
 mod simd;
 
 pub use dtype_strategy::{FloatIgnoreNaN, FloatReturnNaN, Int};
-pub use scalar::{SCALARIgnoreNaN, ScalarArgMinMax, SCALAR}; // TODO: use typestate pattern
+pub use scalar::{ScalarArgMinMax, SCALAR};
 pub use simd::{SIMDArgMinMax, AVX2, AVX512, NEON, SSE};
 
 #[cfg(feature = "half")]
@@ -118,7 +118,7 @@ macro_rules! impl_argminmax_non_float {
                             return unsafe { NEON::<Int>::argminmax(self) }
                         }
                     }
-                    SCALAR::argminmax(self)
+                    SCALAR::<Int>::argminmax(self)
                 }
 
                 // As there are no NaNs when NOT using floats -> just use argminmax
@@ -172,7 +172,7 @@ macro_rules! impl_argminmax_float {
                             return unsafe { NEON::<FloatReturnNaN>::argminmax(self) }
                         }
                     }
-                    SCALAR::argminmax(self)
+                    SCALAR::<FloatReturnNaN>::argminmax(self)
                 }
                 fn argminmax(&self) -> (usize, usize) {
                     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -205,7 +205,7 @@ macro_rules! impl_argminmax_float {
                             return unsafe { NEON::<FloatIgnoreNaN>::argminmax(self) }
                         }
                     }
-                    SCALARIgnoreNaN::argminmax(self)
+                    SCALAR::<FloatIgnoreNaN>::argminmax(self)
                 }
             }
         )*

--- a/src/scalar/mod.rs
+++ b/src/scalar/mod.rs
@@ -1,4 +1,4 @@
-pub(crate) mod generic;
-pub use generic::*;
-// Data type specific modules
-pub(crate) mod scalar_f16;
+mod generic;
+pub use generic::{ScalarArgMinMax, SCALAR};
+// Data type specific modules}
+mod scalar_f16;

--- a/src/scalar/mod.rs
+++ b/src/scalar/mod.rs
@@ -1,4 +1,4 @@
 mod generic;
 pub use generic::{ScalarArgMinMax, SCALAR};
-// Data type specific modules}
+// Data type specific modules
 mod scalar_f16;

--- a/src/simd/config.rs
+++ b/src/simd/config.rs
@@ -5,6 +5,7 @@
 /// More info on SIMD:
 /// https://github.com/rust-lang/portable-simd/blob/master/beginners-guide.md#target-features
 ///
+use std::marker::PhantomData;
 
 /// SIMD instruction set trait - used to store the register size and get the lane size
 /// for a given datatype
@@ -31,7 +32,7 @@ pub trait SIMDInstructionSet {
 /// - floats: returning NaNs (see simd_f*_return_nan.rs files) - FloatReturnNan DTypeStrategy
 /// - floats: ignoring NaNs (see simd_f*_ignore_nan.rs files) - FloatIgnoreNaN DTypeStrategy
 pub struct SSE<DTypeStrategy> {
-    pub(crate) _dtype_strategy: DTypeStrategy,
+    pub(crate) _dtype_strategy: PhantomData<DTypeStrategy>,
 }
 
 impl<DTypeStrategy> SIMDInstructionSet for SSE<DTypeStrategy> {
@@ -48,7 +49,7 @@ impl<DTypeStrategy> SIMDInstructionSet for SSE<DTypeStrategy> {
 ///     ! important remark: AVX is enough for f32 and f64, but we need AVX2 for f16
 ///     -> f16 is currently not yet implemented (TODO)
 pub struct AVX2<DTypeStrategy> {
-    pub(crate) _dtype_strategy: DTypeStrategy,
+    pub(crate) _dtype_strategy: PhantomData<DTypeStrategy>,
 }
 
 impl<DTypeStrategy> SIMDInstructionSet for AVX2<DTypeStrategy> {
@@ -64,7 +65,7 @@ impl<DTypeStrategy> SIMDInstructionSet for AVX2<DTypeStrategy> {
 /// - floats: returning NaNs (see simd_f*_return_nan.rs files) - FloatReturnNan DTypeStrategy
 /// - floats: ignoring NaNs (see simd_f*_ignore_nan.rs files) - FloatIgnoreNaN DTypeStrategy
 pub struct AVX512<DTypeStrategy> {
-    pub(crate) _dtype_strategy: DTypeStrategy,
+    pub(crate) _dtype_strategy: PhantomData<DTypeStrategy>,
 }
 
 impl<DTypeStrategy> SIMDInstructionSet for AVX512<DTypeStrategy> {
@@ -84,7 +85,7 @@ impl<DTypeStrategy> SIMDInstructionSet for AVX512<DTypeStrategy> {
 /// Note: there are no NEON instructions for 64-bit numbers, so for 64-bit numbers we
 /// fall back to the scalar implementation.
 pub struct NEON<DTypeStrategy> {
-    pub(crate) _dtype_strategy: DTypeStrategy,
+    pub(crate) _dtype_strategy: PhantomData<DTypeStrategy>,
 }
 
 impl<DTypeStrategy> SIMDInstructionSet for NEON<DTypeStrategy> {

--- a/src/simd/config.rs
+++ b/src/simd/config.rs
@@ -1,4 +1,10 @@
-// https://github.com/rust-lang/portable-simd/blob/master/beginners-guide.md#target-features
+/// This module contains structs and traits that are used to configure the SIMD
+/// implementation. The structs are used to store the register size and the trait is
+/// used to get the lane size for a given datatype.
+///
+/// More info on SIMD:
+/// https://github.com/rust-lang/portable-simd/blob/master/beginners-guide.md#target-features
+///
 
 /// SIMD instruction set trait - used to store the register size and get the lane size
 /// for a given datatype
@@ -20,36 +26,32 @@ pub trait SIMDInstructionSet {
 // ----------------------------------- x86_64 / x86 ------------------------------------
 
 /// SSE instruction set - this will be implemented for all:
-/// - ints (see, the simd_i*.rs files)
-/// - uints (see, the simd_u*.rs files)
-/// - floats: returning NaNs (see, the simd_f*_return_nan.rs files)
-pub struct SSE;
-/// SSE instruction set - this will be implemented for all:
-/// - floats: ignoring NaNs (see, the `simd_f*_ignore_nan.rs` files)
-pub struct SSEIgnoreNaN;
+/// - ints (see simd_i*.rs files) - Int DTypeStrategy
+/// - uints (see simd_u*.rs files) - Int DTypeStrategy
+/// - floats: returning NaNs (see simd_f*_return_nan.rs files) - FloatReturnNan DTypeStrategy
+/// - floats: ignoring NaNs (see simd_f*_ignore_nan.rs files) - FloatIgnoreNaN DTypeStrategy
+pub struct SSE<DTypeStrategy> {
+    pub(crate) _dtype_strategy: DTypeStrategy,
+}
 
-impl SIMDInstructionSet for SSE {
+impl<DTypeStrategy> SIMDInstructionSet for SSE<DTypeStrategy> {
     /// SSE register size is 128 bits
     /// https://en.wikipedia.org/wiki/Streaming_SIMD_Extensions#Registers
     const REGISTER_SIZE: usize = 128;
 }
 
 /// AVX2 instruction set - this will be implemented for all:
-/// - ints (see, the simd_i*.rs files)
-/// - uints (see, the simd_u*.rs files)
-/// - floats: returning NaNs (see, the simd_f*_return_nan.rs files)
-pub struct AVX2;
+/// - ints (see simd_i*.rs files) - Int DTypeStrategy
+/// - uints (see simd_u*.rs files) - Int DTypeStrategy
+/// - floats: returning NaNs (see simd_f*_return_nan.rs files) - FloatReturnNan DTypeStrategy
+/// - floats: ignoring NaNs (see simd_f*_ignore_nan.rs files) - FloatIgnoreNaN DTypeStrategy
+///     ! important remark: AVX is enough for f32 and f64, but we need AVX2 for f16
+///     -> f16 is currently not yet implemented (TODO)
+pub struct AVX2<DTypeStrategy> {
+    pub(crate) _dtype_strategy: DTypeStrategy,
+}
 
-/// AVX(2) instruction set - this will be implemented for all:
-/// - floats: ignoring NaNs (see, the `simd_f*_ignore_nan.rs` files)
-///
-/// Important remark: AVX is enough for f32 and f64!
-/// -> for f16 we need AVX2 - but this is currently not yet implemented (TODO)
-///
-/// Note: this struct does not implement the `SIMDInstructionSet` trait
-pub struct AVX2IgnoreNaN;
-
-impl SIMDInstructionSet for AVX2 {
+impl<DTypeStrategy> SIMDInstructionSet for AVX2<DTypeStrategy> {
     /// AVX(2) register size is 256 bits
     /// AVX:  https://en.wikipedia.org/wiki/Advanced_Vector_Extensions#Advanced_Vector_Extensions
     /// AVX2: https://en.wikipedia.org/wiki/Advanced_Vector_Extensions#AVX2
@@ -57,18 +59,15 @@ impl SIMDInstructionSet for AVX2 {
 }
 
 /// AVX512 instruction set - this will be implemented for all:
-/// - ints (see, the simd_i*.rs files)
-/// - uints (see, the simd_u*.rs files)
-/// - floats: returning NaNs (see, the simd_f*_return_nan.rs files)
-pub struct AVX512;
+/// - ints (see simd_i*.rs files) - Int DTypeStrategy
+/// - uints (see simd_u*.rs files) - Int DTypeStrategy
+/// - floats: returning NaNs (see simd_f*_return_nan.rs files) - FloatReturnNan DTypeStrategy
+/// - floats: ignoring NaNs (see simd_f*_ignore_nan.rs files) - FloatIgnoreNaN DTypeStrategy
+pub struct AVX512<DTypeStrategy> {
+    pub(crate) _dtype_strategy: DTypeStrategy,
+}
 
-/// AVX512 instruction set - this will be implemented for all:
-/// - floats: ignoring NaNs (see, the `simd_f*_ignore_nan.rs` files)
-///
-/// Note: this struct does not implement the `SIMDInstructionSet` trait
-pub struct AVX512IgnoreNaN;
-
-impl SIMDInstructionSet for AVX512 {
+impl<DTypeStrategy> SIMDInstructionSet for AVX512<DTypeStrategy> {
     /// AVX512 register size is 512 bits
     /// https://en.wikipedia.org/wiki/Advanced_Vector_Extensions#AVX-512
     const REGISTER_SIZE: usize = 512;
@@ -77,118 +76,130 @@ impl SIMDInstructionSet for AVX512 {
 // ----------------------------------- aarch64 / arm -----------------------------------
 
 /// NEON instruction set - this will be implemented for all:
-/// - ints (see, the simd_i*.rs files)
-/// - uints (see, the simd_u*.rs files)
-/// - floats: returning NaNs (see, the simd_f*_return_nan.rs files)
-pub struct NEON;
-
-/// NEON instruction set - this will be implemented for all:
-/// - floats: ignoring NaNs (see, the `simd_f*_ignore_nan.rs` files)
+/// - ints (see simd_i*.rs files) - Int DTypeStrategy
+/// - uints (see simd_u*.rs files) - Int DTypeStrategy
+/// - floats: returning NaNs (see simd_f*_return_nan.rs files) - FloatReturnNan DTypeStrategy
+/// - floats: ignoring NaNs (see simd_f*_ignore_nan.rs files) - FloatIgnoreNaN DTypeStrategy
 ///
-/// Note: this struct does not implement the `SIMDInstructionSet` trait
-pub struct NEONIgnoreNaN;
+/// Note: there are no NEON instructions for 64-bit numbers, so for 64-bit numbers we
+/// fall back to the scalar implementation.
+pub struct NEON<DTypeStrategy> {
+    pub(crate) _dtype_strategy: DTypeStrategy,
+}
 
-impl SIMDInstructionSet for NEON {
+impl<DTypeStrategy> SIMDInstructionSet for NEON<DTypeStrategy> {
     /// NEON register size is 128 bits
     /// https://en.wikipedia.org/wiki/ARM_architecture#Advanced_SIMD_(Neon)
     const REGISTER_SIZE: usize = 128;
 }
 
-// --------------------------------------- Tests ---------------------------------------
+// ======================================= TESTS =======================================
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::dtype_strategy::*;
+
+    use rstest::rstest;
+    use rstest_reuse::{self, *};
 
     #[cfg(feature = "half")]
     use half::f16;
 
+    // The DTypeStrategy should not influence the lane size
+    #[template]
+    #[rstest]
+    #[case::int(Int)]
+    #[case::float_return_nan(FloatIgnoreNaN)]
+    #[case::float_ignore_nan(FloatReturnNaN)]
+    fn dtype_strategies<DTypeStrategy>(#[case] _dtype_strategy: DTypeStrategy) {}
+
     #[cfg(feature = "half")]
-    #[test]
-    fn test_lane_size_f16() {
-        assert_eq!(AVX2::get_lane_size::<f16>(), 16);
-        assert_eq!(AVX512::get_lane_size::<f16>(), 32);
-        assert_eq!(NEON::get_lane_size::<f16>(), 8);
-        assert_eq!(SSE::get_lane_size::<f16>(), 8);
+    #[apply(dtype_strategies)]
+    fn test_lane_size_f16<DTypeStrategy>(#[case] _dtype_strategy: DTypeStrategy) {
+        assert_eq!(SSE::<DTypeStrategy>::get_lane_size::<f16>(), 8);
+        assert_eq!(AVX2::<DTypeStrategy>::get_lane_size::<f16>(), 16);
+        assert_eq!(AVX512::<DTypeStrategy>::get_lane_size::<f16>(), 32);
+        assert_eq!(NEON::<DTypeStrategy>::get_lane_size::<f16>(), 8);
     }
 
-    #[test]
-    fn test_lane_size_f32() {
-        assert_eq!(AVX2::get_lane_size::<f32>(), 8);
-        assert_eq!(AVX512::get_lane_size::<f32>(), 16);
-        assert_eq!(NEON::get_lane_size::<f32>(), 4);
-        assert_eq!(SSE::get_lane_size::<f32>(), 4);
+    #[apply(dtype_strategies)]
+    fn test_lane_size_f32<DTypeStrategy>(#[case] _dtype_strategy: DTypeStrategy) {
+        assert_eq!(SSE::<DTypeStrategy>::get_lane_size::<f32>(), 4);
+        assert_eq!(AVX2::<DTypeStrategy>::get_lane_size::<f32>(), 8);
+        assert_eq!(AVX512::<DTypeStrategy>::get_lane_size::<f32>(), 16);
+        assert_eq!(NEON::<DTypeStrategy>::get_lane_size::<f32>(), 4);
     }
 
-    #[test]
-    fn test_lane_size_f64() {
-        assert_eq!(AVX2::get_lane_size::<f64>(), 4);
-        assert_eq!(AVX512::get_lane_size::<f64>(), 8);
-        assert_eq!(NEON::get_lane_size::<f64>(), 2);
-        assert_eq!(SSE::get_lane_size::<f64>(), 2);
+    #[apply(dtype_strategies)]
+    fn test_lane_size_f64<DTypeStrategy>(#[case] _dtype_strategy: DTypeStrategy) {
+        assert_eq!(SSE::<DTypeStrategy>::get_lane_size::<f64>(), 2);
+        assert_eq!(AVX2::<DTypeStrategy>::get_lane_size::<f64>(), 4);
+        assert_eq!(AVX512::<DTypeStrategy>::get_lane_size::<f64>(), 8);
+        assert_eq!(NEON::<DTypeStrategy>::get_lane_size::<f64>(), 2);
     }
 
-    #[test]
-    fn test_lane_size_i8() {
-        assert_eq!(AVX2::get_lane_size::<i8>(), 32);
-        assert_eq!(AVX512::get_lane_size::<i8>(), 64);
-        assert_eq!(NEON::get_lane_size::<i8>(), 16);
-        assert_eq!(SSE::get_lane_size::<i8>(), 16);
+    #[apply(dtype_strategies)]
+    fn test_lane_size_i8<DTypeStrategy>(#[case] _dtype_strategy: DTypeStrategy) {
+        assert_eq!(SSE::<DTypeStrategy>::get_lane_size::<i8>(), 16);
+        assert_eq!(AVX2::<DTypeStrategy>::get_lane_size::<i8>(), 32);
+        assert_eq!(AVX512::<DTypeStrategy>::get_lane_size::<i8>(), 64);
+        assert_eq!(NEON::<DTypeStrategy>::get_lane_size::<i8>(), 16);
     }
 
-    #[test]
-    fn test_lane_size_i16() {
-        assert_eq!(AVX2::get_lane_size::<i16>(), 16);
-        assert_eq!(AVX512::get_lane_size::<i16>(), 32);
-        assert_eq!(NEON::get_lane_size::<i16>(), 8);
-        assert_eq!(SSE::get_lane_size::<i16>(), 8);
+    #[apply(dtype_strategies)]
+    fn test_lane_size_i16<DTypeStrategy>(#[case] _dtype_strategy: DTypeStrategy) {
+        assert_eq!(SSE::<DTypeStrategy>::get_lane_size::<i16>(), 8);
+        assert_eq!(AVX2::<DTypeStrategy>::get_lane_size::<i16>(), 16);
+        assert_eq!(AVX512::<DTypeStrategy>::get_lane_size::<i16>(), 32);
+        assert_eq!(NEON::<DTypeStrategy>::get_lane_size::<i16>(), 8);
     }
 
-    #[test]
-    fn test_lane_size_i32() {
-        assert_eq!(AVX2::get_lane_size::<i32>(), 8);
-        assert_eq!(AVX512::get_lane_size::<i32>(), 16);
-        assert_eq!(NEON::get_lane_size::<i32>(), 4);
-        assert_eq!(SSE::get_lane_size::<i32>(), 4);
+    #[apply(dtype_strategies)]
+    fn test_lane_size_i32<DTypeStrategy>(#[case] _dtype_strategy: DTypeStrategy) {
+        assert_eq!(SSE::<DTypeStrategy>::get_lane_size::<i32>(), 4);
+        assert_eq!(AVX2::<DTypeStrategy>::get_lane_size::<i32>(), 8);
+        assert_eq!(AVX512::<DTypeStrategy>::get_lane_size::<i32>(), 16);
+        assert_eq!(NEON::<DTypeStrategy>::get_lane_size::<i32>(), 4);
     }
 
-    #[test]
-    fn test_lane_size_i64() {
-        assert_eq!(AVX2::get_lane_size::<i64>(), 4);
-        assert_eq!(AVX512::get_lane_size::<i64>(), 8);
-        assert_eq!(NEON::get_lane_size::<i64>(), 2);
-        assert_eq!(SSE::get_lane_size::<i64>(), 2);
+    #[apply(dtype_strategies)]
+    fn test_lane_size_i64<DTypeStrategy>(#[case] _dtype_strategy: DTypeStrategy) {
+        assert_eq!(SSE::<DTypeStrategy>::get_lane_size::<i64>(), 2);
+        assert_eq!(AVX2::<DTypeStrategy>::get_lane_size::<i64>(), 4);
+        assert_eq!(AVX512::<DTypeStrategy>::get_lane_size::<i64>(), 8);
+        assert_eq!(NEON::<DTypeStrategy>::get_lane_size::<i64>(), 2);
     }
 
-    #[test]
-    fn test_lane_size_u8() {
-        assert_eq!(AVX2::get_lane_size::<u8>(), 32);
-        assert_eq!(AVX512::get_lane_size::<u8>(), 64);
-        assert_eq!(NEON::get_lane_size::<u8>(), 16);
-        assert_eq!(SSE::get_lane_size::<u8>(), 16);
+    #[apply(dtype_strategies)]
+    fn test_lane_size_u8<DTypeStrategy>(#[case] _dtype_strategy: DTypeStrategy) {
+        assert_eq!(SSE::<DTypeStrategy>::get_lane_size::<u8>(), 16);
+        assert_eq!(AVX2::<DTypeStrategy>::get_lane_size::<u8>(), 32);
+        assert_eq!(AVX512::<DTypeStrategy>::get_lane_size::<u8>(), 64);
+        assert_eq!(NEON::<DTypeStrategy>::get_lane_size::<u8>(), 16);
     }
 
-    #[test]
-    fn test_lane_size_u16() {
-        assert_eq!(AVX2::get_lane_size::<u16>(), 16);
-        assert_eq!(AVX512::get_lane_size::<u16>(), 32);
-        assert_eq!(NEON::get_lane_size::<u16>(), 8);
-        assert_eq!(SSE::get_lane_size::<u16>(), 8);
+    #[apply(dtype_strategies)]
+    fn test_lane_size_u16<DTypeStrategy>(#[case] _dtype_strategy: DTypeStrategy) {
+        assert_eq!(SSE::<DTypeStrategy>::get_lane_size::<u16>(), 8);
+        assert_eq!(AVX2::<DTypeStrategy>::get_lane_size::<u16>(), 16);
+        assert_eq!(AVX512::<DTypeStrategy>::get_lane_size::<u16>(), 32);
+        assert_eq!(NEON::<DTypeStrategy>::get_lane_size::<u16>(), 8);
     }
 
-    #[test]
-    fn test_lane_size_u32() {
-        assert_eq!(AVX2::get_lane_size::<u32>(), 8);
-        assert_eq!(AVX512::get_lane_size::<u32>(), 16);
-        assert_eq!(NEON::get_lane_size::<u32>(), 4);
-        assert_eq!(SSE::get_lane_size::<u32>(), 4);
+    #[apply(dtype_strategies)]
+    fn test_lane_size_u32<DTypeStrategy>(#[case] _dtype_strategy: DTypeStrategy) {
+        assert_eq!(SSE::<DTypeStrategy>::get_lane_size::<u32>(), 4);
+        assert_eq!(AVX2::<DTypeStrategy>::get_lane_size::<u32>(), 8);
+        assert_eq!(AVX512::<DTypeStrategy>::get_lane_size::<u32>(), 16);
+        assert_eq!(NEON::<DTypeStrategy>::get_lane_size::<u32>(), 4);
     }
 
-    #[test]
-    fn test_lane_size_u64() {
-        assert_eq!(AVX2::get_lane_size::<u64>(), 4);
-        assert_eq!(AVX512::get_lane_size::<u64>(), 8);
-        assert_eq!(NEON::get_lane_size::<u64>(), 2);
-        assert_eq!(SSE::get_lane_size::<u64>(), 2);
+    #[apply(dtype_strategies)]
+    fn test_lane_size_u64<DTypeStrategy>(#[case] _dtype_strategy: DTypeStrategy) {
+        assert_eq!(SSE::<DTypeStrategy>::get_lane_size::<u64>(), 2);
+        assert_eq!(AVX2::<DTypeStrategy>::get_lane_size::<u64>(), 4);
+        assert_eq!(AVX512::<DTypeStrategy>::get_lane_size::<u64>(), 8);
+        assert_eq!(NEON::<DTypeStrategy>::get_lane_size::<u64>(), 2);
     }
 }

--- a/src/simd/mod.rs
+++ b/src/simd/mod.rs
@@ -6,7 +6,7 @@ pub use config::*;
 mod generic;
 pub use generic::*;
 // FLOAT
-#[cfg(feature = "half")] // TODOL can I remove all #[cfg(feature = "half")] in this file?
+#[cfg(feature = "half")] // TODO: can I remove all #[cfg(feature = "half")] in this file?
 mod simd_f16_ignore_nan; // TODO: not supported yet
 #[cfg(feature = "half")]
 mod simd_f16_return_nan;

--- a/src/simd/mod.rs
+++ b/src/simd/mod.rs
@@ -6,7 +6,9 @@ pub use config::*;
 mod generic;
 pub use generic::*;
 // FLOAT
+#[cfg(feature = "half")] // TODOL can I remove all #[cfg(feature = "half")] in this file?
 mod simd_f16_ignore_nan; // TODO: not supported yet
+#[cfg(feature = "half")]
 mod simd_f16_return_nan;
 mod simd_f32_ignore_nan;
 mod simd_f32_return_nan;

--- a/src/simd/simd_f16_ignore_nan.rs
+++ b/src/simd/simd_f16_ignore_nan.rs
@@ -8,7 +8,7 @@ use super::generic::{unimpl_SIMDArgMinMax, unimpl_SIMDInit, unimpl_SIMDOps};
 #[cfg(feature = "half")]
 use super::generic::{SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(feature = "half")]
-use crate::SCALARIgnoreNaN;
+use crate::SCALAR;
 
 #[cfg(feature = "half")]
 use half::f16;
@@ -26,7 +26,7 @@ mod avx2_ignore_nan {
 
     unimpl_SIMDOps!(f16, usize, AVX2<FloatIgnoreNaN>);
     unimpl_SIMDInit!(f16, usize, AVX2<FloatIgnoreNaN>);
-    unimpl_SIMDArgMinMax!(f16, usize, SCALARIgnoreNaN, AVX2<FloatIgnoreNaN>);
+    unimpl_SIMDArgMinMax!(f16, usize, SCALAR<FloatIgnoreNaN>, AVX2<FloatIgnoreNaN>);
 }
 
 // ---------------------------------------- SSE ----------------------------------------
@@ -39,7 +39,7 @@ mod sse_ignore_nan {
 
     unimpl_SIMDOps!(f16, usize, SSE<FloatIgnoreNaN>);
     unimpl_SIMDInit!(f16, usize, SSE<FloatIgnoreNaN>);
-    unimpl_SIMDArgMinMax!(f16, usize, SCALARIgnoreNaN, SSE<FloatIgnoreNaN>);
+    unimpl_SIMDArgMinMax!(f16, usize, SCALAR<FloatIgnoreNaN>, SSE<FloatIgnoreNaN>);
 }
 
 // -------------------------------------- AVX512 ---------------------------------------
@@ -52,7 +52,7 @@ mod avx512_ignore_nan {
 
     unimpl_SIMDOps!(f16, usize, AVX512<FloatIgnoreNaN>);
     unimpl_SIMDInit!(f16, usize, AVX512<FloatIgnoreNaN>);
-    unimpl_SIMDArgMinMax!(f16, usize, SCALARIgnoreNaN, AVX512<FloatIgnoreNaN>);
+    unimpl_SIMDArgMinMax!(f16, usize, SCALAR<FloatIgnoreNaN>, AVX512<FloatIgnoreNaN>);
 }
 
 // --------------------------------------- NEON ----------------------------------------
@@ -65,5 +65,5 @@ mod neon_ignore_nan {
 
     unimpl_SIMDOps!(f16, usize, NEON<FloatIgnoreNaN>);
     unimpl_SIMDInit!(f16, usize, NEON<FloatIgnoreNaN>);
-    unimpl_SIMDArgMinMax!(f16, usize, SCALARIgnoreNaN, NEON<FloatIgnoreNaN>);
+    unimpl_SIMDArgMinMax!(f16, usize, SCALAR<FloatIgnoreNaN>, NEON<FloatIgnoreNaN>);
 }

--- a/src/simd/simd_f16_ignore_nan.rs
+++ b/src/simd/simd_f16_ignore_nan.rs
@@ -4,23 +4,29 @@
 // #[cfg(feature = "half")]
 // use super::config::SIMDInstructionSet;
 #[cfg(feature = "half")]
-use super::generic::{unimpl_SIMDArgMinMaxIgnoreNaN, unimpl_SIMDOps};
+use super::generic::{unimpl_SIMDArgMinMax, unimpl_SIMDInit, unimpl_SIMDOps};
 #[cfg(feature = "half")]
-use super::generic::{SIMDArgMinMaxIgnoreNaN, SIMDOps, SIMDSetOps};
+use super::generic::{SIMDArgMinMax, SIMDInit, SIMDOps};
+#[cfg(feature = "half")]
+use crate::SCALARIgnoreNaN;
 
 #[cfg(feature = "half")]
 use half::f16;
+
+/// The dtype-strategy for performing operations on f16 data: ignore NaN values
+use super::super::dtype_strategy::FloatIgnoreNaN;
 
 // --------------------------------------- AVX2 ----------------------------------------
 
 #[cfg(feature = "half")]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod avx2_ignore_nan {
-    use super::super::config::AVX2IgnoreNaN;
+    use super::super::config::AVX2;
     use super::*;
 
-    unimpl_SIMDOps!(f16, usize, AVX2IgnoreNaN);
-    unimpl_SIMDArgMinMaxIgnoreNaN!(f16, usize, AVX2IgnoreNaN);
+    unimpl_SIMDOps!(f16, usize, AVX2<FloatIgnoreNaN>);
+    unimpl_SIMDInit!(f16, usize, AVX2<FloatIgnoreNaN>);
+    unimpl_SIMDArgMinMax!(f16, usize, SCALARIgnoreNaN, AVX2<FloatIgnoreNaN>);
 }
 
 // ---------------------------------------- SSE ----------------------------------------
@@ -28,11 +34,12 @@ mod avx2_ignore_nan {
 #[cfg(feature = "half")]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod sse_ignore_nan {
-    use super::super::config::SSEIgnoreNaN;
+    use super::super::config::SSE;
     use super::*;
 
-    unimpl_SIMDOps!(f16, usize, SSEIgnoreNaN);
-    unimpl_SIMDArgMinMaxIgnoreNaN!(f16, usize, SSEIgnoreNaN);
+    unimpl_SIMDOps!(f16, usize, SSE<FloatIgnoreNaN>);
+    unimpl_SIMDInit!(f16, usize, SSE<FloatIgnoreNaN>);
+    unimpl_SIMDArgMinMax!(f16, usize, SCALARIgnoreNaN, SSE<FloatIgnoreNaN>);
 }
 
 // -------------------------------------- AVX512 ---------------------------------------
@@ -40,11 +47,12 @@ mod sse_ignore_nan {
 #[cfg(feature = "half")]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod avx512_ignore_nan {
-    use super::super::config::AVX512IgnoreNaN;
+    use super::super::config::AVX512;
     use super::*;
 
-    unimpl_SIMDOps!(f16, usize, AVX512IgnoreNaN);
-    unimpl_SIMDArgMinMaxIgnoreNaN!(f16, usize, AVX512IgnoreNaN);
+    unimpl_SIMDOps!(f16, usize, AVX512<FloatIgnoreNaN>);
+    unimpl_SIMDInit!(f16, usize, AVX512<FloatIgnoreNaN>);
+    unimpl_SIMDArgMinMax!(f16, usize, SCALARIgnoreNaN, AVX512<FloatIgnoreNaN>);
 }
 
 // --------------------------------------- NEON ----------------------------------------
@@ -52,9 +60,10 @@ mod avx512_ignore_nan {
 #[cfg(feature = "half")]
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 mod neon_ignore_nan {
-    use super::super::config::NEONIgnoreNaN;
+    use super::super::config::NEON;
     use super::*;
 
-    unimpl_SIMDOps!(f16, usize, NEONIgnoreNaN);
-    unimpl_SIMDArgMinMaxIgnoreNaN!(f16, usize, NEONIgnoreNaN);
+    unimpl_SIMDOps!(f16, usize, NEON<FloatIgnoreNaN>);
+    unimpl_SIMDInit!(f16, usize, NEON<FloatIgnoreNaN>);
+    unimpl_SIMDArgMinMax!(f16, usize, SCALARIgnoreNaN, NEON<FloatIgnoreNaN>);
 }

--- a/src/simd/simd_f16_return_nan.rs
+++ b/src/simd/simd_f16_return_nan.rs
@@ -643,6 +643,7 @@ mod neon {
 mod tests {
     use rstest::rstest;
     use rstest_reuse::{self, *};
+    use std::marker::PhantomData;
 
     use half::f16;
 
@@ -671,9 +672,9 @@ mod tests {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[template]
     #[rstest]
-    #[case::sse(SSE {_dtype_strategy: FloatReturnNaN}, is_x86_feature_detected!("sse4.1"))]
-    #[case::avx2(AVX2 {_dtype_strategy: FloatReturnNaN}, is_x86_feature_detected!("avx2"))]
-    #[case::avx512(AVX512 {_dtype_strategy: FloatReturnNaN}, is_x86_feature_detected!("avx512bw"))]
+    #[case::sse(SSE {_dtype_strategy: PhantomData::<FloatReturnNaN>}, is_x86_feature_detected!("sse4.1"))]
+    #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<FloatReturnNaN>}, is_x86_feature_detected!("avx2"))]
+    #[case::avx512(AVX512 {_dtype_strategy: PhantomData::<FloatReturnNaN>}, is_x86_feature_detected!("avx512bw"))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,
@@ -685,7 +686,7 @@ mod tests {
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     #[template]
     #[rstest]
-    #[case::neon(NEON {_dtype_strategy: FloatReturnNaN}, true)]
+    #[case::neon(NEON {_dtype_strategy: PhantomData::<FloatReturnNaN>}, true)]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,

--- a/src/simd/simd_f16_return_nan.rs
+++ b/src/simd/simd_f16_return_nan.rs
@@ -31,7 +31,9 @@
 #[cfg(feature = "half")]
 use super::config::SIMDInstructionSet;
 #[cfg(feature = "half")]
-use super::generic::{SIMDArgMinMax, SIMDOps};
+use super::generic::{impl_SIMDInit_FloatReturnNaN, SIMDArgMinMax, SIMDInit, SIMDOps};
+#[cfg(feature = "half")]
+use crate::SCALAR;
 
 #[cfg(feature = "half")]
 #[cfg(target_arch = "aarch64")]
@@ -48,6 +50,10 @@ use std::arch::x86_64::*;
 
 #[cfg(feature = "half")]
 use half::f16;
+
+/// The dtype-strategy for performing operations on f16 data: return NaN index
+#[cfg(feature = "half")]
+use super::super::dtype_strategy::FloatReturnNaN;
 
 #[cfg(feature = "half")]
 const BIT_SHIFT: i32 = 15;
@@ -72,7 +78,7 @@ mod avx2 {
     use super::super::config::AVX2;
     use super::*;
 
-    const LANE_SIZE: usize = AVX2::LANE_SIZE_16;
+    const LANE_SIZE: usize = AVX2::<FloatReturnNaN>::LANE_SIZE_16;
     const LOWER_15_MASK: __m256i = unsafe { std::mem::transmute([MASK_VALUE; LANE_SIZE]) };
 
     #[inline(always)]
@@ -93,7 +99,7 @@ mod avx2 {
         std::mem::transmute::<__m256i, [i16; LANE_SIZE]>(reg)
     }
 
-    impl SIMDOps<f16, __m256i, __m256i, LANE_SIZE> for AVX2 {
+    impl SIMDOps<f16, __m256i, __m256i, LANE_SIZE> for AVX2<FloatReturnNaN> {
         const INITIAL_INDEX: __m256i = unsafe {
             std::mem::transmute([
                 0i16, 1i16, 2i16, 3i16, 4i16, 5i16, 6i16, 7i16, 8i16, 9i16, 10i16, 11i16, 12i16,
@@ -198,7 +204,9 @@ mod avx2 {
         }
     }
 
-    impl SIMDArgMinMax<f16, __m256i, __m256i, LANE_SIZE> for AVX2 {
+    impl_SIMDInit_FloatReturnNaN!(f16, __m256i, __m256i, LANE_SIZE, AVX2<FloatReturnNaN>);
+
+    impl SIMDArgMinMax<f16, __m256i, __m256i, LANE_SIZE, SCALAR> for AVX2<FloatReturnNaN> {
         #[target_feature(enable = "avx2")]
         unsafe fn argminmax(data: &[f16]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -214,7 +222,7 @@ mod sse {
     use super::super::config::SSE;
     use super::*;
 
-    const LANE_SIZE: usize = SSE::LANE_SIZE_16;
+    const LANE_SIZE: usize = SSE::<FloatReturnNaN>::LANE_SIZE_16;
     const LOWER_15_MASK: __m128i = unsafe { std::mem::transmute([MASK_VALUE; LANE_SIZE]) };
 
     #[inline(always)]
@@ -230,7 +238,7 @@ mod sse {
         std::mem::transmute::<__m128i, [i16; LANE_SIZE]>(reg)
     }
 
-    impl SIMDOps<f16, __m128i, __m128i, LANE_SIZE> for SSE {
+    impl SIMDOps<f16, __m128i, __m128i, LANE_SIZE> for SSE<FloatReturnNaN> {
         const INITIAL_INDEX: __m128i =
             unsafe { std::mem::transmute([0i16, 1i16, 2i16, 3i16, 4i16, 5i16, 6i16, 7i16]) };
         const INDEX_INCREMENT: __m128i =
@@ -327,7 +335,9 @@ mod sse {
         }
     }
 
-    impl SIMDArgMinMax<f16, __m128i, __m128i, LANE_SIZE> for SSE {
+    impl_SIMDInit_FloatReturnNaN!(f16, __m128i, __m128i, LANE_SIZE, SSE<FloatReturnNaN>);
+
+    impl SIMDArgMinMax<f16, __m128i, __m128i, LANE_SIZE, SCALAR> for SSE<FloatReturnNaN> {
         #[target_feature(enable = "sse4.1")]
         unsafe fn argminmax(data: &[f16]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -343,7 +353,7 @@ mod avx512 {
     use super::super::config::AVX512;
     use super::*;
 
-    const LANE_SIZE: usize = AVX512::LANE_SIZE_16;
+    const LANE_SIZE: usize = AVX512::<FloatReturnNaN>::LANE_SIZE_16;
     const LOWER_15_MASK: __m512i = unsafe { std::mem::transmute([MASK_VALUE; LANE_SIZE]) };
 
     #[inline(always)]
@@ -359,7 +369,7 @@ mod avx512 {
         std::mem::transmute::<__m512i, [i16; LANE_SIZE]>(reg)
     }
 
-    impl SIMDOps<f16, __m512i, u32, LANE_SIZE> for AVX512 {
+    impl SIMDOps<f16, __m512i, u32, LANE_SIZE> for AVX512<FloatReturnNaN> {
         const INITIAL_INDEX: __m512i = unsafe {
             std::mem::transmute([
                 0i16, 1i16, 2i16, 3i16, 4i16, 5i16, 6i16, 7i16, 8i16, 9i16, 10i16, 11i16, 12i16,
@@ -469,7 +479,9 @@ mod avx512 {
         }
     }
 
-    impl SIMDArgMinMax<f16, __m512i, u32, LANE_SIZE> for AVX512 {
+    impl_SIMDInit_FloatReturnNaN!(f16, __m512i, u32, LANE_SIZE, AVX512<FloatReturnNaN>);
+
+    impl SIMDArgMinMax<f16, __m512i, u32, LANE_SIZE, SCALAR> for AVX512<FloatReturnNaN> {
         #[target_feature(enable = "avx512bw")]
         unsafe fn argminmax(data: &[f16]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -485,7 +497,7 @@ mod neon {
     use super::super::config::NEON;
     use super::*;
 
-    const LANE_SIZE: usize = NEON::LANE_SIZE_16;
+    const LANE_SIZE: usize = NEON::<FloatReturnNaN>::LANE_SIZE_16;
     const LOWER_15_MASK: int16x8_t = unsafe { std::mem::transmute([MASK_VALUE; LANE_SIZE]) };
 
     #[inline(always)]
@@ -501,7 +513,7 @@ mod neon {
         std::mem::transmute::<int16x8_t, [i16; LANE_SIZE]>(reg)
     }
 
-    impl SIMDOps<f16, int16x8_t, uint16x8_t, LANE_SIZE> for NEON {
+    impl SIMDOps<f16, int16x8_t, uint16x8_t, LANE_SIZE> for NEON<FloatReturnNaN> {
         const INITIAL_INDEX: int16x8_t =
             unsafe { std::mem::transmute([0i16, 1i16, 2i16, 3i16, 4i16, 5i16, 6i16, 7i16]) };
         const INDEX_INCREMENT: int16x8_t =
@@ -600,7 +612,9 @@ mod neon {
         }
     }
 
-    impl SIMDArgMinMax<f16, int16x8_t, uint16x8_t, LANE_SIZE> for NEON {
+    impl_SIMDInit_FloatReturnNaN!(f16, int16x8_t, uint16x8_t, LANE_SIZE, NEON<FloatReturnNaN>);
+
+    impl SIMDArgMinMax<f16, int16x8_t, uint16x8_t, LANE_SIZE, SCALAR> for NEON<FloatReturnNaN> {
         #[target_feature(enable = "neon")]
         unsafe fn argminmax(data: &[f16]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -629,7 +643,7 @@ mod tests {
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, AVX512, SSE};
-    use crate::SIMDArgMinMax;
+    use crate::{FloatReturnNaN, SIMDArgMinMax, SCALAR};
 
     use super::super::test_utils::{
         test_first_index_identical_values_argminmax, test_long_array_argminmax,
@@ -650,9 +664,9 @@ mod tests {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[template]
     #[rstest]
-    #[case::sse(SSE, is_x86_feature_detected!("sse4.1"))]
-    #[case::avx2(AVX2, is_x86_feature_detected!("avx2"))]
-    #[case::avx512(AVX512, is_x86_feature_detected!("avx512bw"))]
+    #[case::sse(SSE {_dtype_strategy: FloatReturnNaN}, is_x86_feature_detected!("sse4.1"))]
+    #[case::avx2(AVX2 {_dtype_strategy: FloatReturnNaN}, is_x86_feature_detected!("avx2"))]
+    #[case::avx512(AVX512 {_dtype_strategy: FloatReturnNaN}, is_x86_feature_detected!("avx512bw"))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,
@@ -664,7 +678,7 @@ mod tests {
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     #[template]
     #[rstest]
-    #[case::neon(NEON, true)]
+    #[case::neon(NEON {_dtype_strategy: FloatReturnNaN}, true)]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,
@@ -683,7 +697,7 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<f16, SIMDV, SIMDM, LANE_SIZE>,
+        T: SIMDArgMinMax<f16, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
@@ -698,7 +712,7 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<f16, SIMDV, SIMDM, LANE_SIZE>,
+        T: SIMDArgMinMax<f16, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
@@ -714,7 +728,7 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<f16, SIMDV, SIMDM, LANE_SIZE>,
+        T: SIMDArgMinMax<f16, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
@@ -729,7 +743,7 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<f16, SIMDV, SIMDM, LANE_SIZE>,
+        T: SIMDArgMinMax<f16, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
@@ -744,7 +758,7 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<f16, SIMDV, SIMDM, LANE_SIZE>,
+        T: SIMDArgMinMax<f16, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
         SIMDV: Copy,
         SIMDM: Copy,
     {

--- a/src/simd/simd_f32_ignore_nan.rs
+++ b/src/simd/simd_f32_ignore_nan.rs
@@ -314,6 +314,7 @@ mod neon_ignore_nan {
 mod tests {
     use rstest::rstest;
     use rstest_reuse::{self, *};
+    use std::marker::PhantomData;
 
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     use crate::simd::config::NEON;
@@ -339,10 +340,9 @@ mod tests {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[template]
     #[rstest]
-    #[case::sse(SSE {_dtype_strategy: FloatIgnoreNaN}, is_x86_feature_detected!("sse4.1"))]
-    #[case::avx2(AVX2 {_dtype_strategy: FloatIgnoreNaN}, is_x86_feature_detected!("avx"))]
-    #[case::avx512(AVX512 {_dtype_strategy: FloatIgnoreNaN}, is_x86_feature_detected!("avx512f"))]
-
+    #[case::sse(SSE {_dtype_strategy: PhantomData::<FloatIgnoreNaN>}, is_x86_feature_detected!("sse4.1"))]
+    #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<FloatIgnoreNaN>}, is_x86_feature_detected!("avx"))]
+    #[case::avx512(AVX512 {_dtype_strategy: PhantomData::<FloatIgnoreNaN>}, is_x86_feature_detected!("avx512f"))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,
@@ -354,7 +354,7 @@ mod tests {
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     #[template]
     #[rstest]
-    #[case::neon(NEON {_dtype_strategy: FloatIgnoreNaN}, true)]
+    #[case::neon(NEON {_dtype_strategy: PhantomData::<FloatIgnoreNaN>}, true)]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,

--- a/src/simd/simd_f32_return_nan.rs
+++ b/src/simd/simd_f32_return_nan.rs
@@ -138,7 +138,9 @@ mod avx2 {
 
     impl_SIMDInit_FloatReturnNaN!(f32, __m256i, __m256i, LANE_SIZE, AVX2<FloatReturnNaN>);
 
-    impl SIMDArgMinMax<f32, __m256i, __m256i, LANE_SIZE, SCALAR> for AVX2<FloatReturnNaN> {
+    impl SIMDArgMinMax<f32, __m256i, __m256i, LANE_SIZE, SCALAR<FloatReturnNaN>>
+        for AVX2<FloatReturnNaN>
+    {
         #[target_feature(enable = "avx2")]
         unsafe fn argminmax(data: &[f32]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -227,7 +229,9 @@ mod sse {
 
     impl_SIMDInit_FloatReturnNaN!(f32, __m128i, __m128i, LANE_SIZE, SSE<FloatReturnNaN>);
 
-    impl SIMDArgMinMax<f32, __m128i, __m128i, LANE_SIZE, SCALAR> for SSE<FloatReturnNaN> {
+    impl SIMDArgMinMax<f32, __m128i, __m128i, LANE_SIZE, SCALAR<FloatReturnNaN>>
+        for SSE<FloatReturnNaN>
+    {
         #[target_feature(enable = "sse4.1")]
         unsafe fn argminmax(data: &[f32]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -321,7 +325,9 @@ mod avx512 {
 
     impl_SIMDInit_FloatReturnNaN!(f32, __m512i, u16, LANE_SIZE, AVX512<FloatReturnNaN>);
 
-    impl SIMDArgMinMax<f32, __m512i, u16, LANE_SIZE, SCALAR> for AVX512<FloatReturnNaN> {
+    impl SIMDArgMinMax<f32, __m512i, u16, LANE_SIZE, SCALAR<FloatReturnNaN>>
+        for AVX512<FloatReturnNaN>
+    {
         #[target_feature(enable = "avx512f")]
         unsafe fn argminmax(data: &[f32]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -410,7 +416,9 @@ mod neon {
 
     impl_SIMDInit_FloatReturnNaN!(f32, int32x4_t, uint32x4_t, LANE_SIZE, NEON<FloatReturnNaN>);
 
-    impl SIMDArgMinMax<f32, int32x4_t, uint32x4_t, LANE_SIZE, SCALAR> for NEON<FloatReturnNaN> {
+    impl SIMDArgMinMax<f32, int32x4_t, uint32x4_t, LANE_SIZE, SCALAR<FloatReturnNaN>>
+        for NEON<FloatReturnNaN>
+    {
         #[target_feature(enable = "neon")]
         unsafe fn argminmax(data: &[f32]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -431,12 +439,11 @@ mod tests {
     use rstest::rstest;
     use rstest_reuse::{self, *};
 
-    use crate::scalar::generic::scalar_argminmax;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, AVX512, SSE};
-    use crate::{FloatReturnNaN, SIMDArgMinMax, SCALAR};
+    use crate::{FloatReturnNaN, SIMDArgMinMax, ScalarArgMinMax, SCALAR};
 
     use super::super::test_utils::{
         test_first_index_identical_values_argminmax, test_long_array_argminmax,
@@ -489,14 +496,17 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<f32, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
+        T: SIMDArgMinMax<f32, SIMDV, SIMDM, LANE_SIZE, SCALAR<FloatReturnNaN>>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
         if !simd_available {
             return;
         }
-        test_first_index_identical_values_argminmax(scalar_argminmax, T::argminmax);
+        test_first_index_identical_values_argminmax(
+            SCALAR::<FloatReturnNaN>::argminmax,
+            T::argminmax,
+        );
     }
 
     #[apply(simd_implementations)]
@@ -504,15 +514,23 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<f32, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
+        T: SIMDArgMinMax<f32, SIMDV, SIMDM, LANE_SIZE, SCALAR<FloatReturnNaN>>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
         if !simd_available {
             return;
         }
-        test_long_array_argminmax(get_array_f32, scalar_argminmax, T::argminmax);
-        test_random_runs_argminmax(get_array_f32, scalar_argminmax, T::argminmax);
+        test_long_array_argminmax(
+            get_array_f32,
+            SCALAR::<FloatReturnNaN>::argminmax,
+            T::argminmax,
+        );
+        test_random_runs_argminmax(
+            get_array_f32,
+            SCALAR::<FloatReturnNaN>::argminmax,
+            T::argminmax,
+        );
     }
 
     #[apply(simd_implementations)]
@@ -520,14 +538,18 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<f32, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
+        T: SIMDArgMinMax<f32, SIMDV, SIMDM, LANE_SIZE, SCALAR<FloatReturnNaN>>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
         if !simd_available {
             return;
         }
-        test_return_infs_argminmax(get_array_f32, scalar_argminmax, T::argminmax);
+        test_return_infs_argminmax(
+            get_array_f32,
+            SCALAR::<FloatReturnNaN>::argminmax,
+            T::argminmax,
+        );
     }
 
     #[apply(simd_implementations)]
@@ -535,13 +557,17 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<f32, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
+        T: SIMDArgMinMax<f32, SIMDV, SIMDM, LANE_SIZE, SCALAR<FloatReturnNaN>>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
         if !simd_available {
             return;
         }
-        test_return_nans_argminmax(get_array_f32, scalar_argminmax, T::argminmax);
+        test_return_nans_argminmax(
+            get_array_f32,
+            SCALAR::<FloatReturnNaN>::argminmax,
+            T::argminmax,
+        );
     }
 }

--- a/src/simd/simd_f32_return_nan.rs
+++ b/src/simd/simd_f32_return_nan.rs
@@ -438,6 +438,7 @@ mod neon {
 mod tests {
     use rstest::rstest;
     use rstest_reuse::{self, *};
+    use std::marker::PhantomData;
 
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     use crate::simd::config::NEON;
@@ -463,9 +464,9 @@ mod tests {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[template]
     #[rstest]
-    #[case::sse(SSE {_dtype_strategy: FloatReturnNaN}, is_x86_feature_detected!("sse4.1"))]
-    #[case::avx2(AVX2 {_dtype_strategy: FloatReturnNaN}, is_x86_feature_detected!("avx2"))]
-    #[case::avx512(AVX512 {_dtype_strategy: FloatReturnNaN}, is_x86_feature_detected!("avx512f"))]
+    #[case::sse(SSE {_dtype_strategy: PhantomData::<FloatReturnNaN>}, is_x86_feature_detected!("sse4.1"))]
+    #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<FloatReturnNaN>}, is_x86_feature_detected!("avx2"))]
+    #[case::avx512(AVX512 {_dtype_strategy: PhantomData::<FloatReturnNaN>}, is_x86_feature_detected!("avx512f"))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,
@@ -477,7 +478,7 @@ mod tests {
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     #[template]
     #[rstest]
-    #[case::neon(NEON { _dtype_strategy: FloatReturnNaN}, true)]
+    #[case::neon(NEON { _dtype_strategy: PhantomData::<FloatReturnNaN>}, true)]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,

--- a/src/simd/simd_f64_ignore_nan.rs
+++ b/src/simd/simd_f64_ignore_nan.rs
@@ -156,7 +156,7 @@ mod sse_ignore_nan {
     impl SIMDArgMinMax<f64, __m128d, __m128d, LANE_SIZE, SCALAR<FloatIgnoreNaN>>
         for SSE<FloatIgnoreNaN>
     {
-        #[target_feature(enable = "sse4.1")] // TODO: check if this is correct
+        #[target_feature(enable = "sse4.1")]
         unsafe fn argminmax(data: &[f64]) -> (usize, usize) {
             Self::_argminmax(data)
         }

--- a/src/simd/simd_f64_ignore_nan.rs
+++ b/src/simd/simd_f64_ignore_nan.rs
@@ -257,6 +257,7 @@ mod neon_ignore_nan {
 mod tests {
     use rstest::rstest;
     use rstest_reuse::{self, *};
+    use std::marker::PhantomData;
 
     use crate::simd::config::{AVX2, AVX512, SSE};
     use crate::{FloatIgnoreNaN, SIMDArgMinMax, ScalarArgMinMax, SCALAR};
@@ -278,9 +279,9 @@ mod tests {
 
     #[template]
     #[rstest]
-    #[case::sse(SSE {_dtype_strategy: FloatIgnoreNaN}, is_x86_feature_detected!("sse4.1"))]
-    #[case::avx2(AVX2 {_dtype_strategy: FloatIgnoreNaN}, is_x86_feature_detected!("avx"))]
-    #[case::avx512(AVX512 {_dtype_strategy: FloatIgnoreNaN}, is_x86_feature_detected!("avx512f"))]
+    #[case::sse(SSE {_dtype_strategy: PhantomData::<FloatIgnoreNaN>}, is_x86_feature_detected!("sse4.1"))]
+    #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<FloatIgnoreNaN>}, is_x86_feature_detected!("avx"))]
+    #[case::avx512(AVX512 {_dtype_strategy: PhantomData::<FloatIgnoreNaN>}, is_x86_feature_detected!("avx512f"))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,

--- a/src/simd/simd_f64_ignore_nan.rs
+++ b/src/simd/simd_f64_ignore_nan.rs
@@ -233,7 +233,7 @@ mod avx512_ignore_nan {
 
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 mod neon_ignore_nan {
-    use super::super::config::NEONIgnoreNaN;
+    use super::super::config::NEON;
     use super::super::generic::{unimpl_SIMDArgMinMax, unimpl_SIMDInit, unimpl_SIMDOps};
     use super::*;
 
@@ -243,7 +243,7 @@ mod neon_ignore_nan {
     // > 64 bit data types.
     unimpl_SIMDOps!(f64, usize, NEON<FloatIgnoreNaN>);
     unimpl_SIMDInit!(f64, usize, NEON<FloatIgnoreNaN>);
-    unimpl_SIMDArgMinMax!(f64, usize, SCALAR, NEON<FloatIgnoreNaN>);
+    unimpl_SIMDArgMinMax!(f64, usize, SCALARIgnoreNaN, NEON<FloatIgnoreNaN>);
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]

--- a/src/simd/simd_f64_ignore_nan.rs
+++ b/src/simd/simd_f64_ignore_nan.rs
@@ -14,11 +14,15 @@
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use super::config::SIMDInstructionSet;
-use super::generic::{SIMDArgMinMaxIgnoreNaN, SIMDOps, SIMDSetOps};
+use super::generic::{impl_SIMDInit_FloatIgnoreNaN, SIMDArgMinMax, SIMDInit, SIMDOps};
+use crate::SCALARIgnoreNaN;
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
+
+/// The dtype-strategy for performing operations on f64 data: ignore NaN values
+use super::super::dtype_strategy::FloatIgnoreNaN;
 
 // https://stackoverflow.com/a/3793950
 #[cfg(target_arch = "x86_64")]
@@ -30,12 +34,12 @@ const MAX_INDEX: usize = u32::MAX as usize;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod avx_ignore_nan {
-    use super::super::config::{AVX2IgnoreNaN, AVX2};
+    use super::super::config::AVX2;
     use super::*;
 
-    const LANE_SIZE: usize = AVX2::LANE_SIZE_64;
+    const LANE_SIZE: usize = AVX2::<FloatIgnoreNaN>::LANE_SIZE_64;
 
-    impl SIMDOps<f64, __m256d, __m256d, LANE_SIZE> for AVX2IgnoreNaN {
+    impl SIMDOps<f64, __m256d, __m256d, LANE_SIZE> for AVX2<FloatIgnoreNaN> {
         const INITIAL_INDEX: __m256d =
             unsafe { std::mem::transmute([0.0f64, 1.0f64, 2.0f64, 3.0f64]) };
         const INDEX_INCREMENT: __m256d =
@@ -71,16 +75,18 @@ mod avx_ignore_nan {
         unsafe fn _mm_blendv(a: __m256d, b: __m256d, mask: __m256d) -> __m256d {
             _mm256_blendv_pd(a, b, mask)
         }
-    }
 
-    impl SIMDSetOps<f64, __m256d> for AVX2IgnoreNaN {
+        // --- Necessary for impl_SIMDInit_FloatIgnoreNaN
+
         #[inline(always)]
-        unsafe fn _mm_set1(a: f64) -> __m256d {
-            _mm256_set1_pd(a)
+        unsafe fn _mm_set1(val: f64) -> __m256d {
+            _mm256_set1_pd(val)
         }
     }
 
-    impl SIMDArgMinMaxIgnoreNaN<f64, __m256d, __m256d, LANE_SIZE> for AVX2IgnoreNaN {
+    impl_SIMDInit_FloatIgnoreNaN!(f64, __m256d, __m256d, LANE_SIZE, AVX2<FloatIgnoreNaN>);
+
+    impl SIMDArgMinMax<f64, __m256d, __m256d, LANE_SIZE, SCALARIgnoreNaN> for AVX2<FloatIgnoreNaN> {
         #[target_feature(enable = "avx")]
         unsafe fn argminmax(data: &[f64]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -92,12 +98,12 @@ mod avx_ignore_nan {
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod sse_ignore_nan {
-    use super::super::config::{SSEIgnoreNaN, SSE};
+    use super::super::config::SSE;
     use super::*;
 
-    const LANE_SIZE: usize = SSE::LANE_SIZE_64;
+    const LANE_SIZE: usize = SSE::<FloatIgnoreNaN>::LANE_SIZE_64;
 
-    impl SIMDOps<f64, __m128d, __m128d, LANE_SIZE> for SSEIgnoreNaN {
+    impl SIMDOps<f64, __m128d, __m128d, LANE_SIZE> for SSE<FloatIgnoreNaN> {
         const INITIAL_INDEX: __m128d = unsafe { std::mem::transmute([0.0f64, 1.0f64]) };
         const INDEX_INCREMENT: __m128d =
             unsafe { std::mem::transmute([LANE_SIZE as f64; LANE_SIZE]) };
@@ -132,16 +138,18 @@ mod sse_ignore_nan {
         unsafe fn _mm_blendv(a: __m128d, b: __m128d, mask: __m128d) -> __m128d {
             _mm_blendv_pd(a, b, mask)
         }
-    }
 
-    impl SIMDSetOps<f64, __m128d> for SSEIgnoreNaN {
+        // --- Necessary for impl_SIMDInit_FloatIgnoreNaN
+
         #[inline(always)]
-        unsafe fn _mm_set1(a: f64) -> __m128d {
-            _mm_set1_pd(a)
+        unsafe fn _mm_set1(val: f64) -> __m128d {
+            _mm_set1_pd(val)
         }
     }
 
-    impl SIMDArgMinMaxIgnoreNaN<f64, __m128d, __m128d, LANE_SIZE> for SSEIgnoreNaN {
+    impl_SIMDInit_FloatIgnoreNaN!(f64, __m128d, __m128d, LANE_SIZE, SSE<FloatIgnoreNaN>);
+
+    impl SIMDArgMinMax<f64, __m128d, __m128d, LANE_SIZE, SCALARIgnoreNaN> for SSE<FloatIgnoreNaN> {
         #[target_feature(enable = "sse4.1")] // TODO: check if this is correct
         unsafe fn argminmax(data: &[f64]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -153,12 +161,12 @@ mod sse_ignore_nan {
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod avx512_ignore_nan {
-    use super::super::config::{AVX512IgnoreNaN, AVX512};
+    use super::super::config::AVX512;
     use super::*;
 
-    const LANE_SIZE: usize = AVX512::LANE_SIZE_64;
+    const LANE_SIZE: usize = AVX512::<FloatIgnoreNaN>::LANE_SIZE_64;
 
-    impl SIMDOps<f64, __m512d, u8, LANE_SIZE> for AVX512IgnoreNaN {
+    impl SIMDOps<f64, __m512d, u8, LANE_SIZE> for AVX512<FloatIgnoreNaN> {
         const INITIAL_INDEX: __m512d = unsafe {
             std::mem::transmute([
                 0.0f64, 1.0f64, 2.0f64, 3.0f64, 4.0f64, 5.0f64, 6.0f64, 7.0f64,
@@ -197,16 +205,18 @@ mod avx512_ignore_nan {
         unsafe fn _mm_blendv(a: __m512d, b: __m512d, mask: u8) -> __m512d {
             _mm512_mask_blend_pd(mask, a, b)
         }
-    }
 
-    impl SIMDSetOps<f64, __m512d> for AVX512IgnoreNaN {
+        // --- Necessary for impl_SIMDInit_FloatIgnoreNaN
+
         #[inline(always)]
-        unsafe fn _mm_set1(a: f64) -> __m512d {
-            _mm512_set1_pd(a)
+        unsafe fn _mm_set1(val: f64) -> __m512d {
+            _mm512_set1_pd(val)
         }
     }
 
-    impl SIMDArgMinMaxIgnoreNaN<f64, __m512d, u8, LANE_SIZE> for AVX512IgnoreNaN {
+    impl_SIMDInit_FloatIgnoreNaN!(f64, __m512d, u8, LANE_SIZE, AVX512<FloatIgnoreNaN>);
+
+    impl SIMDArgMinMax<f64, __m512d, u8, LANE_SIZE, SCALARIgnoreNaN> for AVX512<FloatIgnoreNaN> {
         #[target_feature(enable = "avx512f")]
         unsafe fn argminmax(data: &[f64]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -224,15 +234,16 @@ mod avx512_ignore_nan {
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 mod neon_ignore_nan {
     use super::super::config::NEONIgnoreNaN;
-    use super::super::generic::{unimpl_SIMDArgMinMaxIgnoreNaN, unimpl_SIMDOps};
+    use super::super::generic::{unimpl_SIMDArgMinMax, unimpl_SIMDInit, unimpl_SIMDOps};
     use super::*;
 
     // We need to (un)implement the SIMD trait for the NEON struct as otherwise the
     // compiler will complain that the trait is not implemented for the struct -
     // even though we are not using the trait for the NEON struct when dealing with
     // > 64 bit data types.
-    unimpl_SIMDOps!(f64, usize, NEONIgnoreNaN);
-    unimpl_SIMDArgMinMaxIgnoreNaN!(f64, usize, NEONIgnoreNaN);
+    unimpl_SIMDOps!(f64, usize, NEON<FloatIgnoreNaN>);
+    unimpl_SIMDInit!(f64, usize, NEON<FloatIgnoreNaN>);
+    unimpl_SIMDArgMinMax!(f64, usize, SCALAR, NEON<FloatIgnoreNaN>);
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -242,8 +253,8 @@ mod tests {
     use rstest_reuse::{self, *};
 
     use crate::scalar::generic::scalar_argminmax_ignore_nans as scalar_argminmax;
-    use crate::simd::config::{AVX2IgnoreNaN, AVX512IgnoreNaN, SSEIgnoreNaN};
-    use crate::SIMDArgMinMaxIgnoreNaN; // todo use type-state pattern
+    use crate::simd::config::{AVX2, AVX512, SSE};
+    use crate::{FloatIgnoreNaN, SCALARIgnoreNaN, SIMDArgMinMax};
 
     use super::super::test_utils::{
         test_first_index_identical_values_argminmax, test_long_array_argminmax,
@@ -262,9 +273,9 @@ mod tests {
 
     #[template]
     #[rstest]
-    #[case::sse(SSEIgnoreNaN, is_x86_feature_detected!("sse4.1"))]
-    #[case::avx2(AVX2IgnoreNaN, is_x86_feature_detected!("avx"))]
-    #[case::avx512(AVX512IgnoreNaN, is_x86_feature_detected!("avx512f"))]
+    #[case::sse(SSE {_dtype_strategy: FloatIgnoreNaN}, is_x86_feature_detected!("sse4.1"))]
+    #[case::avx2(AVX2 {_dtype_strategy: FloatIgnoreNaN}, is_x86_feature_detected!("avx"))]
+    #[case::avx512(AVX512 {_dtype_strategy: FloatIgnoreNaN}, is_x86_feature_detected!("avx512f"))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,
@@ -283,7 +294,7 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMaxIgnoreNaN<f64, SIMDV, SIMDM, LANE_SIZE>,
+        T: SIMDArgMinMax<f64, SIMDV, SIMDM, LANE_SIZE, SCALARIgnoreNaN>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
@@ -298,7 +309,7 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMaxIgnoreNaN<f64, SIMDV, SIMDM, LANE_SIZE>,
+        T: SIMDArgMinMax<f64, SIMDV, SIMDM, LANE_SIZE, SCALARIgnoreNaN>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
@@ -314,7 +325,7 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMaxIgnoreNaN<f64, SIMDV, SIMDM, LANE_SIZE>,
+        T: SIMDArgMinMax<f64, SIMDV, SIMDM, LANE_SIZE, SCALARIgnoreNaN>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
@@ -329,7 +340,7 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMaxIgnoreNaN<f64, SIMDV, SIMDM, LANE_SIZE>,
+        T: SIMDArgMinMax<f64, SIMDV, SIMDM, LANE_SIZE, SCALARIgnoreNaN>,
         SIMDV: Copy,
         SIMDM: Copy,
     {

--- a/src/simd/simd_f64_return_nan.rs
+++ b/src/simd/simd_f64_return_nan.rs
@@ -372,6 +372,7 @@ mod neon {
 mod tests {
     use rstest::rstest;
     use rstest_reuse::{self, *};
+    use std::marker::PhantomData;
 
     use crate::simd::config::{AVX2, AVX512, SSE};
     use crate::{FloatReturnNaN, SIMDArgMinMax, ScalarArgMinMax, SCALAR};
@@ -393,9 +394,9 @@ mod tests {
 
     #[template]
     #[rstest]
-    #[case::sse(SSE {_dtype_strategy: FloatReturnNaN}, is_x86_feature_detected!("sse4.2"))]
-    #[case::avx2(AVX2 {_dtype_strategy: FloatReturnNaN}, is_x86_feature_detected!("avx2"))]
-    #[case::avx512(AVX512 {_dtype_strategy: FloatReturnNaN}, is_x86_feature_detected!("avx512f"))]
+    #[case::sse(SSE {_dtype_strategy: PhantomData::<FloatReturnNaN>}, is_x86_feature_detected!("sse4.2"))]
+    #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<FloatReturnNaN>}, is_x86_feature_detected!("avx2"))]
+    #[case::avx512(AVX512 {_dtype_strategy: PhantomData::<FloatReturnNaN>}, is_x86_feature_detected!("avx512f"))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,

--- a/src/simd/simd_f64_return_nan.rs
+++ b/src/simd/simd_f64_return_nan.rs
@@ -39,7 +39,6 @@ use std::arch::x86::*;
 use std::arch::x86_64::*;
 
 /// The dtype-strategy for performing operations on f64 data: return NaN index
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use super::super::dtype_strategy::FloatReturnNaN;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]

--- a/src/simd/simd_i16.rs
+++ b/src/simd/simd_i16.rs
@@ -128,7 +128,7 @@ mod avx2 {
 
     impl_SIMDInit_Int!(i16, __m256i, __m256i, LANE_SIZE, AVX2<Int>);
 
-    impl SIMDArgMinMax<i16, __m256i, __m256i, LANE_SIZE, SCALAR> for AVX2<Int> {
+    impl SIMDArgMinMax<i16, __m256i, __m256i, LANE_SIZE, SCALAR<Int>> for AVX2<Int> {
         #[target_feature(enable = "avx2")]
         unsafe fn argminmax(data: &[i16]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -241,7 +241,7 @@ mod sse {
 
     impl_SIMDInit_Int!(i16, __m128i, __m128i, LANE_SIZE, SSE<Int>);
 
-    impl SIMDArgMinMax<i16, __m128i, __m128i, LANE_SIZE, SCALAR> for SSE<Int> {
+    impl SIMDArgMinMax<i16, __m128i, __m128i, LANE_SIZE, SCALAR<Int>> for SSE<Int> {
         #[target_feature(enable = "sse4.1")]
         unsafe fn argminmax(data: &[i16]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -367,7 +367,7 @@ mod avx512 {
 
     impl_SIMDInit_Int!(i16, __m512i, u32, LANE_SIZE, AVX512<Int>);
 
-    impl SIMDArgMinMax<i16, __m512i, u32, LANE_SIZE, SCALAR> for AVX512<Int> {
+    impl SIMDArgMinMax<i16, __m512i, u32, LANE_SIZE, SCALAR<Int>> for AVX512<Int> {
         #[target_feature(enable = "avx512bw")]
         unsafe fn argminmax(data: &[i16]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -480,7 +480,7 @@ mod neon {
 
     impl_SIMDInit_Int!(i16, int16x8_t, uint16x8_t, LANE_SIZE, NEON<Int>);
 
-    impl SIMDArgMinMax<i16, int16x8_t, uint16x8_t, LANE_SIZE, SCALAR> for NEON<Int> {
+    impl SIMDArgMinMax<i16, int16x8_t, uint16x8_t, LANE_SIZE, SCALAR<Int>> for NEON<Int> {
         #[target_feature(enable = "neon")]
         unsafe fn argminmax(data: &[i16]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -501,12 +501,11 @@ mod tests {
     use rstest::rstest;
     use rstest_reuse::{self, *};
 
-    use crate::scalar::generic::scalar_argminmax;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, AVX512, SSE};
-    use crate::{Int, SIMDArgMinMax, SCALAR};
+    use crate::{Int, SIMDArgMinMax, ScalarArgMinMax, SCALAR};
 
     use super::super::test_utils::{
         test_first_index_identical_values_argminmax, test_long_array_argminmax,
@@ -557,14 +556,14 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<i16, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
+        T: SIMDArgMinMax<i16, SIMDV, SIMDM, LANE_SIZE, SCALAR<Int>>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
         if !simd_available {
             return;
         }
-        test_first_index_identical_values_argminmax(scalar_argminmax, T::argminmax);
+        test_first_index_identical_values_argminmax(SCALAR::<Int>::argminmax, T::argminmax);
     }
 
     #[apply(simd_implementations)]
@@ -572,15 +571,15 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<i16, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
+        T: SIMDArgMinMax<i16, SIMDV, SIMDM, LANE_SIZE, SCALAR<Int>>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
         if !simd_available {
             return;
         }
-        test_long_array_argminmax(get_array_i16, scalar_argminmax, T::argminmax);
-        test_random_runs_argminmax(get_array_i16, scalar_argminmax, T::argminmax);
+        test_long_array_argminmax(get_array_i16, SCALAR::<Int>::argminmax, T::argminmax);
+        test_random_runs_argminmax(get_array_i16, SCALAR::<Int>::argminmax, T::argminmax);
     }
 
     #[apply(simd_implementations)]
@@ -588,13 +587,13 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<i16, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
+        T: SIMDArgMinMax<i16, SIMDV, SIMDM, LANE_SIZE, SCALAR<Int>>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
         if !simd_available {
             return;
         }
-        test_no_overflow_argminmax(get_array_i16, scalar_argminmax, T::argminmax, None);
+        test_no_overflow_argminmax(get_array_i16, SCALAR::<Int>::argminmax, T::argminmax, None);
     }
 }

--- a/src/simd/simd_i16.rs
+++ b/src/simd/simd_i16.rs
@@ -1,5 +1,6 @@
 use super::config::SIMDInstructionSet;
-use super::generic::{SIMDArgMinMax, SIMDOps};
+use super::generic::{impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
+use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 #[cfg(target_arch = "arm")]
@@ -8,6 +9,9 @@ use std::arch::arm::*;
 use std::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
+
+/// The dtype-strategy for performing operations on i16 data: (default) Int
+use super::super::dtype_strategy::Int;
 
 const MAX_INDEX: usize = i16::MAX as usize;
 
@@ -18,9 +22,9 @@ mod avx2 {
     use super::super::config::AVX2;
     use super::*;
 
-    const LANE_SIZE: usize = AVX2::LANE_SIZE_16;
+    const LANE_SIZE: usize = AVX2::<Int>::LANE_SIZE_16;
 
-    impl SIMDOps<i16, __m256i, __m256i, LANE_SIZE> for AVX2 {
+    impl SIMDOps<i16, __m256i, __m256i, LANE_SIZE> for AVX2<Int> {
         const INITIAL_INDEX: __m256i = unsafe {
             std::mem::transmute([
                 0i16, 1i16, 2i16, 3i16, 4i16, 5i16, 6i16, 7i16, 8i16, 9i16, 10i16, 11i16, 12i16,
@@ -122,7 +126,9 @@ mod avx2 {
         }
     }
 
-    impl SIMDArgMinMax<i16, __m256i, __m256i, LANE_SIZE> for AVX2 {
+    impl_SIMDInit_Int!(i16, __m256i, __m256i, LANE_SIZE, AVX2<Int>);
+
+    impl SIMDArgMinMax<i16, __m256i, __m256i, LANE_SIZE, SCALAR> for AVX2<Int> {
         #[target_feature(enable = "avx2")]
         unsafe fn argminmax(data: &[i16]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -137,9 +143,9 @@ mod sse {
     use super::super::config::SSE;
     use super::*;
 
-    const LANE_SIZE: usize = SSE::LANE_SIZE_16;
+    const LANE_SIZE: usize = SSE::<Int>::LANE_SIZE_16;
 
-    impl SIMDOps<i16, __m128i, __m128i, LANE_SIZE> for SSE {
+    impl SIMDOps<i16, __m128i, __m128i, LANE_SIZE> for SSE<Int> {
         const INITIAL_INDEX: __m128i =
             unsafe { std::mem::transmute([0i16, 1i16, 2i16, 3i16, 4i16, 5i16, 6i16, 7i16]) };
         const INDEX_INCREMENT: __m128i =
@@ -233,7 +239,9 @@ mod sse {
         }
     }
 
-    impl SIMDArgMinMax<i16, __m128i, __m128i, LANE_SIZE> for SSE {
+    impl_SIMDInit_Int!(i16, __m128i, __m128i, LANE_SIZE, SSE<Int>);
+
+    impl SIMDArgMinMax<i16, __m128i, __m128i, LANE_SIZE, SCALAR> for SSE<Int> {
         #[target_feature(enable = "sse4.1")]
         unsafe fn argminmax(data: &[i16]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -248,9 +256,9 @@ mod avx512 {
     use super::super::config::AVX512;
     use super::*;
 
-    const LANE_SIZE: usize = AVX512::LANE_SIZE_16;
+    const LANE_SIZE: usize = AVX512::<Int>::LANE_SIZE_16;
 
-    impl SIMDOps<i16, __m512i, u32, LANE_SIZE> for AVX512 {
+    impl SIMDOps<i16, __m512i, u32, LANE_SIZE> for AVX512<Int> {
         const INITIAL_INDEX: __m512i = unsafe {
             std::mem::transmute([
                 0i16, 1i16, 2i16, 3i16, 4i16, 5i16, 6i16, 7i16, 8i16, 9i16, 10i16, 11i16, 12i16,
@@ -357,7 +365,9 @@ mod avx512 {
         }
     }
 
-    impl SIMDArgMinMax<i16, __m512i, u32, LANE_SIZE> for AVX512 {
+    impl_SIMDInit_Int!(i16, __m512i, u32, LANE_SIZE, AVX512<Int>);
+
+    impl SIMDArgMinMax<i16, __m512i, u32, LANE_SIZE, SCALAR> for AVX512<Int> {
         #[target_feature(enable = "avx512bw")]
         unsafe fn argminmax(data: &[i16]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -372,9 +382,9 @@ mod neon {
     use super::super::config::NEON;
     use super::*;
 
-    const LANE_SIZE: usize = NEON::LANE_SIZE_16;
+    const LANE_SIZE: usize = NEON::<Int>::LANE_SIZE_16;
 
-    impl SIMDOps<i16, int16x8_t, uint16x8_t, LANE_SIZE> for NEON {
+    impl SIMDOps<i16, int16x8_t, uint16x8_t, LANE_SIZE, SCALAR> for NEON<Int> {
         const INITIAL_INDEX: int16x8_t =
             unsafe { std::mem::transmute([0i16, 1i16, 2i16, 3i16, 4i16, 5i16, 6i16, 7i16]) };
         const INDEX_INCREMENT: int16x8_t =
@@ -468,7 +478,9 @@ mod neon {
         }
     }
 
-    impl SIMDArgMinMax<i16, int16x8_t, uint16x8_t, LANE_SIZE> for NEON {
+    impl_SIMDInit_Int!(i16, int16x8_t, uint16x8_t, LANE_SIZE, NEON<Int>);
+
+    impl SIMDArgMinMax<i16, int16x8_t, uint16x8_t, LANE_SIZE> for NEON<Int> {
         #[target_feature(enable = "neon")]
         unsafe fn argminmax(data: &[i16]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -494,7 +506,7 @@ mod tests {
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, AVX512, SSE};
-    use crate::SIMDArgMinMax;
+    use crate::{Int, SIMDArgMinMax, SCALAR};
 
     use super::super::test_utils::{
         test_first_index_identical_values_argminmax, test_long_array_argminmax,
@@ -512,9 +524,9 @@ mod tests {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[template]
     #[rstest]
-    #[case::sse(SSE, is_x86_feature_detected!("sse4.1"))]
-    #[case::avx2(AVX2, is_x86_feature_detected!("avx2"))]
-    #[case::avx512(AVX512, is_x86_feature_detected!("avx512bw"))]
+    #[case::sse(SSE {_dtype_strategy: Int}, is_x86_feature_detected!("sse4.1"))]
+    #[case::avx2(AVX2 {_dtype_strategy: Int}, is_x86_feature_detected!("avx2"))]
+    #[case::avx512(AVX512 {_dtype_strategy: Int}, is_x86_feature_detected!("avx512bw"))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,
@@ -526,7 +538,7 @@ mod tests {
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     #[template]
     #[rstest]
-    #[case::neon(NEON, true)]
+    #[case::neon(NEON {_dtype_strategy: Int}, true)]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,
@@ -545,7 +557,7 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<i16, SIMDV, SIMDM, LANE_SIZE>,
+        T: SIMDArgMinMax<i16, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
@@ -560,7 +572,7 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<i16, SIMDV, SIMDM, LANE_SIZE>,
+        T: SIMDArgMinMax<i16, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
@@ -576,7 +588,7 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<i16, SIMDV, SIMDM, LANE_SIZE>,
+        T: SIMDArgMinMax<i16, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
         SIMDV: Copy,
         SIMDM: Copy,
     {

--- a/src/simd/simd_i16.rs
+++ b/src/simd/simd_i16.rs
@@ -500,6 +500,7 @@ mod neon {
 mod tests {
     use rstest::rstest;
     use rstest_reuse::{self, *};
+    use std::marker::PhantomData;
 
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     use crate::simd::config::NEON;
@@ -523,9 +524,9 @@ mod tests {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[template]
     #[rstest]
-    #[case::sse(SSE {_dtype_strategy: Int}, is_x86_feature_detected!("sse4.1"))]
-    #[case::avx2(AVX2 {_dtype_strategy: Int}, is_x86_feature_detected!("avx2"))]
-    #[case::avx512(AVX512 {_dtype_strategy: Int}, is_x86_feature_detected!("avx512bw"))]
+    #[case::sse(SSE {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("sse4.1"))]
+    #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx2"))]
+    #[case::avx512(AVX512 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx512bw"))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,
@@ -537,7 +538,7 @@ mod tests {
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     #[template]
     #[rstest]
-    #[case::neon(NEON {_dtype_strategy: Int}, true)]
+    #[case::neon(NEON {_dtype_strategy: PhantomData::<Int>}, true)]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,

--- a/src/simd/simd_i16.rs
+++ b/src/simd/simd_i16.rs
@@ -384,7 +384,7 @@ mod neon {
 
     const LANE_SIZE: usize = NEON::<Int>::LANE_SIZE_16;
 
-    impl SIMDOps<i16, int16x8_t, uint16x8_t, LANE_SIZE, SCALAR> for NEON<Int> {
+    impl SIMDOps<i16, int16x8_t, uint16x8_t, LANE_SIZE> for NEON<Int> {
         const INITIAL_INDEX: int16x8_t =
             unsafe { std::mem::transmute([0i16, 1i16, 2i16, 3i16, 4i16, 5i16, 6i16, 7i16]) };
         const INDEX_INCREMENT: int16x8_t =
@@ -480,7 +480,7 @@ mod neon {
 
     impl_SIMDInit_Int!(i16, int16x8_t, uint16x8_t, LANE_SIZE, NEON<Int>);
 
-    impl SIMDArgMinMax<i16, int16x8_t, uint16x8_t, LANE_SIZE> for NEON<Int> {
+    impl SIMDArgMinMax<i16, int16x8_t, uint16x8_t, LANE_SIZE, SCALAR> for NEON<Int> {
         #[target_feature(enable = "neon")]
         unsafe fn argminmax(data: &[i16]) -> (usize, usize) {
             Self::_argminmax(data)

--- a/src/simd/simd_i32.rs
+++ b/src/simd/simd_i32.rs
@@ -1,5 +1,6 @@
 use super::config::SIMDInstructionSet;
-use super::generic::{SIMDArgMinMax, SIMDOps};
+use super::generic::{impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
+use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 #[cfg(target_arch = "arm")]
@@ -8,6 +9,9 @@ use std::arch::arm::*;
 use std::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
+
+/// The dtype-strategy for performing operations on i32 data: (default) Int
+use super::super::dtype_strategy::Int;
 
 const MAX_INDEX: usize = i32::MAX as usize;
 
@@ -18,9 +22,9 @@ mod avx2 {
     use super::super::config::AVX2;
     use super::*;
 
-    const LANE_SIZE: usize = AVX2::LANE_SIZE_32;
+    const LANE_SIZE: usize = AVX2::<Int>::LANE_SIZE_32;
 
-    impl SIMDOps<i32, __m256i, __m256i, LANE_SIZE> for AVX2 {
+    impl SIMDOps<i32, __m256i, __m256i, LANE_SIZE> for AVX2<Int> {
         const INITIAL_INDEX: __m256i =
             unsafe { std::mem::transmute([0i32, 1i32, 2i32, 3i32, 4i32, 5i32, 6i32, 7i32]) };
         const INDEX_INCREMENT: __m256i =
@@ -58,7 +62,9 @@ mod avx2 {
         }
     }
 
-    impl SIMDArgMinMax<i32, __m256i, __m256i, LANE_SIZE> for AVX2 {
+    impl_SIMDInit_Int!(i32, __m256i, __m256i, LANE_SIZE, AVX2<Int>);
+
+    impl SIMDArgMinMax<i32, __m256i, __m256i, LANE_SIZE, SCALAR> for AVX2<Int> {
         #[target_feature(enable = "avx2")]
         unsafe fn argminmax(data: &[i32]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -73,9 +79,9 @@ mod sse {
     use super::super::config::SSE;
     use super::*;
 
-    const LANE_SIZE: usize = SSE::LANE_SIZE_32;
+    const LANE_SIZE: usize = SSE::<Int>::LANE_SIZE_32;
 
-    impl SIMDOps<i32, __m128i, __m128i, LANE_SIZE> for SSE {
+    impl SIMDOps<i32, __m128i, __m128i, LANE_SIZE> for SSE<Int> {
         const INITIAL_INDEX: __m128i = unsafe { std::mem::transmute([0i32, 1i32, 2i32, 3i32]) };
         const INDEX_INCREMENT: __m128i =
             unsafe { std::mem::transmute([LANE_SIZE as i32; LANE_SIZE]) };
@@ -112,7 +118,9 @@ mod sse {
         }
     }
 
-    impl SIMDArgMinMax<i32, __m128i, __m128i, LANE_SIZE> for SSE {
+    impl_SIMDInit_Int!(i32, __m128i, __m128i, LANE_SIZE, SSE<Int>);
+
+    impl SIMDArgMinMax<i32, __m128i, __m128i, LANE_SIZE, SCALAR> for SSE<Int> {
         #[target_feature(enable = "sse4.1")]
         unsafe fn argminmax(data: &[i32]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -127,9 +135,9 @@ mod avx512 {
     use super::super::config::AVX512;
     use super::*;
 
-    const LANE_SIZE: usize = AVX512::LANE_SIZE_32;
+    const LANE_SIZE: usize = AVX512::<Int>::LANE_SIZE_32;
 
-    impl SIMDOps<i32, __m512i, u16, LANE_SIZE> for AVX512 {
+    impl SIMDOps<i32, __m512i, u16, LANE_SIZE> for AVX512<Int> {
         const INITIAL_INDEX: __m512i = unsafe {
             std::mem::transmute([
                 0i32, 1i32, 2i32, 3i32, 4i32, 5i32, 6i32, 7i32, 8i32, 9i32, 10i32, 11i32, 12i32,
@@ -171,7 +179,9 @@ mod avx512 {
         }
     }
 
-    impl SIMDArgMinMax<i32, __m512i, u16, LANE_SIZE> for AVX512 {
+    impl_SIMDInit_Int!(i32, __m512i, u16, LANE_SIZE, AVX512<Int>);
+
+    impl SIMDArgMinMax<i32, __m512i, u16, LANE_SIZE, SCALAR> for AVX512<Int> {
         #[target_feature(enable = "avx512f")]
         unsafe fn argminmax(data: &[i32]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -186,9 +196,9 @@ mod neon {
     use super::super::config::NEON;
     use super::*;
 
-    const LANE_SIZE: usize = NEON::LANE_SIZE_32;
+    const LANE_SIZE: usize = NEON::<Int>::LANE_SIZE_32;
 
-    impl SIMDOps<i32, int32x4_t, uint32x4_t, LANE_SIZE> for NEON {
+    impl SIMDOps<i32, int32x4_t, uint32x4_t, LANE_SIZE> for NEON<Int> {
         const INITIAL_INDEX: int32x4_t = unsafe { std::mem::transmute([0i32, 1i32, 2i32, 3i32]) };
         const INDEX_INCREMENT: int32x4_t =
             unsafe { std::mem::transmute([LANE_SIZE as i32; LANE_SIZE]) };
@@ -225,7 +235,9 @@ mod neon {
         }
     }
 
-    impl SIMDArgMinMax<i32, int32x4_t, uint32x4_t, LANE_SIZE> for NEON {
+    impl_SIMDInit_Int!(i32, int32x4_t, uint32x4_t, LANE_SIZE, NEON<Int>);
+
+    impl SIMDArgMinMax<i32, int32x4_t, uint32x4_t, LANE_SIZE, SCALAR> for NEON<Int> {
         #[target_feature(enable = "neon")]
         unsafe fn argminmax(data: &[i32]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -246,12 +258,11 @@ mod tests {
     use rstest::rstest;
     use rstest_reuse::{self, *};
 
-    use crate::scalar::generic::scalar_argminmax;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, AVX512, SSE};
-    use crate::SIMDArgMinMax;
+    use crate::{Int, SIMDArgMinMax, ScalarArgMinMax, SCALAR}; // TODO: use ScalarArgMinMax everywhere for consistency
 
     use super::super::test_utils::{
         test_first_index_identical_values_argminmax, test_long_array_argminmax,
@@ -269,9 +280,9 @@ mod tests {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[template]
     #[rstest]
-    #[case::sse(SSE, is_x86_feature_detected!("sse4.1"))]
-    #[case::avx2(AVX2, is_x86_feature_detected!("avx2"))]
-    #[case::avx512(AVX512, is_x86_feature_detected!("avx512f"))]
+    #[case::sse(SSE {_dtype_strategy: Int}, is_x86_feature_detected!("sse4.1"))]
+    #[case::avx2(AVX2 {_dtype_strategy: Int}, is_x86_feature_detected!("avx2"))]
+    #[case::avx512(AVX512 {_dtype_strategy: Int}, is_x86_feature_detected!("avx512f"))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,
@@ -283,7 +294,7 @@ mod tests {
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     #[template]
     #[rstest]
-    #[case::neon(NEON, true)]
+    #[case::neon(NEON {_dtype_strategy: Int}, true)]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,
@@ -302,14 +313,14 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<i32, SIMDV, SIMDM, LANE_SIZE>,
+        T: SIMDArgMinMax<i32, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
         if !simd_available {
             return;
         }
-        test_first_index_identical_values_argminmax(scalar_argminmax, T::argminmax);
+        test_first_index_identical_values_argminmax(SCALAR::argminmax, T::argminmax);
     }
 
     #[apply(simd_implementations)]
@@ -317,14 +328,14 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<i32, SIMDV, SIMDM, LANE_SIZE>,
+        T: SIMDArgMinMax<i32, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
         if !simd_available {
             return;
         }
-        test_long_array_argminmax(get_array_i32, scalar_argminmax, T::argminmax);
-        test_random_runs_argminmax(get_array_i32, scalar_argminmax, T::argminmax);
+        test_long_array_argminmax(get_array_i32, SCALAR::argminmax, T::argminmax);
+        test_random_runs_argminmax(get_array_i32, SCALAR::argminmax, T::argminmax);
     }
 }

--- a/src/simd/simd_i32.rs
+++ b/src/simd/simd_i32.rs
@@ -64,7 +64,7 @@ mod avx2 {
 
     impl_SIMDInit_Int!(i32, __m256i, __m256i, LANE_SIZE, AVX2<Int>);
 
-    impl SIMDArgMinMax<i32, __m256i, __m256i, LANE_SIZE, SCALAR> for AVX2<Int> {
+    impl SIMDArgMinMax<i32, __m256i, __m256i, LANE_SIZE, SCALAR<Int>> for AVX2<Int> {
         #[target_feature(enable = "avx2")]
         unsafe fn argminmax(data: &[i32]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -120,7 +120,7 @@ mod sse {
 
     impl_SIMDInit_Int!(i32, __m128i, __m128i, LANE_SIZE, SSE<Int>);
 
-    impl SIMDArgMinMax<i32, __m128i, __m128i, LANE_SIZE, SCALAR> for SSE<Int> {
+    impl SIMDArgMinMax<i32, __m128i, __m128i, LANE_SIZE, SCALAR<Int>> for SSE<Int> {
         #[target_feature(enable = "sse4.1")]
         unsafe fn argminmax(data: &[i32]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -181,7 +181,7 @@ mod avx512 {
 
     impl_SIMDInit_Int!(i32, __m512i, u16, LANE_SIZE, AVX512<Int>);
 
-    impl SIMDArgMinMax<i32, __m512i, u16, LANE_SIZE, SCALAR> for AVX512<Int> {
+    impl SIMDArgMinMax<i32, __m512i, u16, LANE_SIZE, SCALAR<Int>> for AVX512<Int> {
         #[target_feature(enable = "avx512f")]
         unsafe fn argminmax(data: &[i32]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -237,7 +237,7 @@ mod neon {
 
     impl_SIMDInit_Int!(i32, int32x4_t, uint32x4_t, LANE_SIZE, NEON<Int>);
 
-    impl SIMDArgMinMax<i32, int32x4_t, uint32x4_t, LANE_SIZE, SCALAR> for NEON<Int> {
+    impl SIMDArgMinMax<i32, int32x4_t, uint32x4_t, LANE_SIZE, SCALAR<Int>> for NEON<Int> {
         #[target_feature(enable = "neon")]
         unsafe fn argminmax(data: &[i32]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -262,7 +262,7 @@ mod tests {
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, AVX512, SSE};
-    use crate::{Int, SIMDArgMinMax, ScalarArgMinMax, SCALAR}; // TODO: use ScalarArgMinMax everywhere for consistency
+    use crate::{Int, SIMDArgMinMax, ScalarArgMinMax, SCALAR};
 
     use super::super::test_utils::{
         test_first_index_identical_values_argminmax, test_long_array_argminmax,
@@ -313,14 +313,14 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<i32, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
+        T: SIMDArgMinMax<i32, SIMDV, SIMDM, LANE_SIZE, SCALAR<Int>>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
         if !simd_available {
             return;
         }
-        test_first_index_identical_values_argminmax(SCALAR::argminmax, T::argminmax);
+        test_first_index_identical_values_argminmax(SCALAR::<Int>::argminmax, T::argminmax);
     }
 
     #[apply(simd_implementations)]
@@ -328,14 +328,14 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<i32, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
+        T: SIMDArgMinMax<i32, SIMDV, SIMDM, LANE_SIZE, SCALAR<Int>>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
         if !simd_available {
             return;
         }
-        test_long_array_argminmax(get_array_i32, SCALAR::argminmax, T::argminmax);
-        test_random_runs_argminmax(get_array_i32, SCALAR::argminmax, T::argminmax);
+        test_long_array_argminmax(get_array_i32, SCALAR::<Int>::argminmax, T::argminmax);
+        test_random_runs_argminmax(get_array_i32, SCALAR::<Int>::argminmax, T::argminmax);
     }
 }

--- a/src/simd/simd_i32.rs
+++ b/src/simd/simd_i32.rs
@@ -257,6 +257,7 @@ mod neon {
 mod tests {
     use rstest::rstest;
     use rstest_reuse::{self, *};
+    use std::marker::PhantomData;
 
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     use crate::simd::config::NEON;
@@ -280,9 +281,9 @@ mod tests {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[template]
     #[rstest]
-    #[case::sse(SSE {_dtype_strategy: Int}, is_x86_feature_detected!("sse4.1"))]
-    #[case::avx2(AVX2 {_dtype_strategy: Int}, is_x86_feature_detected!("avx2"))]
-    #[case::avx512(AVX512 {_dtype_strategy: Int}, is_x86_feature_detected!("avx512f"))]
+    #[case::sse(SSE {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("sse4.1"))]
+    #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx2"))]
+    #[case::avx512(AVX512 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx512f"))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,
@@ -294,7 +295,7 @@ mod tests {
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     #[template]
     #[rstest]
-    #[case::neon(NEON {_dtype_strategy: Int}, true)]
+    #[case::neon(NEON {_dtype_strategy: PhantomData::<Int>}, true)]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,

--- a/src/simd/simd_i64.rs
+++ b/src/simd/simd_i64.rs
@@ -1,6 +1,8 @@
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use super::config::SIMDInstructionSet;
-use super::generic::{impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+use super::generic::impl_SIMDInit_Int;
+use super::generic::{SIMDArgMinMax, SIMDInit, SIMDOps};
 use crate::SCALAR;
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;
@@ -61,7 +63,7 @@ mod avx2 {
 
     impl_SIMDInit_Int!(i64, __m256i, __m256i, LANE_SIZE, AVX2<Int>);
 
-    impl SIMDArgMinMax<i64, __m256i, __m256i, LANE_SIZE, SCALAR> for AVX2<Int> {
+    impl SIMDArgMinMax<i64, __m256i, __m256i, LANE_SIZE, SCALAR<Int>> for AVX2<Int> {
         #[target_feature(enable = "avx2")]
         unsafe fn argminmax(data: &[i64]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -117,7 +119,7 @@ mod sse {
 
     impl_SIMDInit_Int!(i64, __m128i, __m128i, LANE_SIZE, SSE<Int>);
 
-    impl SIMDArgMinMax<i64, __m128i, __m128i, LANE_SIZE, SCALAR> for SSE<Int> {
+    impl SIMDArgMinMax<i64, __m128i, __m128i, LANE_SIZE, SCALAR<Int>> for SSE<Int> {
         #[target_feature(enable = "sse4.2")]
         unsafe fn argminmax(data: &[i64]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -174,7 +176,7 @@ mod avx512 {
 
     impl_SIMDInit_Int!(i64, __m512i, u8, LANE_SIZE, AVX512<Int>);
 
-    impl SIMDArgMinMax<i64, __m512i, u8, LANE_SIZE, SCALAR> for AVX512<Int> {
+    impl SIMDArgMinMax<i64, __m512i, u8, LANE_SIZE, SCALAR<Int>> for AVX512<Int> {
         #[target_feature(enable = "avx512f")]
         unsafe fn argminmax(data: &[i64]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -201,7 +203,7 @@ mod neon {
     // > 64 bit data types.
     unimpl_SIMDOps!(i64, usize, NEON<Int>);
     unimpl_SIMDInit!(i64, usize, NEON<Int>);
-    unimpl_SIMDArgMinMax!(i64, usize, SCALAR, NEON<Int>);
+    unimpl_SIMDArgMinMax!(i64, usize, SCALAR<FloatReturnNaN>, NEON<Int>);
 }
 
 // ======================================= TESTS =======================================
@@ -212,9 +214,8 @@ mod tests {
     use rstest::rstest;
     use rstest_reuse::{self, *};
 
-    use crate::scalar::generic::scalar_argminmax;
     use crate::simd::config::{AVX2, AVX512, SSE};
-    use crate::{Int, SIMDArgMinMax, SCALAR};
+    use crate::{Int, SIMDArgMinMax, ScalarArgMinMax, SCALAR};
 
     use super::super::test_utils::{
         test_first_index_identical_values_argminmax, test_long_array_argminmax,
@@ -252,14 +253,14 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<i64, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
+        T: SIMDArgMinMax<i64, SIMDV, SIMDM, LANE_SIZE, SCALAR<Int>>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
         if !simd_available {
             return;
         }
-        test_first_index_identical_values_argminmax(scalar_argminmax, T::argminmax);
+        test_first_index_identical_values_argminmax(SCALAR::<Int>::argminmax, T::argminmax);
     }
 
     #[apply(simd_implementations)]
@@ -267,14 +268,14 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<i64, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
+        T: SIMDArgMinMax<i64, SIMDV, SIMDM, LANE_SIZE, SCALAR<Int>>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
         if !simd_available {
             return;
         }
-        test_long_array_argminmax(get_array_i64, scalar_argminmax, T::argminmax);
-        test_random_runs_argminmax(get_array_i64, scalar_argminmax, T::argminmax);
+        test_long_array_argminmax(get_array_i64, SCALAR::<Int>::argminmax, T::argminmax);
+        test_random_runs_argminmax(get_array_i64, SCALAR::<Int>::argminmax, T::argminmax);
     }
 }

--- a/src/simd/simd_i64.rs
+++ b/src/simd/simd_i64.rs
@@ -213,6 +213,7 @@ mod neon {
 mod tests {
     use rstest::rstest;
     use rstest_reuse::{self, *};
+    use std::marker::PhantomData;
 
     use crate::simd::config::{AVX2, AVX512, SSE};
     use crate::{Int, SIMDArgMinMax, ScalarArgMinMax, SCALAR};
@@ -232,9 +233,9 @@ mod tests {
 
     #[template]
     #[rstest]
-    #[case::sse(SSE {_dtype_strategy: Int}, is_x86_feature_detected!("sse4.2"))]
-    #[case::avx2(AVX2 {_dtype_strategy: Int}, is_x86_feature_detected!("avx2"))]
-    #[case::avx512(AVX512 {_dtype_strategy: Int}, is_x86_feature_detected!("avx512f"))]
+    #[case::sse(SSE {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("sse4.2"))]
+    #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx2"))]
+    #[case::avx512(AVX512 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx512f"))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,

--- a/src/simd/simd_i64.rs
+++ b/src/simd/simd_i64.rs
@@ -203,7 +203,7 @@ mod neon {
     // > 64 bit data types.
     unimpl_SIMDOps!(i64, usize, NEON<Int>);
     unimpl_SIMDInit!(i64, usize, NEON<Int>);
-    unimpl_SIMDArgMinMax!(i64, usize, SCALAR<FloatReturnNaN>, NEON<Int>);
+    unimpl_SIMDArgMinMax!(i64, usize, SCALAR<Int>, NEON<Int>);
 }
 
 // ======================================= TESTS =======================================

--- a/src/simd/simd_i8.rs
+++ b/src/simd/simd_i8.rs
@@ -527,6 +527,7 @@ mod neon {
 mod tests {
     use rstest::rstest;
     use rstest_reuse::{self, *};
+    use std::marker::PhantomData;
 
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     use crate::simd::config::NEON;
@@ -550,9 +551,9 @@ mod tests {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[template]
     #[rstest]
-    #[case::sse(SSE {_dtype_strategy: Int}, is_x86_feature_detected!("sse4.1"))]
-    #[case::avx2(AVX2 {_dtype_strategy: Int}, is_x86_feature_detected!("avx2"))]
-    #[case::avx512(AVX512 {_dtype_strategy: Int}, is_x86_feature_detected!("avx512bw"))]
+    #[case::sse(SSE {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("sse4.1"))]
+    #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx2"))]
+    #[case::avx512(AVX512 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx512bw"))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,
@@ -564,7 +565,7 @@ mod tests {
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     #[template]
     #[rstest]
-    #[case::neon(NEON {_dtype_strategy: Int}, true)]
+    #[case::neon(NEON {_dtype_strategy: PhantomData::<Int>}, true)]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,

--- a/src/simd/simd_i8.rs
+++ b/src/simd/simd_i8.rs
@@ -133,7 +133,7 @@ mod avx2 {
 
     impl_SIMDInit_Int!(i8, __m256i, __m256i, LANE_SIZE, AVX2<Int>);
 
-    impl SIMDArgMinMax<i8, __m256i, __m256i, LANE_SIZE, SCALAR> for AVX2<Int> {
+    impl SIMDArgMinMax<i8, __m256i, __m256i, LANE_SIZE, SCALAR<Int>> for AVX2<Int> {
         #[target_feature(enable = "avx2")]
         unsafe fn argminmax(data: &[i8]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -253,7 +253,7 @@ mod sse {
 
     impl_SIMDInit_Int!(i8, __m128i, __m128i, LANE_SIZE, SSE<Int>);
 
-    impl SIMDArgMinMax<i8, __m128i, __m128i, LANE_SIZE, SCALAR> for SSE<Int> {
+    impl SIMDArgMinMax<i8, __m128i, __m128i, LANE_SIZE, SCALAR<Int>> for SSE<Int> {
         #[target_feature(enable = "sse4.1")]
         unsafe fn argminmax(data: &[i8]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -385,7 +385,7 @@ mod avx512 {
 
     impl_SIMDInit_Int!(i8, __m512i, u64, LANE_SIZE, AVX512<Int>);
 
-    impl SIMDArgMinMax<i8, __m512i, u64, LANE_SIZE, SCALAR> for AVX512<Int> {
+    impl SIMDArgMinMax<i8, __m512i, u64, LANE_SIZE, SCALAR<Int>> for AVX512<Int> {
         #[target_feature(enable = "avx512bw")]
         unsafe fn argminmax(data: &[i8]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -507,7 +507,7 @@ mod neon {
 
     impl_SIMDInit_Int!(i8, int8x16_t, uint8x16_t, LANE_SIZE, NEON<Int>);
 
-    impl SIMDArgMinMax<i8, int8x16_t, uint8x16_t, LANE_SIZE, SCALAR> for NEON<Int> {
+    impl SIMDArgMinMax<i8, int8x16_t, uint8x16_t, LANE_SIZE, SCALAR<Int>> for NEON<Int> {
         #[target_feature(enable = "neon")]
         unsafe fn argminmax(data: &[i8]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -528,12 +528,11 @@ mod tests {
     use rstest::rstest;
     use rstest_reuse::{self, *};
 
-    use crate::scalar::generic::scalar_argminmax;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, AVX512, SSE};
-    use crate::{Int, SIMDArgMinMax, SCALAR};
+    use crate::{Int, SIMDArgMinMax, ScalarArgMinMax, SCALAR};
 
     use super::super::test_utils::{
         test_first_index_identical_values_argminmax, test_long_array_argminmax,
@@ -584,14 +583,14 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<i8, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
+        T: SIMDArgMinMax<i8, SIMDV, SIMDM, LANE_SIZE, SCALAR<Int>>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
         if !simd_available {
             return;
         }
-        test_first_index_identical_values_argminmax(scalar_argminmax, T::argminmax);
+        test_first_index_identical_values_argminmax(SCALAR::<Int>::argminmax, T::argminmax);
     }
 
     #[apply(simd_implementations)]
@@ -599,15 +598,15 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<i8, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
+        T: SIMDArgMinMax<i8, SIMDV, SIMDM, LANE_SIZE, SCALAR<Int>>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
         if !simd_available {
             return;
         }
-        test_long_array_argminmax(get_array_i8, scalar_argminmax, T::argminmax);
-        test_random_runs_argminmax(get_array_i8, scalar_argminmax, T::argminmax);
+        test_long_array_argminmax(get_array_i8, SCALAR::<Int>::argminmax, T::argminmax);
+        test_random_runs_argminmax(get_array_i8, SCALAR::<Int>::argminmax, T::argminmax);
     }
 
     #[apply(simd_implementations)]
@@ -615,13 +614,13 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<i8, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
+        T: SIMDArgMinMax<i8, SIMDV, SIMDM, LANE_SIZE, SCALAR<Int>>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
         if !simd_available {
             return;
         }
-        test_no_overflow_argminmax(get_array_i8, scalar_argminmax, T::argminmax, None);
+        test_no_overflow_argminmax(get_array_i8, SCALAR::<Int>::argminmax, T::argminmax, None);
     }
 }

--- a/src/simd/simd_i8.rs
+++ b/src/simd/simd_i8.rs
@@ -1,5 +1,6 @@
 use super::config::SIMDInstructionSet;
-use super::generic::{SIMDArgMinMax, SIMDOps};
+use super::generic::{impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
+use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 #[cfg(target_arch = "arm")]
@@ -8,6 +9,9 @@ use std::arch::arm::*;
 use std::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
+
+/// The dtype-strategy for performing operations on i8 data: (default) Int
+use super::super::dtype_strategy::Int;
 
 const MAX_INDEX: usize = i8::MAX as usize;
 
@@ -18,9 +22,9 @@ mod avx2 {
     use super::super::config::AVX2;
     use super::*;
 
-    const LANE_SIZE: usize = AVX2::LANE_SIZE_8;
+    const LANE_SIZE: usize = AVX2::<Int>::LANE_SIZE_8;
 
-    impl SIMDOps<i8, __m256i, __m256i, LANE_SIZE> for AVX2 {
+    impl SIMDOps<i8, __m256i, __m256i, LANE_SIZE> for AVX2<Int> {
         const INITIAL_INDEX: __m256i = unsafe {
             std::mem::transmute([
                 0i8, 1i8, 2i8, 3i8, 4i8, 5i8, 6i8, 7i8, 8i8, 9i8, 10i8, 11i8, 12i8, 13i8, 14i8,
@@ -127,7 +131,9 @@ mod avx2 {
         }
     }
 
-    impl SIMDArgMinMax<i8, __m256i, __m256i, LANE_SIZE> for AVX2 {
+    impl_SIMDInit_Int!(i8, __m256i, __m256i, LANE_SIZE, AVX2<Int>);
+
+    impl SIMDArgMinMax<i8, __m256i, __m256i, LANE_SIZE, SCALAR> for AVX2<Int> {
         #[target_feature(enable = "avx2")]
         unsafe fn argminmax(data: &[i8]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -141,9 +147,9 @@ mod sse {
     use super::super::config::SSE;
     use super::*;
 
-    const LANE_SIZE: usize = SSE::LANE_SIZE_8;
+    const LANE_SIZE: usize = SSE::<Int>::LANE_SIZE_8;
 
-    impl SIMDOps<i8, __m128i, __m128i, LANE_SIZE> for SSE {
+    impl SIMDOps<i8, __m128i, __m128i, LANE_SIZE> for SSE<Int> {
         const INITIAL_INDEX: __m128i = unsafe {
             std::mem::transmute([
                 0i8, 1i8, 2i8, 3i8, 4i8, 5i8, 6i8, 7i8, 8i8, 9i8, 10i8, 11i8, 12i8, 13i8, 14i8,
@@ -245,7 +251,9 @@ mod sse {
         }
     }
 
-    impl SIMDArgMinMax<i8, __m128i, __m128i, LANE_SIZE> for SSE {
+    impl_SIMDInit_Int!(i8, __m128i, __m128i, LANE_SIZE, SSE<Int>);
+
+    impl SIMDArgMinMax<i8, __m128i, __m128i, LANE_SIZE, SCALAR> for SSE<Int> {
         #[target_feature(enable = "sse4.1")]
         unsafe fn argminmax(data: &[i8]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -260,9 +268,9 @@ mod avx512 {
     use super::super::config::AVX512;
     use super::*;
 
-    const LANE_SIZE: usize = AVX512::LANE_SIZE_8;
+    const LANE_SIZE: usize = AVX512::<Int>::LANE_SIZE_8;
 
-    impl SIMDOps<i8, __m512i, u64, LANE_SIZE> for AVX512 {
+    impl SIMDOps<i8, __m512i, u64, LANE_SIZE> for AVX512<Int> {
         const INITIAL_INDEX: __m512i = unsafe {
             std::mem::transmute([
                 0i8, 1i8, 2i8, 3i8, 4i8, 5i8, 6i8, 7i8, 8i8, 9i8, 10i8, 11i8, 12i8, 13i8, 14i8,
@@ -375,7 +383,9 @@ mod avx512 {
         }
     }
 
-    impl SIMDArgMinMax<i8, __m512i, u64, LANE_SIZE> for AVX512 {
+    impl_SIMDInit_Int!(i8, __m512i, u64, LANE_SIZE, AVX512<Int>);
+
+    impl SIMDArgMinMax<i8, __m512i, u64, LANE_SIZE, SCALAR> for AVX512<Int> {
         #[target_feature(enable = "avx512bw")]
         unsafe fn argminmax(data: &[i8]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -390,9 +400,9 @@ mod neon {
     use super::super::config::NEON;
     use super::*;
 
-    const LANE_SIZE: usize = NEON::LANE_SIZE_8;
+    const LANE_SIZE: usize = NEON::<Int>::LANE_SIZE_8;
 
-    impl SIMDOps<i8, int8x16_t, uint8x16_t, LANE_SIZE> for NEON {
+    impl SIMDOps<i8, int8x16_t, uint8x16_t, LANE_SIZE> for NEON<Int> {
         const INITIAL_INDEX: int8x16_t = unsafe {
             std::mem::transmute([
                 0i8, 1i8, 2i8, 3i8, 4i8, 5i8, 6i8, 7i8, 8i8, 9i8, 10i8, 11i8, 12i8, 13i8, 14i8,
@@ -495,7 +505,9 @@ mod neon {
         }
     }
 
-    impl SIMDArgMinMax<i8, int8x16_t, uint8x16_t, LANE_SIZE> for NEON {
+    impl_SIMDInit_Int!(i8, int8x16_t, uint8x16_t, LANE_SIZE, NEON<Int>);
+
+    impl SIMDArgMinMax<i8, int8x16_t, uint8x16_t, LANE_SIZE, SCALAR> for NEON<Int> {
         #[target_feature(enable = "neon")]
         unsafe fn argminmax(data: &[i8]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -521,7 +533,7 @@ mod tests {
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, AVX512, SSE};
-    use crate::SIMDArgMinMax;
+    use crate::{Int, SIMDArgMinMax, SCALAR};
 
     use super::super::test_utils::{
         test_first_index_identical_values_argminmax, test_long_array_argminmax,
@@ -539,9 +551,9 @@ mod tests {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[template]
     #[rstest]
-    #[case::sse(SSE, is_x86_feature_detected!("sse4.1"))]
-    #[case::avx2(AVX2, is_x86_feature_detected!("avx2"))]
-    #[case::avx512(AVX512, is_x86_feature_detected!("avx512bw"))]
+    #[case::sse(SSE {_dtype_strategy: Int}, is_x86_feature_detected!("sse4.1"))]
+    #[case::avx2(AVX2 {_dtype_strategy: Int}, is_x86_feature_detected!("avx2"))]
+    #[case::avx512(AVX512 {_dtype_strategy: Int}, is_x86_feature_detected!("avx512bw"))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,
@@ -553,7 +565,7 @@ mod tests {
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     #[template]
     #[rstest]
-    #[case::neon(NEON, true)]
+    #[case::neon(NEON {_dtype_strategy: Int}, true)]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,
@@ -572,7 +584,7 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<i8, SIMDV, SIMDM, LANE_SIZE>,
+        T: SIMDArgMinMax<i8, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
@@ -587,7 +599,7 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<i8, SIMDV, SIMDM, LANE_SIZE>,
+        T: SIMDArgMinMax<i8, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
@@ -603,7 +615,7 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<i8, SIMDV, SIMDM, LANE_SIZE>,
+        T: SIMDArgMinMax<i8, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
         SIMDV: Copy,
         SIMDM: Copy,
     {

--- a/src/simd/simd_u16.rs
+++ b/src/simd/simd_u16.rs
@@ -570,6 +570,7 @@ mod neon {
 mod tests {
     use rstest::rstest;
     use rstest_reuse::{self, *};
+    use std::marker::PhantomData;
 
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     use crate::simd::config::NEON;
@@ -593,9 +594,9 @@ mod tests {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[template]
     #[rstest]
-    #[case::sse(SSE {_dtype_strategy: Int}, is_x86_feature_detected!("sse4.1"))]
-    #[case::avx2(AVX2 {_dtype_strategy: Int}, is_x86_feature_detected!("avx2"))]
-    #[case::avx512(AVX512 {_dtype_strategy: Int}, is_x86_feature_detected!("avx512bw"))]
+    #[case::sse(SSE {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("sse4.1"))]
+    #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx2"))]
+    #[case::avx512(AVX512 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx512bw"))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,
@@ -607,7 +608,7 @@ mod tests {
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     #[template]
     #[rstest]
-    #[case::neon(NEON {_dtype_strategy: Int}, true)]
+    #[case::neon(NEON {_dtype_strategy: PhantomData::<Int>}, true)]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,

--- a/src/simd/simd_u16.rs
+++ b/src/simd/simd_u16.rs
@@ -166,7 +166,7 @@ mod avx2 {
 
     impl_SIMDInit_Int!(u16, __m256i, __m256i, LANE_SIZE, AVX2<Int>);
 
-    impl SIMDArgMinMax<u16, __m256i, __m256i, LANE_SIZE, SCALAR> for AVX2<Int> {
+    impl SIMDArgMinMax<u16, __m256i, __m256i, LANE_SIZE, SCALAR<Int>> for AVX2<Int> {
         #[target_feature(enable = "avx2")]
         unsafe fn argminmax(data: &[u16]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -295,7 +295,7 @@ mod sse {
 
     impl_SIMDInit_Int!(u16, __m128i, __m128i, LANE_SIZE, SSE<Int>);
 
-    impl SIMDArgMinMax<u16, __m128i, __m128i, LANE_SIZE, SCALAR> for SSE<Int> {
+    impl SIMDArgMinMax<u16, __m128i, __m128i, LANE_SIZE, SCALAR<Int>> for SSE<Int> {
         #[target_feature(enable = "sse4.1")]
         unsafe fn argminmax(data: &[u16]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -437,7 +437,7 @@ mod avx512 {
 
     impl_SIMDInit_Int!(u16, __m512i, u32, LANE_SIZE, AVX512<Int>);
 
-    impl SIMDArgMinMax<u16, __m512i, u32, LANE_SIZE, SCALAR> for AVX512<Int> {
+    impl SIMDArgMinMax<u16, __m512i, u32, LANE_SIZE, SCALAR<Int>> for AVX512<Int> {
         #[target_feature(enable = "avx512bw")]
         unsafe fn argminmax(data: &[u16]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -550,7 +550,7 @@ mod neon {
 
     impl_SIMDInit_Int!(u16, uint16x8_t, uint16x8_t, LANE_SIZE, NEON<Int>);
 
-    impl SIMDArgMinMax<u16, uint16x8_t, uint16x8_t, LANE_SIZE, SCALAR> for NEON<Int> {
+    impl SIMDArgMinMax<u16, uint16x8_t, uint16x8_t, LANE_SIZE, SCALAR<Int>> for NEON<Int> {
         #[target_feature(enable = "neon")]
         unsafe fn argminmax(data: &[u16]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -571,12 +571,11 @@ mod tests {
     use rstest::rstest;
     use rstest_reuse::{self, *};
 
-    use crate::scalar::generic::scalar_argminmax;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, AVX512, SSE};
-    use crate::{Int, SIMDArgMinMax, SCALAR};
+    use crate::{Int, SIMDArgMinMax, ScalarArgMinMax, SCALAR};
 
     use super::super::test_utils::{
         test_first_index_identical_values_argminmax, test_long_array_argminmax,
@@ -627,14 +626,14 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<u16, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
+        T: SIMDArgMinMax<u16, SIMDV, SIMDM, LANE_SIZE, SCALAR<Int>>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
         if !simd_available {
             return;
         }
-        test_first_index_identical_values_argminmax(scalar_argminmax, T::argminmax);
+        test_first_index_identical_values_argminmax(SCALAR::<Int>::argminmax, T::argminmax);
     }
 
     #[apply(simd_implementations)]
@@ -642,15 +641,15 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<u16, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
+        T: SIMDArgMinMax<u16, SIMDV, SIMDM, LANE_SIZE, SCALAR<Int>>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
         if !simd_available {
             return;
         }
-        test_long_array_argminmax(get_array_u16, scalar_argminmax, T::argminmax);
-        test_random_runs_argminmax(get_array_u16, scalar_argminmax, T::argminmax);
+        test_long_array_argminmax(get_array_u16, SCALAR::<Int>::argminmax, T::argminmax);
+        test_random_runs_argminmax(get_array_u16, SCALAR::<Int>::argminmax, T::argminmax);
     }
 
     #[apply(simd_implementations)]
@@ -658,13 +657,13 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<u16, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
+        T: SIMDArgMinMax<u16, SIMDV, SIMDM, LANE_SIZE, SCALAR<Int>>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
         if !simd_available {
             return;
         }
-        test_no_overflow_argminmax(get_array_u16, scalar_argminmax, T::argminmax, None);
+        test_no_overflow_argminmax(get_array_u16, SCALAR::<Int>::argminmax, T::argminmax, None);
     }
 }

--- a/src/simd/simd_u32.rs
+++ b/src/simd/simd_u32.rs
@@ -121,7 +121,7 @@ mod avx2 {
 
     impl_SIMDInit_Int!(u32, __m256i, __m256i, LANE_SIZE, AVX2<Int>);
 
-    impl SIMDArgMinMax<u32, __m256i, __m256i, LANE_SIZE, SCALAR> for AVX2<Int> {
+    impl SIMDArgMinMax<u32, __m256i, __m256i, LANE_SIZE, SCALAR<Int>> for AVX2<Int> {
         #[target_feature(enable = "avx2")]
         unsafe fn argminmax(data: &[u32]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -209,7 +209,7 @@ mod sse {
 
     impl_SIMDInit_Int!(u32, __m128i, __m128i, LANE_SIZE, SSE<Int>);
 
-    impl SIMDArgMinMax<u32, __m128i, __m128i, LANE_SIZE, SCALAR> for SSE<Int> {
+    impl SIMDArgMinMax<u32, __m128i, __m128i, LANE_SIZE, SCALAR<Int>> for SSE<Int> {
         #[target_feature(enable = "sse4.1")]
         unsafe fn argminmax(data: &[u32]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -302,7 +302,7 @@ mod avx512 {
 
     impl_SIMDInit_Int!(u32, __m512i, u16, LANE_SIZE, AVX512<Int>);
 
-    impl SIMDArgMinMax<u32, __m512i, u16, LANE_SIZE, SCALAR> for AVX512<Int> {
+    impl SIMDArgMinMax<u32, __m512i, u16, LANE_SIZE, SCALAR<Int>> for AVX512<Int> {
         #[target_feature(enable = "avx512f")]
         unsafe fn argminmax(data: &[u32]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -358,7 +358,7 @@ mod neon {
 
     impl_SIMDInit_Int!(u32, uint32x4_t, uint32x4_t, LANE_SIZE, NEON<Int>);
 
-    impl SIMDArgMinMax<u32, uint32x4_t, uint32x4_t, LANE_SIZE, SCALAR> for NEON<Int> {
+    impl SIMDArgMinMax<u32, uint32x4_t, uint32x4_t, LANE_SIZE, SCALAR<Int>> for NEON<Int> {
         #[target_feature(enable = "neon")]
         unsafe fn argminmax(data: &[u32]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -379,12 +379,11 @@ mod tests {
     use rstest::rstest;
     use rstest_reuse::{self, *};
 
-    use crate::scalar::generic::scalar_argminmax;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, AVX512, SSE};
-    use crate::{Int, SIMDArgMinMax, SCALAR};
+    use crate::{Int, SIMDArgMinMax, ScalarArgMinMax, SCALAR};
 
     use super::super::test_utils::{
         test_first_index_identical_values_argminmax, test_long_array_argminmax,
@@ -435,14 +434,14 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<u32, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
+        T: SIMDArgMinMax<u32, SIMDV, SIMDM, LANE_SIZE, SCALAR<Int>>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
         if !simd_available {
             return;
         }
-        test_first_index_identical_values_argminmax(scalar_argminmax, T::argminmax);
+        test_first_index_identical_values_argminmax(SCALAR::<Int>::argminmax, T::argminmax);
     }
 
     #[apply(simd_implementations)]
@@ -450,14 +449,14 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<u32, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
+        T: SIMDArgMinMax<u32, SIMDV, SIMDM, LANE_SIZE, SCALAR<Int>>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
         if !simd_available {
             return;
         }
-        test_long_array_argminmax(get_array_u32, scalar_argminmax, T::argminmax);
-        test_random_runs_argminmax(get_array_u32, scalar_argminmax, T::argminmax);
+        test_long_array_argminmax(get_array_u32, SCALAR::<Int>::argminmax, T::argminmax);
+        test_random_runs_argminmax(get_array_u32, SCALAR::<Int>::argminmax, T::argminmax);
     }
 }

--- a/src/simd/simd_u32.rs
+++ b/src/simd/simd_u32.rs
@@ -378,6 +378,7 @@ mod neon {
 mod tests {
     use rstest::rstest;
     use rstest_reuse::{self, *};
+    use std::marker::PhantomData;
 
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     use crate::simd::config::NEON;
@@ -401,9 +402,9 @@ mod tests {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[template]
     #[rstest]
-    #[case::sse(SSE {_dtype_strategy: Int}, is_x86_feature_detected!("sse4.1"))]
-    #[case::avx2(AVX2 {_dtype_strategy: Int}, is_x86_feature_detected!("avx2"))]
-    #[case::avx512(AVX512 {_dtype_strategy: Int}, is_x86_feature_detected!("avx512f"))]
+    #[case::sse(SSE {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("sse4.1"))]
+    #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx2"))]
+    #[case::avx512(AVX512 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx512f"))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,
@@ -415,7 +416,7 @@ mod tests {
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     #[template]
     #[rstest]
-    #[case::neon(NEON {_dtype_strategy: Int}, true)]
+    #[case::neon(NEON {_dtype_strategy: PhantomData::<Int>}, true)]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,

--- a/src/simd/simd_u32.rs
+++ b/src/simd/simd_u32.rs
@@ -11,7 +11,8 @@
 /// values.
 ///
 use super::config::SIMDInstructionSet;
-use super::generic::{SIMDArgMinMax, SIMDOps};
+use super::generic::{impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
+use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 #[cfg(target_arch = "arm")]
@@ -20,6 +21,9 @@ use std::arch::arm::*;
 use std::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
+
+/// The dtype-strategy for performing operations on u32 data: (default) Int
+use super::super::dtype_strategy::Int;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use super::task::{max_index_value, min_index_value};
@@ -43,7 +47,7 @@ mod avx2 {
     use super::super::config::AVX2;
     use super::*;
 
-    const LANE_SIZE: usize = AVX2::LANE_SIZE_32;
+    const LANE_SIZE: usize = AVX2::<Int>::LANE_SIZE_32;
     const XOR_MASK: __m256i = unsafe { std::mem::transmute([XOR_VALUE; LANE_SIZE]) };
 
     #[inline(always)]
@@ -58,7 +62,7 @@ mod avx2 {
         std::mem::transmute::<__m256i, [i32; LANE_SIZE]>(reg)
     }
 
-    impl SIMDOps<u32, __m256i, __m256i, LANE_SIZE> for AVX2 {
+    impl SIMDOps<u32, __m256i, __m256i, LANE_SIZE> for AVX2<Int> {
         const INITIAL_INDEX: __m256i =
             unsafe { std::mem::transmute([0i32, 1i32, 2i32, 3i32, 4i32, 5i32, 6i32, 7i32]) };
         const INDEX_INCREMENT: __m256i =
@@ -115,7 +119,9 @@ mod avx2 {
         }
     }
 
-    impl SIMDArgMinMax<u32, __m256i, __m256i, LANE_SIZE> for AVX2 {
+    impl_SIMDInit_Int!(u32, __m256i, __m256i, LANE_SIZE, AVX2<Int>);
+
+    impl SIMDArgMinMax<u32, __m256i, __m256i, LANE_SIZE, SCALAR> for AVX2<Int> {
         #[target_feature(enable = "avx2")]
         unsafe fn argminmax(data: &[u32]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -130,7 +136,7 @@ mod sse {
     use super::super::config::SSE;
     use super::*;
 
-    const LANE_SIZE: usize = SSE::LANE_SIZE_32;
+    const LANE_SIZE: usize = SSE::<Int>::LANE_SIZE_32;
     const XOR_MASK: __m128i = unsafe { std::mem::transmute([XOR_VALUE; LANE_SIZE]) };
 
     #[inline(always)]
@@ -145,7 +151,7 @@ mod sse {
         std::mem::transmute::<__m128i, [i32; LANE_SIZE]>(reg)
     }
 
-    impl SIMDOps<u32, __m128i, __m128i, LANE_SIZE> for SSE {
+    impl SIMDOps<u32, __m128i, __m128i, LANE_SIZE> for SSE<Int> {
         const INITIAL_INDEX: __m128i = unsafe { std::mem::transmute([0i32, 1i32, 2i32, 3i32]) };
         const INDEX_INCREMENT: __m128i =
             unsafe { std::mem::transmute([LANE_SIZE as i32; LANE_SIZE]) };
@@ -201,7 +207,9 @@ mod sse {
         }
     }
 
-    impl SIMDArgMinMax<u32, __m128i, __m128i, LANE_SIZE> for SSE {
+    impl_SIMDInit_Int!(u32, __m128i, __m128i, LANE_SIZE, SSE<Int>);
+
+    impl SIMDArgMinMax<u32, __m128i, __m128i, LANE_SIZE, SCALAR> for SSE<Int> {
         #[target_feature(enable = "sse4.1")]
         unsafe fn argminmax(data: &[u32]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -216,7 +224,7 @@ mod avx512 {
     use super::super::config::AVX512;
     use super::*;
 
-    const LANE_SIZE: usize = AVX512::LANE_SIZE_32;
+    const LANE_SIZE: usize = AVX512::<Int>::LANE_SIZE_32;
     const XOR_MASK: __m512i = unsafe { std::mem::transmute([XOR_VALUE; LANE_SIZE]) };
 
     #[inline(always)]
@@ -231,7 +239,7 @@ mod avx512 {
         std::mem::transmute::<__m512i, [i32; LANE_SIZE]>(reg)
     }
 
-    impl SIMDOps<u32, __m512i, u16, LANE_SIZE> for AVX512 {
+    impl SIMDOps<u32, __m512i, u16, LANE_SIZE> for AVX512<Int> {
         const INITIAL_INDEX: __m512i = unsafe {
             std::mem::transmute([
                 0i32, 1i32, 2i32, 3i32, 4i32, 5i32, 6i32, 7i32, 8i32, 9i32, 10i32, 11i32, 12i32,
@@ -292,7 +300,9 @@ mod avx512 {
         }
     }
 
-    impl SIMDArgMinMax<u32, __m512i, u16, LANE_SIZE> for AVX512 {
+    impl_SIMDInit_Int!(u32, __m512i, u16, LANE_SIZE, AVX512<Int>);
+
+    impl SIMDArgMinMax<u32, __m512i, u16, LANE_SIZE, SCALAR> for AVX512<Int> {
         #[target_feature(enable = "avx512f")]
         unsafe fn argminmax(data: &[u32]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -307,9 +317,9 @@ mod neon {
     use super::super::config::NEON;
     use super::*;
 
-    const LANE_SIZE: usize = NEON::LANE_SIZE_32;
+    const LANE_SIZE: usize = NEON::<Int>::LANE_SIZE_32;
 
-    impl SIMDOps<u32, uint32x4_t, uint32x4_t, LANE_SIZE> for NEON {
+    impl SIMDOps<u32, uint32x4_t, uint32x4_t, LANE_SIZE> for NEON<Int> {
         const INITIAL_INDEX: uint32x4_t = unsafe { std::mem::transmute([0u32, 1u32, 2u32, 3u32]) };
         const INDEX_INCREMENT: uint32x4_t =
             unsafe { std::mem::transmute([LANE_SIZE as i32; LANE_SIZE]) };
@@ -346,7 +356,9 @@ mod neon {
         }
     }
 
-    impl SIMDArgMinMax<u32, uint32x4_t, uint32x4_t, LANE_SIZE> for NEON {
+    impl_SIMDInit_Int!(u32, uint32x4_t, uint32x4_t, LANE_SIZE, NEON<Int>);
+
+    impl SIMDArgMinMax<u32, uint32x4_t, uint32x4_t, LANE_SIZE, SCALAR> for NEON<Int> {
         #[target_feature(enable = "neon")]
         unsafe fn argminmax(data: &[u32]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -372,7 +384,7 @@ mod tests {
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, AVX512, SSE};
-    use crate::SIMDArgMinMax;
+    use crate::{Int, SIMDArgMinMax, SCALAR};
 
     use super::super::test_utils::{
         test_first_index_identical_values_argminmax, test_long_array_argminmax,
@@ -390,9 +402,9 @@ mod tests {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[template]
     #[rstest]
-    #[case::sse(SSE, is_x86_feature_detected!("sse4.1"))]
-    #[case::avx2(AVX2, is_x86_feature_detected!("avx2"))]
-    #[case::avx512(AVX512, is_x86_feature_detected!("avx512f"))]
+    #[case::sse(SSE {_dtype_strategy: Int}, is_x86_feature_detected!("sse4.1"))]
+    #[case::avx2(AVX2 {_dtype_strategy: Int}, is_x86_feature_detected!("avx2"))]
+    #[case::avx512(AVX512 {_dtype_strategy: Int}, is_x86_feature_detected!("avx512f"))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,
@@ -404,7 +416,7 @@ mod tests {
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     #[template]
     #[rstest]
-    #[case::neon(NEON, true)]
+    #[case::neon(NEON {_dtype_strategy: Int}, true)]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,
@@ -423,7 +435,7 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<u32, SIMDV, SIMDM, LANE_SIZE>,
+        T: SIMDArgMinMax<u32, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
@@ -438,7 +450,7 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<u32, SIMDV, SIMDM, LANE_SIZE>,
+        T: SIMDArgMinMax<u32, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
         SIMDV: Copy,
         SIMDM: Copy,
     {

--- a/src/simd/simd_u64.rs
+++ b/src/simd/simd_u64.rs
@@ -13,11 +13,15 @@
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use super::config::SIMDInstructionSet;
-use super::generic::{SIMDArgMinMax, SIMDOps};
+use super::generic::{impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
+use crate::SCALAR;
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
+
+/// The dtype-strategy for performing operations on u64 data: (default) Int
+use super::super::dtype_strategy::Int;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use super::task::{max_index_value, min_index_value};
@@ -42,7 +46,7 @@ mod avx2 {
     use super::super::config::AVX2;
     use super::*;
 
-    const LANE_SIZE: usize = AVX2::LANE_SIZE_64;
+    const LANE_SIZE: usize = AVX2::<Int>::LANE_SIZE_64;
     const XOR_MASK: __m256i = unsafe { std::mem::transmute([XOR_VALUE; LANE_SIZE]) };
 
     #[inline(always)]
@@ -57,7 +61,7 @@ mod avx2 {
         std::mem::transmute::<__m256i, [i64; LANE_SIZE]>(reg)
     }
 
-    impl SIMDOps<u64, __m256i, __m256i, LANE_SIZE> for AVX2 {
+    impl SIMDOps<u64, __m256i, __m256i, LANE_SIZE> for AVX2<Int> {
         const INITIAL_INDEX: __m256i = unsafe { std::mem::transmute([0i64, 1i64, 2i64, 3i64]) };
         const INDEX_INCREMENT: __m256i =
             unsafe { std::mem::transmute([LANE_SIZE as i64; LANE_SIZE]) };
@@ -113,7 +117,9 @@ mod avx2 {
         }
     }
 
-    impl SIMDArgMinMax<u64, __m256i, __m256i, LANE_SIZE> for AVX2 {
+    impl_SIMDInit_Int!(u64, __m256i, __m256i, LANE_SIZE, AVX2<Int>);
+
+    impl SIMDArgMinMax<u64, __m256i, __m256i, LANE_SIZE, SCALAR> for AVX2<Int> {
         #[target_feature(enable = "avx2")]
         unsafe fn argminmax(data: &[u64]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -128,7 +134,7 @@ mod sse {
     use super::super::config::SSE;
     use super::*;
 
-    const LANE_SIZE: usize = SSE::LANE_SIZE_64;
+    const LANE_SIZE: usize = SSE::<Int>::LANE_SIZE_64;
     const XOR_MASK: __m128i = unsafe { std::mem::transmute([XOR_VALUE; LANE_SIZE]) };
 
     #[inline(always)]
@@ -143,7 +149,7 @@ mod sse {
         std::mem::transmute::<__m128i, [i64; LANE_SIZE]>(reg)
     }
 
-    impl SIMDOps<u64, __m128i, __m128i, LANE_SIZE> for SSE {
+    impl SIMDOps<u64, __m128i, __m128i, LANE_SIZE> for SSE<Int> {
         const INITIAL_INDEX: __m128i = unsafe { std::mem::transmute([0i64, 1i64]) };
         const INDEX_INCREMENT: __m128i =
             unsafe { std::mem::transmute([LANE_SIZE as i64; LANE_SIZE]) };
@@ -199,7 +205,9 @@ mod sse {
         }
     }
 
-    impl SIMDArgMinMax<u64, __m128i, __m128i, LANE_SIZE> for SSE {
+    impl_SIMDInit_Int!(u64, __m128i, __m128i, LANE_SIZE, SSE<Int>);
+
+    impl SIMDArgMinMax<u64, __m128i, __m128i, LANE_SIZE, SCALAR> for SSE<Int> {
         #[target_feature(enable = "sse4.2")]
         unsafe fn argminmax(data: &[u64]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -214,7 +222,7 @@ mod avx512 {
     use super::super::config::AVX512;
     use super::*;
 
-    const LANE_SIZE: usize = AVX512::LANE_SIZE_64;
+    const LANE_SIZE: usize = AVX512::<Int>::LANE_SIZE_64;
     const XOR_MASK: __m512i = unsafe { std::mem::transmute([XOR_VALUE; LANE_SIZE]) };
 
     #[inline(always)]
@@ -229,7 +237,7 @@ mod avx512 {
         std::mem::transmute::<__m512i, [i64; LANE_SIZE]>(reg)
     }
 
-    impl SIMDOps<u64, __m512i, u8, LANE_SIZE> for AVX512 {
+    impl SIMDOps<u64, __m512i, u8, LANE_SIZE> for AVX512<Int> {
         const INITIAL_INDEX: __m512i =
             unsafe { std::mem::transmute([0i64, 1i64, 2i64, 3i64, 4i64, 5i64, 6i64, 7i64]) };
         const INDEX_INCREMENT: __m512i =
@@ -286,7 +294,9 @@ mod avx512 {
         }
     }
 
-    impl SIMDArgMinMax<u64, __m512i, u8, LANE_SIZE> for AVX512 {
+    impl_SIMDInit_Int!(u64, __m512i, u8, LANE_SIZE, AVX512<Int>);
+
+    impl SIMDArgMinMax<u64, __m512i, u8, LANE_SIZE, SCALAR> for AVX512<Int> {
         #[target_feature(enable = "avx512f")]
         unsafe fn argminmax(data: &[u64]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -304,15 +314,16 @@ mod avx512 {
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 mod neon {
     use super::super::config::NEON;
-    use super::super::generic::{unimpl_SIMDArgMinMax, unimpl_SIMDOps};
+    use super::super::generic::{unimpl_SIMDArgMinMax, unimpl_SIMDInit, unimpl_SIMDOps};
     use super::*;
 
     // We need to (un)implement the SIMD trait for the NEON struct as otherwise the
     // compiler will complain that the trait is not implemented for the struct -
     // even though we are not using the trait for the NEON struct when dealing with
     // > 64 bit data types.
-    unimpl_SIMDOps!(u64, usize, NEON);
-    unimpl_SIMDArgMinMax!(u64, usize, NEON);
+    unimpl_SIMDOps!(u64, usize, NEON<Int>);
+    unimpl_SIMDInit!(u64, usize, NEON<Int>);
+    unimpl_SIMDArgMinMax!(u64, usize, SCALAR, NEON<Int>);
 }
 
 // ======================================= TESTS =======================================
@@ -325,7 +336,7 @@ mod tests {
 
     use crate::scalar::generic::scalar_argminmax;
     use crate::simd::config::{AVX2, AVX512, SSE};
-    use crate::SIMDArgMinMax;
+    use crate::{Int, SIMDArgMinMax, SCALAR};
 
     use super::super::test_utils::{
         test_first_index_identical_values_argminmax, test_long_array_argminmax,
@@ -343,9 +354,9 @@ mod tests {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[template]
     #[rstest]
-    #[case::sse(SSE, is_x86_feature_detected!("sse4.2"))]
-    #[case::avx2(AVX2, is_x86_feature_detected!("avx2"))]
-    #[case::avx512(AVX512, is_x86_feature_detected!("avx512f"))]
+    #[case::sse(SSE {_dtype_strategy: Int}, is_x86_feature_detected!("sse4.2"))]
+    #[case::avx2(AVX2 {_dtype_strategy: Int}, is_x86_feature_detected!("avx2"))]
+    #[case::avx512(AVX512 {_dtype_strategy: Int}, is_x86_feature_detected!("avx512f"))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,
@@ -364,7 +375,7 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<u64, SIMDV, SIMDM, LANE_SIZE>,
+        T: SIMDArgMinMax<u64, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
@@ -379,7 +390,7 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<u64, SIMDV, SIMDM, LANE_SIZE>,
+        T: SIMDArgMinMax<u64, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
         SIMDV: Copy,
         SIMDM: Copy,
     {

--- a/src/simd/simd_u64.rs
+++ b/src/simd/simd_u64.rs
@@ -335,6 +335,7 @@ mod neon {
 mod tests {
     use rstest::rstest;
     use rstest_reuse::{self, *};
+    use std::marker::PhantomData;
 
     use crate::simd::config::{AVX2, AVX512, SSE};
     use crate::{Int, SIMDArgMinMax, ScalarArgMinMax, SCALAR};
@@ -355,9 +356,9 @@ mod tests {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[template]
     #[rstest]
-    #[case::sse(SSE {_dtype_strategy: Int}, is_x86_feature_detected!("sse4.2"))]
-    #[case::avx2(AVX2 {_dtype_strategy: Int}, is_x86_feature_detected!("avx2"))]
-    #[case::avx512(AVX512 {_dtype_strategy: Int}, is_x86_feature_detected!("avx512f"))]
+    #[case::sse(SSE {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("sse4.2"))]
+    #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx2"))]
+    #[case::avx512(AVX512 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx512f"))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,

--- a/src/simd/simd_u8.rs
+++ b/src/simd/simd_u8.rs
@@ -171,7 +171,7 @@ mod avx2 {
 
     impl_SIMDInit_Int!(u8, __m256i, __m256i, LANE_SIZE, AVX2<Int>);
 
-    impl SIMDArgMinMax<u8, __m256i, __m256i, LANE_SIZE, SCALAR> for AVX2<Int> {
+    impl SIMDArgMinMax<u8, __m256i, __m256i, LANE_SIZE, SCALAR<Int>> for AVX2<Int> {
         #[target_feature(enable = "avx2")]
         unsafe fn argminmax(data: &[u8]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -308,7 +308,7 @@ mod sse {
 
     impl_SIMDInit_Int!(u8, __m128i, __m128i, LANE_SIZE, SSE<Int>);
 
-    impl SIMDArgMinMax<u8, __m128i, __m128i, LANE_SIZE, SCALAR> for SSE<Int> {
+    impl SIMDArgMinMax<u8, __m128i, __m128i, LANE_SIZE, SCALAR<Int>> for SSE<Int> {
         #[target_feature(enable = "sse4.1")]
         unsafe fn argminmax(data: &[u8]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -456,7 +456,7 @@ mod avx512 {
 
     impl_SIMDInit_Int!(u8, __m512i, u64, LANE_SIZE, AVX512<Int>);
 
-    impl SIMDArgMinMax<u8, __m512i, u64, LANE_SIZE, SCALAR> for AVX512<Int> {
+    impl SIMDArgMinMax<u8, __m512i, u64, LANE_SIZE, SCALAR<Int>> for AVX512<Int> {
         #[target_feature(enable = "avx512bw")]
         unsafe fn argminmax(data: &[u8]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -577,7 +577,7 @@ mod neon {
 
     impl_SIMDInit_Int!(u8, uint8x16_t, uint8x16_t, LANE_SIZE, NEON<Int>);
 
-    impl SIMDArgMinMax<u8, uint8x16_t, uint8x16_t, LANE_SIZE, SCALAR> for NEON<Int> {
+    impl SIMDArgMinMax<u8, uint8x16_t, uint8x16_t, LANE_SIZE, SCALAR<Int>> for NEON<Int> {
         #[target_feature(enable = "neon")]
         unsafe fn argminmax(data: &[u8]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -598,12 +598,11 @@ mod tests {
     use rstest::rstest;
     use rstest_reuse::{self, *};
 
-    use crate::scalar::generic::scalar_argminmax;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, AVX512, SSE};
-    use crate::{Int, SIMDArgMinMax, SCALAR};
+    use crate::{Int, SIMDArgMinMax, ScalarArgMinMax, SCALAR};
 
     use super::super::test_utils::{
         test_first_index_identical_values_argminmax, test_long_array_argminmax,
@@ -654,14 +653,14 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<u8, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
+        T: SIMDArgMinMax<u8, SIMDV, SIMDM, LANE_SIZE, SCALAR<Int>>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
         if !simd_available {
             return;
         }
-        test_first_index_identical_values_argminmax(scalar_argminmax, T::argminmax);
+        test_first_index_identical_values_argminmax(SCALAR::<Int>::argminmax, T::argminmax);
     }
 
     #[apply(simd_implementations)]
@@ -669,15 +668,15 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<u8, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
+        T: SIMDArgMinMax<u8, SIMDV, SIMDM, LANE_SIZE, SCALAR<Int>>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
         if !simd_available {
             return;
         }
-        test_long_array_argminmax(get_array_u8, scalar_argminmax, T::argminmax);
-        test_random_runs_argminmax(get_array_u8, scalar_argminmax, T::argminmax);
+        test_long_array_argminmax(get_array_u8, SCALAR::<Int>::argminmax, T::argminmax);
+        test_random_runs_argminmax(get_array_u8, SCALAR::<Int>::argminmax, T::argminmax);
     }
 
     #[apply(simd_implementations)]
@@ -685,13 +684,13 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<u8, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
+        T: SIMDArgMinMax<u8, SIMDV, SIMDM, LANE_SIZE, SCALAR<Int>>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
         if !simd_available {
             return;
         }
-        test_no_overflow_argminmax(get_array_u8, scalar_argminmax, T::argminmax, None);
+        test_no_overflow_argminmax(get_array_u8, SCALAR::<Int>::argminmax, T::argminmax, None);
     }
 }

--- a/src/simd/simd_u8.rs
+++ b/src/simd/simd_u8.rs
@@ -597,6 +597,7 @@ mod neon {
 mod tests {
     use rstest::rstest;
     use rstest_reuse::{self, *};
+    use std::marker::PhantomData;
 
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     use crate::simd::config::NEON;
@@ -620,9 +621,9 @@ mod tests {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[template]
     #[rstest]
-    #[case::sse(SSE {_dtype_strategy: Int}, is_x86_feature_detected!("sse4.1"))]
-    #[case::avx2(AVX2 {_dtype_strategy: Int}, is_x86_feature_detected!("avx2"))]
-    #[case::avx512(AVX512 {_dtype_strategy: Int}, is_x86_feature_detected!("avx512bw"))]
+    #[case::sse(SSE {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("sse4.1"))]
+    #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx2"))]
+    #[case::avx512(AVX512 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx512bw"))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,
@@ -634,7 +635,7 @@ mod tests {
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     #[template]
     #[rstest]
-    #[case::neon(NEON {_dtype_strategy: Int}, true)]
+    #[case::neon(NEON {_dtype_strategy: PhantomData::<Int>}, true)]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,

--- a/src/simd/simd_u8.rs
+++ b/src/simd/simd_u8.rs
@@ -11,7 +11,8 @@
 /// values.
 ///
 use super::config::SIMDInstructionSet;
-use super::generic::{SIMDArgMinMax, SIMDOps};
+use super::generic::{impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
+use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 #[cfg(target_arch = "arm")]
@@ -20,6 +21,9 @@ use std::arch::arm::*;
 use std::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
+
+/// The dtype-strategy for performing operations on u8 data: (default) Int
+use super::super::dtype_strategy::Int;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 const XOR_VALUE: i8 = -0x80; // i8::MIN
@@ -40,7 +44,7 @@ mod avx2 {
     use super::super::config::AVX2;
     use super::*;
 
-    const LANE_SIZE: usize = AVX2::LANE_SIZE_8;
+    const LANE_SIZE: usize = AVX2::<Int>::LANE_SIZE_8;
     const XOR_MASK: __m256i = unsafe { std::mem::transmute([XOR_VALUE; LANE_SIZE]) };
 
     #[inline(always)]
@@ -55,7 +59,7 @@ mod avx2 {
         std::mem::transmute::<__m256i, [i8; LANE_SIZE]>(reg)
     }
 
-    impl SIMDOps<u8, __m256i, __m256i, LANE_SIZE> for AVX2 {
+    impl SIMDOps<u8, __m256i, __m256i, LANE_SIZE> for AVX2<Int> {
         const INITIAL_INDEX: __m256i = unsafe {
             std::mem::transmute([
                 0i8, 1i8, 2i8, 3i8, 4i8, 5i8, 6i8, 7i8, 8i8, 9i8, 10i8, 11i8, 12i8, 13i8, 14i8,
@@ -165,7 +169,9 @@ mod avx2 {
         }
     }
 
-    impl SIMDArgMinMax<u8, __m256i, __m256i, LANE_SIZE> for AVX2 {
+    impl_SIMDInit_Int!(u8, __m256i, __m256i, LANE_SIZE, AVX2<Int>);
+
+    impl SIMDArgMinMax<u8, __m256i, __m256i, LANE_SIZE, SCALAR> for AVX2<Int> {
         #[target_feature(enable = "avx2")]
         unsafe fn argminmax(data: &[u8]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -180,7 +186,7 @@ mod sse {
     use super::super::config::SSE;
     use super::*;
 
-    const LANE_SIZE: usize = SSE::LANE_SIZE_8;
+    const LANE_SIZE: usize = SSE::<Int>::LANE_SIZE_8;
     const XOR_MASK: __m128i = unsafe { std::mem::transmute([XOR_VALUE; LANE_SIZE]) };
 
     #[inline(always)]
@@ -195,7 +201,7 @@ mod sse {
         std::mem::transmute::<__m128i, [i8; LANE_SIZE]>(reg)
     }
 
-    impl SIMDOps<u8, __m128i, __m128i, LANE_SIZE> for SSE {
+    impl SIMDOps<u8, __m128i, __m128i, LANE_SIZE> for SSE<Int> {
         const INITIAL_INDEX: __m128i = unsafe {
             std::mem::transmute([
                 0i8, 1i8, 2i8, 3i8, 4i8, 5i8, 6i8, 7i8, 8i8, 9i8, 10i8, 11i8, 12i8, 13i8, 14i8,
@@ -300,7 +306,9 @@ mod sse {
         }
     }
 
-    impl SIMDArgMinMax<u8, __m128i, __m128i, LANE_SIZE> for SSE {
+    impl_SIMDInit_Int!(u8, __m128i, __m128i, LANE_SIZE, SSE<Int>);
+
+    impl SIMDArgMinMax<u8, __m128i, __m128i, LANE_SIZE, SCALAR> for SSE<Int> {
         #[target_feature(enable = "sse4.1")]
         unsafe fn argminmax(data: &[u8]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -315,7 +323,7 @@ mod avx512 {
     use super::super::config::AVX512;
     use super::*;
 
-    const LANE_SIZE: usize = AVX512::LANE_SIZE_8;
+    const LANE_SIZE: usize = AVX512::<Int>::LANE_SIZE_8;
     const XOR_MASK: __m512i = unsafe { std::mem::transmute([XOR_VALUE; LANE_SIZE]) };
 
     #[inline(always)]
@@ -330,7 +338,7 @@ mod avx512 {
         std::mem::transmute::<__m512i, [i8; LANE_SIZE]>(reg)
     }
 
-    impl SIMDOps<u8, __m512i, u64, LANE_SIZE> for AVX512 {
+    impl SIMDOps<u8, __m512i, u64, LANE_SIZE> for AVX512<Int> {
         const INITIAL_INDEX: __m512i = unsafe {
             std::mem::transmute([
                 0i8, 1i8, 2i8, 3i8, 4i8, 5i8, 6i8, 7i8, 8i8, 9i8, 10i8, 11i8, 12i8, 13i8, 14i8,
@@ -446,7 +454,9 @@ mod avx512 {
         }
     }
 
-    impl SIMDArgMinMax<u8, __m512i, u64, LANE_SIZE> for AVX512 {
+    impl_SIMDInit_Int!(u8, __m512i, u64, LANE_SIZE, AVX512<Int>);
+
+    impl SIMDArgMinMax<u8, __m512i, u64, LANE_SIZE, SCALAR> for AVX512<Int> {
         #[target_feature(enable = "avx512bw")]
         unsafe fn argminmax(data: &[u8]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -461,9 +471,9 @@ mod neon {
     use super::super::config::NEON;
     use super::*;
 
-    const LANE_SIZE: usize = NEON::LANE_SIZE_8;
+    const LANE_SIZE: usize = NEON::<Int>::LANE_SIZE_8;
 
-    impl SIMDOps<u8, uint8x16_t, uint8x16_t, LANE_SIZE> for NEON {
+    impl SIMDOps<u8, uint8x16_t, uint8x16_t, LANE_SIZE> for NEON<Int> {
         const INITIAL_INDEX: uint8x16_t = unsafe {
             std::mem::transmute([
                 0u8, 1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8, 8u8, 9u8, 10u8, 11u8, 12u8, 13u8, 14u8,
@@ -565,7 +575,9 @@ mod neon {
         }
     }
 
-    impl SIMDArgMinMax<u8, uint8x16_t, uint8x16_t, LANE_SIZE> for NEON {
+    impl_SIMDInit_Int!(u8, uint8x16_t, uint8x16_t, LANE_SIZE, NEON<Int>);
+
+    impl SIMDArgMinMax<u8, uint8x16_t, uint8x16_t, LANE_SIZE, SCALAR> for NEON<Int> {
         #[target_feature(enable = "neon")]
         unsafe fn argminmax(data: &[u8]) -> (usize, usize) {
             Self::_argminmax(data)
@@ -591,7 +603,7 @@ mod tests {
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, AVX512, SSE};
-    use crate::SIMDArgMinMax;
+    use crate::{Int, SIMDArgMinMax, SCALAR};
 
     use super::super::test_utils::{
         test_first_index_identical_values_argminmax, test_long_array_argminmax,
@@ -609,9 +621,9 @@ mod tests {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[template]
     #[rstest]
-    #[case::sse(SSE, is_x86_feature_detected!("sse4.1"))]
-    #[case::avx2(AVX2, is_x86_feature_detected!("avx2"))]
-    #[case::avx512(AVX512, is_x86_feature_detected!("avx512bw"))]
+    #[case::sse(SSE {_dtype_strategy: Int}, is_x86_feature_detected!("sse4.1"))]
+    #[case::avx2(AVX2 {_dtype_strategy: Int}, is_x86_feature_detected!("avx2"))]
+    #[case::avx512(AVX512 {_dtype_strategy: Int}, is_x86_feature_detected!("avx512bw"))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,
@@ -623,7 +635,7 @@ mod tests {
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     #[template]
     #[rstest]
-    #[case::neon(NEON, true)]
+    #[case::neon(NEON {_dtype_strategy: Int}, true)]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] _simd: T,
         #[case] simd_available: bool,
@@ -642,7 +654,7 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<u8, SIMDV, SIMDM, LANE_SIZE>,
+        T: SIMDArgMinMax<u8, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
@@ -657,7 +669,7 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<u8, SIMDV, SIMDM, LANE_SIZE>,
+        T: SIMDArgMinMax<u8, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
         SIMDV: Copy,
         SIMDM: Copy,
     {
@@ -673,7 +685,7 @@ mod tests {
         #[case] _simd: T, // This is just to make sure the template is applied
         #[case] simd_available: bool,
     ) where
-        T: SIMDArgMinMax<u8, SIMDV, SIMDM, LANE_SIZE>,
+        T: SIMDArgMinMax<u8, SIMDV, SIMDM, LANE_SIZE, SCALAR>,
         SIMDV: Copy,
         SIMDM: Copy,
     {


### PR DESCRIPTION
Make the architecture more flexible;
- less duplicate code
- more clear how traits + structs interoperate

To achieve the type-state pattern is applied for the 
- SIMD structs in `simd/config.rs`
- SCALAR struct in `scalar/generic.rs`