### PR TITLE
refactor(test): pass struct to tests instead of method

### DIFF
--- a/src/scalar/generic.rs
+++ b/src/scalar/generic.rs
@@ -40,7 +40,7 @@ pub trait ScalarArgMinMax<ScalarDType: Copy + PartialOrd> {
 /// See the impl_scalar! macro below for the implementation of the ScalarArgMinMax trait
 ///
 pub struct SCALAR<DTypeStrategy> {
-    _phantom: std::marker::PhantomData<DTypeStrategy>,
+    pub(crate) _dtype_strategy: std::marker::PhantomData<DTypeStrategy>,
 }
 
 /// ------- Implement the SCALARInit trait for the different DTypeStrategy -------

--- a/src/simd/simd_f16_return_nan.rs
+++ b/src/simd/simd_f16_return_nan.rs
@@ -651,11 +651,11 @@ mod tests {
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, AVX512, SSE};
-    use crate::{FloatReturnNaN, SIMDArgMinMax, ScalarArgMinMax, SCALAR};
+    use crate::{FloatReturnNaN, SIMDArgMinMax, SCALAR};
 
     use super::super::test_utils::{
-        test_first_index_identical_values_argminmax, test_long_array_argminmax,
-        test_no_overflow_argminmax, test_random_runs_argminmax,
+        test_first_index_identical_values_argminmax, test_no_overflow_argminmax,
+        test_return_same_result_argminmax,
     };
     // Float specific tests
     use super::super::test_utils::{test_return_infs_argminmax, test_return_nans_argminmax};
@@ -667,6 +667,11 @@ mod tests {
         arr.iter().map(|x| f16::from_f32(*x as f32)).collect()
     }
 
+    // The scalar implementation
+    const SCALAR_STRATEGY: SCALAR<FloatReturnNaN> = SCALAR {
+        _dtype_strategy: PhantomData::<FloatReturnNaN>,
+    };
+
     // ------------ Template for x86 / x86_64 -------------
 
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -676,7 +681,7 @@ mod tests {
     #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<FloatReturnNaN>}, is_x86_feature_detected!("avx2"))]
     #[case::avx512(AVX512 {_dtype_strategy: PhantomData::<FloatReturnNaN>}, is_x86_feature_detected!("avx512bw"))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
-        #[case] _simd: T,
+        #[case] simd: T,
         #[case] simd_available: bool,
     ) {
     }
@@ -688,7 +693,7 @@ mod tests {
     #[rstest]
     #[case::neon(NEON {_dtype_strategy: PhantomData::<FloatReturnNaN>}, true)]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
-        #[case] _simd: T,
+        #[case] simd: T,
         #[case] simd_available: bool,
     ) {
     }
@@ -702,7 +707,7 @@ mod tests {
         SIMDM,
         const LANE_SIZE: usize,
     >(
-        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd: T,
         #[case] simd_available: bool,
     ) where
         T: SIMDArgMinMax<f16, SIMDV, SIMDM, LANE_SIZE, SCALAR<FloatReturnNaN>>,
@@ -712,15 +717,12 @@ mod tests {
         if !simd_available {
             return;
         }
-        test_first_index_identical_values_argminmax(
-            SCALAR::<FloatReturnNaN>::argminmax,
-            T::argminmax,
-        );
+        test_first_index_identical_values_argminmax(SCALAR_STRATEGY, simd);
     }
 
     #[apply(simd_implementations)]
     fn test_return_same_result<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
-        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd: T,
         #[case] simd_available: bool,
     ) where
         T: SIMDArgMinMax<f16, SIMDV, SIMDM, LANE_SIZE, SCALAR<FloatReturnNaN>>,
@@ -730,21 +732,12 @@ mod tests {
         if !simd_available {
             return;
         }
-        test_long_array_argminmax(
-            get_array_f16,
-            SCALAR::<FloatReturnNaN>::argminmax,
-            T::argminmax,
-        );
-        test_random_runs_argminmax(
-            get_array_f16,
-            SCALAR::<FloatReturnNaN>::argminmax,
-            T::argminmax,
-        );
+        test_return_same_result_argminmax(get_array_f16, SCALAR_STRATEGY, simd);
     }
 
     #[apply(simd_implementations)]
     fn test_no_overflow<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
-        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd: T,
         #[case] simd_available: bool,
     ) where
         T: SIMDArgMinMax<f16, SIMDV, SIMDM, LANE_SIZE, SCALAR<FloatReturnNaN>>,
