### PR TITLE
ci: upgrade codspeed & make half non-default feature

### DIFF
--- a/.github/workflows/codspeed.yaml
+++ b/.github/workflows/codspeed.yaml
@@ -41,7 +41,7 @@ jobs:
           crate: cargo-codspeed
 
       - name: Build the benchmark target(s)
-        run: cargo codspeed build # --features half
+        run: cargo codspeed build --features half
 
       - uses: CodSpeedHQ/action@v1
         name: Run benchmarks

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,12 @@ ndarray = { version = "0.15.6", default-features = false, optional = true}
 arrow = { version = ">0", default-features = false, optional = true}
 # once_cell = "1.16.0"
 
-[features]
-default = ["half"] # TODO: remove this as default feature as soon as https://github.com/CodSpeedHQ/codspeed-rust/issues/1 is fixed
 
 [dev-dependencies]
 rstest = { version = "0.16", default-features = false }
 rstest_reuse = { version = "0.5", default-features = false }
 rand = { version = "0.7.2", default-features = false }
-codspeed-criterion-compat = "1.0.1"
+codspeed-criterion-compat = "1.1"
 criterion = "0.3.1"
 dev_utils = { path = "dev_utils" }
 

--- a/benches/bench_f16_return_nan.rs
+++ b/benches/bench_f16_return_nan.rs
@@ -1,6 +1,5 @@
 #![feature(stdsimd)]
 
-#[cfg(feature = "half")]
 use argminmax::ArgMinMax;
 use codspeed_criterion_compat::*;
 use dev_utils::{config, utils};
@@ -11,10 +10,8 @@ use argminmax::{FloatReturnNaN, SIMDArgMinMax, AVX2, AVX512, SSE};
 use argminmax::{FloatReturnNaN, SIMDArgMinMax, NEON};
 use argminmax::{ScalarArgMinMax, SCALAR};
 
-#[cfg(feature = "half")]
 use half::f16;
 