@@ -754,17 +747,12 @@ mod tests {
         if !simd_available {
             return;
         }
-        test_no_overflow_argminmax(
-            get_array_f16,
-            SCALAR::<FloatReturnNaN>::argminmax,
-            T::argminmax,
-            None,
-        );
+        test_no_overflow_argminmax(get_array_f16, SCALAR_STRATEGY, simd, None);
     }
 
     #[apply(simd_implementations)]
     fn test_return_infs<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
-        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd: T,
         #[case] simd_available: bool,
     ) where
         T: SIMDArgMinMax<f16, SIMDV, SIMDM, LANE_SIZE, SCALAR<FloatReturnNaN>>,
@@ -774,16 +762,12 @@ mod tests {
         if !simd_available {
             return;
         }
-        test_return_infs_argminmax(
-            get_array_f16,
-            SCALAR::<FloatReturnNaN>::argminmax,
-            T::argminmax,
-        );
+        test_return_infs_argminmax(get_array_f16, SCALAR_STRATEGY, simd);
     }
 
     #[apply(simd_implementations)]
     fn test_return_nans<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
-        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd: T,
         #[case] simd_available: bool,
     ) where
         T: SIMDArgMinMax<f16, SIMDV, SIMDM, LANE_SIZE, SCALAR<FloatReturnNaN>>,
@@ -793,10 +777,6 @@ mod tests {
         if !simd_available {
             return;
         }
-        test_return_nans_argminmax(
-            get_array_f16,
-            SCALAR::<FloatReturnNaN>::argminmax,
-            T::argminmax,
-        );
+        test_return_nans_argminmax(get_array_f16, SCALAR_STRATEGY, simd);
     }
 }

--- a/src/simd/simd_f64_return_nan.rs
+++ b/src/simd/simd_f64_return_nan.rs
@@ -375,11 +375,10 @@ mod tests {
     use std::marker::PhantomData;
 
     use crate::simd::config::{AVX2, AVX512, SSE};
-    use crate::{FloatReturnNaN, SIMDArgMinMax, ScalarArgMinMax, SCALAR};
+    use crate::{FloatReturnNaN, SIMDArgMinMax, SCALAR};
 
     use super::super::test_utils::{
-        test_first_index_identical_values_argminmax, test_long_array_argminmax,
-        test_random_runs_argminmax,
+        test_first_index_identical_values_argminmax, test_return_same_result_argminmax,
     };
     // Float specific tests
     use super::super::test_utils::{test_return_infs_argminmax, test_return_nans_argminmax};
@@ -390,6 +389,11 @@ mod tests {
         utils::get_random_array(n, f64::MIN, f64::MAX)
     }
 
+    // The scalar implementation
+    const SCALAR_STRATEGY: SCALAR<FloatReturnNaN> = SCALAR {
+        _dtype_strategy: PhantomData::<FloatReturnNaN>,
+    };
+
     // ------------ Template for x86 / x86_64 -------------
 
     #[template]
@@ -398,7 +402,7 @@ mod tests {
     #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<FloatReturnNaN>}, is_x86_feature_detected!("avx2"))]
     #[case::avx512(AVX512 {_dtype_strategy: PhantomData::<FloatReturnNaN>}, is_x86_feature_detected!("avx512f"))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
-        #[case] _simd: T,
+        #[case] simd: T,
         #[case] simd_available: bool,
     ) {
     }
@@ -412,7 +416,7 @@ mod tests {
         SIMDM,
         const LANE_SIZE: usize,
     >(
-        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd: T,
         #[case] simd_available: bool,
     ) where
         T: SIMDArgMinMax<f64, SIMDV, SIMDM, LANE_SIZE, SCALAR<FloatReturnNaN>>,
@@ -422,15 +426,12 @@ mod tests {
         if !simd_available {
             return;
         }
-        test_first_index_identical_values_argminmax(
-            SCALAR::<FloatReturnNaN>::argminmax,
-            T::argminmax,
-        );
+        test_first_index_identical_values_argminmax(SCALAR_STRATEGY, simd);
     }
 
     #[apply(simd_implementations)]
     fn test_return_same_result<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
-        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd: T,
         #[case] simd_available: bool,
     ) where
         T: SIMDArgMinMax<f64, SIMDV, SIMDM, LANE_SIZE, SCALAR<FloatReturnNaN>>,
@@ -440,21 +441,12 @@ mod tests {
         if !simd_available {
             return;
         }
-        test_long_array_argminmax(
-            get_array_f64,
-            SCALAR::<FloatReturnNaN>::argminmax,
-            T::argminmax,
-        );
-        test_random_runs_argminmax(
-            get_array_f64,
-            SCALAR::<FloatReturnNaN>::argminmax,
-            T::argminmax,
-        );
+        test_return_same_result_argminmax(get_array_f64, SCALAR_STRATEGY, simd);
     }
 
     #[apply(simd_implementations)]
     fn test_return_infs<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
-        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd: T,
         #[case] simd_available: bool,
     ) where
         T: SIMDArgMinMax<f64, SIMDV, SIMDM, LANE_SIZE, SCALAR<FloatReturnNaN>>,
@@ -464,16 +456,12 @@ mod tests {
         if !simd_available {
             return;
         }
-        test_return_infs_argminmax(
-            get_array_f64,
-            SCALAR::<FloatReturnNaN>::argminmax,
-            T::argminmax,
-        );
+        test_return_infs_argminmax(get_array_f64, SCALAR_STRATEGY, simd);
     }
 
     #[apply(simd_implementations)]
     fn test_return_nans<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
-        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd: T,
         #[case] simd_available: bool,
     ) where
         T: SIMDArgMinMax<f64, SIMDV, SIMDM, LANE_SIZE, SCALAR<FloatReturnNaN>>,
@@ -483,10 +471,6 @@ mod tests {
         if !simd_available {
             return;
         }
-        test_return_nans_argminmax(
-            get_array_f64,
-            SCALAR::<FloatReturnNaN>::argminmax,
-            T::argminmax,
-        );
+        test_return_nans_argminmax(get_array_f64, SCALAR_STRATEGY, simd);
     }
 }

--- a/src/simd/simd_i32.rs
+++ b/src/simd/simd_i32.rs
@@ -263,11 +263,10 @@ mod tests {
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, AVX512, SSE};
-    use crate::{Int, SIMDArgMinMax, ScalarArgMinMax, SCALAR};
+    use crate::{Int, SIMDArgMinMax, SCALAR};
 
     use super::super::test_utils::{
-        test_first_index_identical_values_argminmax, test_long_array_argminmax,
-        test_random_runs_argminmax,
+        test_first_index_identical_values_argminmax, test_return_same_result_argminmax,
     };
 
     use dev_utils::utils;
@@ -275,6 +274,11 @@ mod tests {
     fn get_array_i32(n: usize) -> Vec<i32> {
         utils::get_random_array(n, i32::MIN, i32::MAX)
     }
+
+    // The scalar implementation
+    const SCALAR_STRATEGY: SCALAR<Int> = SCALAR {
+        _dtype_strategy: PhantomData::<Int>,
+    };
 
     // ------------ Template for x86 / x86_64 -------------
 
@@ -285,7 +289,7 @@ mod tests {
     #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx2"))]
     #[case::avx512(AVX512 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx512f"))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
-        #[case] _simd: T,
+        #[case] simd: T,
         #[case] simd_available: bool,
     ) {
     }
@@ -297,7 +301,7 @@ mod tests {
     #[rstest]
     #[case::neon(NEON {_dtype_strategy: PhantomData::<Int>}, true)]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
-        #[case] _simd: T,
+        #[case] simd: T,
         #[case] simd_available: bool,
     ) {
     }
@@ -311,7 +315,7 @@ mod tests {
         SIMDM,
         const LANE_SIZE: usize,
     >(
-        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd: T,
         #[case] simd_available: bool,
     ) where
         T: SIMDArgMinMax<i32, SIMDV, SIMDM, LANE_SIZE, SCALAR<Int>>,
@@ -321,12 +325,12 @@ mod tests {
         if !simd_available {
             return;
         }
-        test_first_index_identical_values_argminmax(SCALAR::<Int>::argminmax, T::argminmax);
+        test_first_index_identical_values_argminmax(SCALAR_STRATEGY, simd);
     }
 
     #[apply(simd_implementations)]
     fn test_return_same_result<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
-        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd: T,
         #[case] simd_available: bool,
     ) where
         T: SIMDArgMinMax<i32, SIMDV, SIMDM, LANE_SIZE, SCALAR<Int>>,
@@ -336,7 +340,6 @@ mod tests {
         if !simd_available {
             return;
         }
-        test_long_array_argminmax(get_array_i32, SCALAR::<Int>::argminmax, T::argminmax);
-        test_random_runs_argminmax(get_array_i32, SCALAR::<Int>::argminmax, T::argminmax);
+        test_return_same_result_argminmax(get_array_i32, SCALAR_STRATEGY, simd);
     }
 }