-#[cfg(feature = "half")]
 fn get_random_f16_array(n: usize) -> Vec<f16> {
     let data = utils::get_random_array::<u16>(n, u16::MIN, u16::MAX);
     let data: Vec<f16> = data.iter().map(|&x| f16::from_bits(x)).collect();
@@ -34,7 +31,6 @@ fn get_random_f16_array(n: usize) -> Vec<f16> {
 
 // _rn stands for "return nan"
 
-#[cfg(feature = "half")]
 fn argminmax_rn_f16_random_array_long(c: &mut Criterion) {
     let n = config::ARRAY_LENGTH_LONG;
     let data: &[f16] = &get_random_f16_array(n);
@@ -76,7 +72,5 @@ fn argminmax_rn_f16_random_array_long(c: &mut Criterion) {
     });
 }
 
-#[cfg(feature = "half")]
 criterion_group!(benches, argminmax_rn_f16_random_array_long,);
-#[cfg(feature = "half")]
 criterion_main!(benches);

--- a/src/scalar/generic.rs
+++ b/src/scalar/generic.rs
@@ -1,9 +1,5 @@
-use num_traits::{Float, PrimInt};
-
-#[cfg(feature = "half")]
-use super::scalar_f16::scalar_argminmax_f16_return_nan;
-#[cfg(feature = "half")]
-use half::f16;
+use num_traits::float::FloatCore;
+use num_traits::PrimInt;
 
 /// The DTypeStrategy for which we implement the ScalarArgMinMax trait
 use crate::{FloatIgnoreNaN, FloatReturnNaN, Int};
@@ -67,7 +63,7 @@ where
 
 impl<ScalarDType> SCALARInit<ScalarDType> for SCALAR<FloatReturnNaN>
 where
-    ScalarDType: Float,
+    ScalarDType: FloatCore,
 {
     #[inline(always)]
     fn _init_min(arr: &[ScalarDType]) -> ScalarDType {
@@ -87,7 +83,7 @@ where
 
 impl<ScalarDType> SCALARInit<ScalarDType> for SCALAR<FloatIgnoreNaN>
 where
-    ScalarDType: Float,
+    ScalarDType: FloatCore,
 {
     #[inline(always)]
     fn _init_min(arr: &[ScalarDType]) -> ScalarDType {
@@ -155,6 +151,11 @@ impl_scalar!(FloatReturnNaN, f32, f64);
 impl_scalar!(FloatIgnoreNaN, f32, f64);
 
 // --- Optional data types
+
+#[cfg(feature = "half")]
+use super::scalar_f16::scalar_argminmax_f16_return_nan;
+#[cfg(feature = "half")]
+use half::f16;
 
 #[cfg(feature = "half")]
 impl ScalarArgMinMax<f16> for SCALAR<FloatReturnNaN> {

--- a/src/scalar/mod.rs
+++ b/src/scalar/mod.rs
@@ -1,4 +1,5 @@
 mod generic;
 pub use generic::{ScalarArgMinMax, SCALAR};
 // Data type specific modules
+#[cfg(feature = "half")]
 mod scalar_f16;

--- a/src/scalar/scalar_f16.rs
+++ b/src/scalar/scalar_f16.rs
@@ -4,11 +4,8 @@
 /// implementation of argminmax operations on f16 arrays through transforming the f16
 /// values to i16ord. (more details in simd/simd_f16_return_nan.rs)
 ///
-
-#[cfg(feature = "half")]
 use half::f16;
 
-#[cfg(feature = "half")]
 #[inline(always)]
 fn f16_to_i16ord(x: f16) -> i16 {
     let x = unsafe { std::mem::transmute::<f16, i16>(x) };
@@ -19,7 +16,6 @@ fn f16_to_i16ord(x: f16) -> i16 {
 
 // TODO: commented this (see the TODO below)
 // #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-#[cfg(feature = "half")]
 // #[inline(never)]
 pub(crate) fn scalar_argminmax_f16_return_nan(arr: &[f16]) -> (usize, usize) {
     // f16 is transformed to i16ord
@@ -54,7 +50,6 @@ pub(crate) fn scalar_argminmax_f16_return_nan(arr: &[f16]) -> (usize, usize) {
 // TODO: previously we had dedicated non x86_64 code for f16 (see below)
 
 // #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
-// #[cfg(feature = "half")]
 // // #[inline(never)]
 // pub(crate) fn scalar_argminmax_f16(arr: &[f16]) -> (usize, usize) {
 //     // f16 is transformed to i16ord
@@ -83,7 +78,8 @@ pub(crate) fn scalar_argminmax_f16_return_nan(arr: &[f16]) -> (usize, usize) {
 //     (minmax_tuple.0, minmax_tuple.2)
 // }
 
-#[cfg(feature = "half")]
+// ======================================= TESTS =======================================
+
 #[cfg(test)]
 mod tests {
     use super::scalar_argminmax_f16_return_nan;

--- a/src/simd/generic.rs
+++ b/src/simd/generic.rs
@@ -476,7 +476,7 @@ where
 // TODO: temporarily removed the target_arch specification bc we currently do not
 // ArgMinMax for f16 ignore nan
 
-// #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(any(target_arch = "arm", target_arch = "aarch64", feature = "half"))]
 macro_rules! unimpl_SIMDOps {
     ($scalar_type:ty, $reg:ty, $simd_struct:ty) => {
         impl SIMDOps<$scalar_type, $reg, $reg, 0> for $simd_struct {
@@ -511,7 +511,7 @@ macro_rules! unimpl_SIMDOps {
     };
 }
 
-// #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(any(target_arch = "arm", target_arch = "aarch64", feature = "half"))]
 macro_rules! unimpl_SIMDInit {
     ($scalar_type:ty, $reg:ty, $simd_struct:ty) => {
         impl SIMDInit<$scalar_type, $reg, $reg, 0> for $simd_struct {
@@ -520,7 +520,7 @@ macro_rules! unimpl_SIMDInit {
     };
 }
 
-// #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(any(target_arch = "arm", target_arch = "aarch64", feature = "half"))]
 macro_rules! unimpl_SIMDArgMinMax {
     ($scalar_type:ty, $reg:ty, $scalar:ty, $simd_struct:ty) => {
         impl SIMDArgMinMax<$scalar_type, $reg, $reg, 0, $scalar> for $simd_struct {
@@ -533,11 +533,11 @@ macro_rules! unimpl_SIMDArgMinMax {
 
 // TODO: temporarily removed the target_arch until we implement f16_ignore_nans
 
-// #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(any(target_arch = "arm", target_arch = "aarch64", feature = "half"))]
 pub(crate) use unimpl_SIMDArgMinMax; // Now classic paths Just Work™
 
-// #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(any(target_arch = "arm", target_arch = "aarch64", feature = "half"))]
 pub(crate) use unimpl_SIMDInit; // Now classic paths Just Work™
 
-// #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(any(target_arch = "arm", target_arch = "aarch64", feature = "half"))]
 pub(crate) use unimpl_SIMDOps; // Now classic paths Just Work™

--- a/src/simd/mod.rs
+++ b/src/simd/mod.rs
@@ -6,7 +6,7 @@ pub use config::*;
 mod generic;
 pub use generic::*;
 // FLOAT
-#[cfg(feature = "half")] // TODO: can I remove all #[cfg(feature = "half")] in this file?
+#[cfg(feature = "half")]
 mod simd_f16_ignore_nan; // TODO: not supported yet
 #[cfg(feature = "half")]
 mod simd_f16_return_nan;

--- a/src/simd/simd_f16_ignore_nan.rs
+++ b/src/simd/simd_f16_ignore_nan.rs
@@ -1,16 +1,10 @@
 /// Currently not supported. Should give this some more thought.
 ///
-
-// #[cfg(feature = "half")]
 // use super::config::SIMDInstructionSet;
-#[cfg(feature = "half")]
 use super::generic::{unimpl_SIMDArgMinMax, unimpl_SIMDInit, unimpl_SIMDOps};
-#[cfg(feature = "half")]
 use super::generic::{SIMDArgMinMax, SIMDInit, SIMDOps};
-#[cfg(feature = "half")]
 use crate::SCALAR;
 
-#[cfg(feature = "half")]
 use half::f16;
 
 /// The dtype-strategy for performing operations on f16 data: ignore NaN values
@@ -18,7 +12,6 @@ use super::super::dtype_strategy::FloatIgnoreNaN;
 
 // --------------------------------------- AVX2 ----------------------------------------
 
-#[cfg(feature = "half")]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod avx2_ignore_nan {
     use super::super::config::AVX2;
@@ -31,7 +24,6 @@ mod avx2_ignore_nan {
 
 // ---------------------------------------- SSE ----------------------------------------
 
-#[cfg(feature = "half")]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod sse_ignore_nan {
     use super::super::config::SSE;
@@ -44,7 +36,6 @@ mod sse_ignore_nan {
 
 // -------------------------------------- AVX512 ---------------------------------------
 
-#[cfg(feature = "half")]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod avx512_ignore_nan {
     use super::super::config::AVX512;
@@ -57,7 +48,6 @@ mod avx512_ignore_nan {
 
 // --------------------------------------- NEON ----------------------------------------
 
-#[cfg(feature = "half")]
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 mod neon_ignore_nan {
     use super::super::config::NEON;

--- a/src/simd/simd_f16_return_nan.rs
+++ b/src/simd/simd_f16_return_nan.rs
@@ -27,52 +27,37 @@
 /// SIMDOps::_get_overflow_lane_size_limit() chunk of the data - which is not
 /// necessarily the index of the first NaN value.
 ///
-
-#[cfg(feature = "half")]
 use super::config::SIMDInstructionSet;
-#[cfg(feature = "half")]
 use super::generic::{impl_SIMDInit_FloatReturnNaN, SIMDArgMinMax, SIMDInit, SIMDOps};
-#[cfg(feature = "half")]
 use crate::SCALAR;
 
-#[cfg(feature = "half")]
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
-#[cfg(feature = "half")]
 #[cfg(target_arch = "arm")]
 use std::arch::arm::*;
-#[cfg(feature = "half")]
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;
-#[cfg(feature = "half")]
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
 
-#[cfg(feature = "half")]
 use half::f16;
 
 /// The dtype-strategy for performing operations on f16 data: return NaN index
-#[cfg(feature = "half")]
 use super::super::dtype_strategy::FloatReturnNaN;
 
-#[cfg(feature = "half")]
 const BIT_SHIFT: i32 = 15;
-#[cfg(feature = "half")]
 const MASK_VALUE: i16 = 0x7FFF; // i16::MAX - masks everything but the sign bit
 
-#[cfg(feature = "half")]
 #[inline(always)]
 fn _i16ord_to_f16(ord_i16: i16) -> f16 {
     let v = ((ord_i16 >> BIT_SHIFT) & MASK_VALUE) ^ ord_i16;
     f16::from_bits(v as u16)
 }
 
-#[cfg(feature = "half")]
 const MAX_INDEX: usize = i16::MAX as usize;
 
 // --------------------------------------- AVX2 ----------------------------------------
 
-#[cfg(feature = "half")]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod avx2 {
     use super::super::config::AVX2;
@@ -218,7 +203,6 @@ mod avx2 {
 
 // ---------------------------------------- SSE ----------------------------------------
 
-#[cfg(feature = "half")]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod sse {
     use super::super::config::SSE;
@@ -351,7 +335,6 @@ mod sse {
 
 // -------------------------------------- AVX512 ---------------------------------------
 
-#[cfg(feature = "half")]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod avx512 {
     use super::super::config::AVX512;
@@ -497,7 +480,6 @@ mod avx512 {
 
 // --------------------------------------- NEON ----------------------------------------
 
-#[cfg(feature = "half")]
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 mod neon {
     use super::super::config::NEON;
@@ -632,7 +614,6 @@ mod neon {
 
 // ======================================= TESTS =======================================
 
-#[cfg(feature = "half")]
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",


### PR DESCRIPTION
Since https://github.com/CodSpeedHQ/codspeed-rust/issues/1 is solved we can remove `"half"` from the default-features :tada: 

Changes contributed in this PR:
- make `"half"` feature non-default
- upgrade `codspeed-criterion-compat` to 1.1
- remove unnecessary `#[cfg(feature = "half")]`