--- a/src/simd/simd_i8.rs
+++ b/src/simd/simd_i8.rs
@@ -533,11 +533,11 @@ mod tests {
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, AVX512, SSE};
-    use crate::{Int, SIMDArgMinMax, ScalarArgMinMax, SCALAR};
+    use crate::{Int, SIMDArgMinMax, SCALAR};
 
     use super::super::test_utils::{
-        test_first_index_identical_values_argminmax, test_long_array_argminmax,
-        test_no_overflow_argminmax, test_random_runs_argminmax,
+        test_first_index_identical_values_argminmax, test_no_overflow_argminmax,
+        test_return_same_result_argminmax,
     };
 
     use dev_utils::utils;
@@ -545,6 +545,11 @@ mod tests {
     fn get_array_i8(n: usize) -> Vec<i8> {
         utils::get_random_array(n, i8::MIN, i8::MAX)
     }
+
+    // The scalar implementation
+    const SCALAR_STRATEGY: SCALAR<Int> = SCALAR {
+        _dtype_strategy: PhantomData::<Int>,
+    };
 
     // ------------ Template for x86 / x86_64 -------------
 
@@ -555,7 +560,7 @@ mod tests {
     #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx2"))]
     #[case::avx512(AVX512 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx512bw"))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
-        #[case] _simd: T,
+        #[case] simd: T,
         #[case] simd_available: bool,
     ) {
     }
@@ -567,7 +572,7 @@ mod tests {
     #[rstest]
     #[case::neon(NEON {_dtype_strategy: PhantomData::<Int>}, true)]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
-        #[case] _simd: T,
+        #[case] simd: T,
         #[case] simd_available: bool,
     ) {
     }
@@ -581,7 +586,7 @@ mod tests {
         SIMDM,
         const LANE_SIZE: usize,
     >(
-        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd: T,
         #[case] simd_available: bool,
     ) where
         T: SIMDArgMinMax<i8, SIMDV, SIMDM, LANE_SIZE, SCALAR<Int>>,
@@ -591,12 +596,12 @@ mod tests {
         if !simd_available {
             return;
         }
-        test_first_index_identical_values_argminmax(SCALAR::<Int>::argminmax, T::argminmax);
+        test_first_index_identical_values_argminmax(SCALAR_STRATEGY, simd);
     }
 
     #[apply(simd_implementations)]
     fn test_return_same_result<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
-        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd: T,
         #[case] simd_available: bool,
     ) where
         T: SIMDArgMinMax<i8, SIMDV, SIMDM, LANE_SIZE, SCALAR<Int>>,
@@ -606,13 +611,12 @@ mod tests {
         if !simd_available {
             return;
         }
-        test_long_array_argminmax(get_array_i8, SCALAR::<Int>::argminmax, T::argminmax);
-        test_random_runs_argminmax(get_array_i8, SCALAR::<Int>::argminmax, T::argminmax);
+        test_return_same_result_argminmax(get_array_i8, SCALAR_STRATEGY, simd);
     }
 
     #[apply(simd_implementations)]
     fn test_no_overflow<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
-        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd: T,
         #[case] simd_available: bool,
     ) where
         T: SIMDArgMinMax<i8, SIMDV, SIMDM, LANE_SIZE, SCALAR<Int>>,
@@ -622,6 +626,6 @@ mod tests {
         if !simd_available {
             return;
         }
-        test_no_overflow_argminmax(get_array_i8, SCALAR::<Int>::argminmax, T::argminmax, None);
+        test_no_overflow_argminmax(get_array_i8, SCALAR_STRATEGY, simd, None);
     }
 }

--- a/src/simd/simd_u32.rs
+++ b/src/simd/simd_u32.rs
@@ -384,11 +384,10 @@ mod tests {
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, AVX512, SSE};
-    use crate::{Int, SIMDArgMinMax, ScalarArgMinMax, SCALAR};
+    use crate::{Int, SIMDArgMinMax, SCALAR};
 
     use super::super::test_utils::{
-        test_first_index_identical_values_argminmax, test_long_array_argminmax,
-        test_random_runs_argminmax,
+        test_first_index_identical_values_argminmax, test_return_same_result_argminmax,
     };
 
     use dev_utils::utils;
@@ -396,6 +395,11 @@ mod tests {
     fn get_array_u32(n: usize) -> Vec<u32> {
         utils::get_random_array(n, u32::MIN, u32::MAX)
     }
+
+    // The scalar implementation
+    const SCALAR_STRATEGY: SCALAR<Int> = SCALAR {
+        _dtype_strategy: PhantomData::<Int>,
+    };
 
     // ------------ Template for x86 / x86_64 -------------
 
@@ -406,7 +410,7 @@ mod tests {
     #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx2"))]
     #[case::avx512(AVX512 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx512f"))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
-        #[case] _simd: T,
+        #[case] simd: T,
         #[case] simd_available: bool,
     ) {
     }
@@ -418,7 +422,7 @@ mod tests {
     #[rstest]
     #[case::neon(NEON {_dtype_strategy: PhantomData::<Int>}, true)]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
-        #[case] _simd: T,
+        #[case] simd: T,
         #[case] simd_available: bool,
     ) {
     }
@@ -432,7 +436,7 @@ mod tests {
         SIMDM,
         const LANE_SIZE: usize,
     >(
-        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd: T,
         #[case] simd_available: bool,
     ) where
         T: SIMDArgMinMax<u32, SIMDV, SIMDM, LANE_SIZE, SCALAR<Int>>,
@@ -442,12 +446,12 @@ mod tests {
         if !simd_available {
             return;
         }
-        test_first_index_identical_values_argminmax(SCALAR::<Int>::argminmax, T::argminmax);
+        test_first_index_identical_values_argminmax(SCALAR_STRATEGY, simd);
     }
 
     #[apply(simd_implementations)]
     fn test_return_same_result<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
-        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd: T,
         #[case] simd_available: bool,
     ) where
         T: SIMDArgMinMax<u32, SIMDV, SIMDM, LANE_SIZE, SCALAR<Int>>,
@@ -457,7 +461,6 @@ mod tests {
         if !simd_available {
             return;
         }
-        test_long_array_argminmax(get_array_u32, SCALAR::<Int>::argminmax, T::argminmax);
-        test_random_runs_argminmax(get_array_u32, SCALAR::<Int>::argminmax, T::argminmax);
+        test_return_same_result_argminmax(get_array_u32, SCALAR_STRATEGY, simd);
     }
 }

--- a/src/simd/simd_u64.rs
+++ b/src/simd/simd_u64.rs
@@ -338,11 +338,10 @@ mod tests {
     use std::marker::PhantomData;
 
     use crate::simd::config::{AVX2, AVX512, SSE};
-    use crate::{Int, SIMDArgMinMax, ScalarArgMinMax, SCALAR};
+    use crate::{Int, SIMDArgMinMax, SCALAR};
 
     use super::super::test_utils::{
-        test_first_index_identical_values_argminmax, test_long_array_argminmax,
-        test_random_runs_argminmax,
+        test_first_index_identical_values_argminmax, test_return_same_result_argminmax,
     };
 
     use dev_utils::utils;
@@ -350,6 +349,11 @@ mod tests {
     fn get_array_u64(n: usize) -> Vec<u64> {
         utils::get_random_array(n, u64::MIN, u64::MAX)
     }
+
+    // The scalar implementation
+    const SCALAR_STRATEGY: SCALAR<Int> = SCALAR {
+        _dtype_strategy: PhantomData::<Int>,
+    };
 
     // ------------ Template for x86 / x86_64 -------------
 
@@ -360,7 +364,7 @@ mod tests {
     #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx2"))]
     #[case::avx512(AVX512 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx512f"))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
-        #[case] _simd: T,
+        #[case] simd: T,
         #[case] simd_available: bool,
     ) {
     }
@@ -374,7 +378,7 @@ mod tests {
         SIMDM,
         const LANE_SIZE: usize,
     >(
-        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd: T,
         #[case] simd_available: bool,
     ) where
         T: SIMDArgMinMax<u64, SIMDV, SIMDM, LANE_SIZE, SCALAR<Int>>,
@@ -384,12 +388,12 @@ mod tests {
         if !simd_available {
             return;
         }
-        test_first_index_identical_values_argminmax(SCALAR::<Int>::argminmax, T::argminmax);
+        test_first_index_identical_values_argminmax(SCALAR_STRATEGY, simd);
     }
 
     #[apply(simd_implementations)]
     fn test_return_same_result<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
-        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd: T,
         #[case] simd_available: bool,
     ) where
         T: SIMDArgMinMax<u64, SIMDV, SIMDM, LANE_SIZE, SCALAR<Int>>,
@@ -399,7 +403,6 @@ mod tests {
         if !simd_available {
             return;
         }
-        test_long_array_argminmax(get_array_u64, SCALAR::<Int>::argminmax, T::argminmax);
-        test_random_runs_argminmax(get_array_u64, SCALAR::<Int>::argminmax, T::argminmax);
+        test_return_same_result_argminmax(get_array_u64, SCALAR_STRATEGY, simd);
     }
 }

--- a/src/simd/simd_u8.rs
+++ b/src/simd/simd_u8.rs
@@ -603,11 +603,11 @@ mod tests {
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, AVX512, SSE};
-    use crate::{Int, SIMDArgMinMax, ScalarArgMinMax, SCALAR};
+    use crate::{Int, SIMDArgMinMax, SCALAR};
 
     use super::super::test_utils::{
-        test_first_index_identical_values_argminmax, test_long_array_argminmax,
-        test_no_overflow_argminmax, test_random_runs_argminmax,
+        test_first_index_identical_values_argminmax, test_no_overflow_argminmax,
+        test_return_same_result_argminmax,
     };
 
     use dev_utils::utils;
@@ -615,6 +615,11 @@ mod tests {
     fn get_array_u8(n: usize) -> Vec<u8> {
         utils::get_random_array(n, u8::MIN, u8::MAX)
     }
+
+    // The scalar implementation
+    const SCALAR_STRATEGY: SCALAR<Int> = SCALAR {
+        _dtype_strategy: PhantomData::<Int>,
+    };
 
     // ------------ Template for x86 / x86_64 -------------
 
@@ -625,7 +630,7 @@ mod tests {
     #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx2"))]
     #[case::avx512(AVX512 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx512bw"))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
-        #[case] _simd: T,
+        #[case] simd: T,
         #[case] simd_available: bool,
     ) {
     }
@@ -637,7 +642,7 @@ mod tests {
     #[rstest]
     #[case::neon(NEON {_dtype_strategy: PhantomData::<Int>}, true)]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
-        #[case] _simd: T,
+        #[case] simd: T,
         #[case] simd_available: bool,
     ) {
     }
@@ -651,7 +656,7 @@ mod tests {
         SIMDM,
         const LANE_SIZE: usize,
     >(
-        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd: T,
         #[case] simd_available: bool,
     ) where
         T: SIMDArgMinMax<u8, SIMDV, SIMDM, LANE_SIZE, SCALAR<Int>>,
@@ -661,12 +666,12 @@ mod tests {
         if !simd_available {
             return;
         }
-        test_first_index_identical_values_argminmax(SCALAR::<Int>::argminmax, T::argminmax);
+        test_first_index_identical_values_argminmax(SCALAR_STRATEGY, simd);
     }
 
     #[apply(simd_implementations)]
     fn test_return_same_result<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
-        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd: T,
         #[case] simd_available: bool,
     ) where
         T: SIMDArgMinMax<u8, SIMDV, SIMDM, LANE_SIZE, SCALAR<Int>>,
@@ -676,13 +681,12 @@ mod tests {
         if !simd_available {
             return;
         }
-        test_long_array_argminmax(get_array_u8, SCALAR::<Int>::argminmax, T::argminmax);
-        test_random_runs_argminmax(get_array_u8, SCALAR::<Int>::argminmax, T::argminmax);
+        test_return_same_result_argminmax(get_array_u8, SCALAR_STRATEGY, simd);
     }
 
     #[apply(simd_implementations)]
     fn test_no_overflow<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
-        #[case] _simd: T, // This is just to make sure the template is applied
+        #[case] simd: T,
         #[case] simd_available: bool,
     ) where
         T: SIMDArgMinMax<u8, SIMDV, SIMDM, LANE_SIZE, SCALAR<Int>>,
@@ -692,6 +696,6 @@ mod tests {
         if !simd_available {
             return;
         }
-        test_no_overflow_argminmax(get_array_u8, SCALAR::<Int>::argminmax, T::argminmax, None);
+        test_no_overflow_argminmax(get_array_u8, SCALAR_STRATEGY, simd, None);
     }
 }


### PR DESCRIPTION
Refactors how the shared test code (in `test_utils.rs`) is called.

Previously we passed the functions to this test method, but since #35 it is more clean to pass the structs that implement `SIMDArgMinMax` or `ScalarArgMinMax` 
-> this allows more flexible updates to the tests (e.g, when supporting a new method)