### PR TITLE
feat: add "nightly_simd" feature to allow stable build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,20 @@ jobs:
       # - name: check with clippy
       #   run: cargo clippy --all --all-targets --all-features -- -D warnings
 
+  Check_Stable:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Rust
+        run: rustup override set stable
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run cargo check
+        run: cargo check
+
   Test:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Run cargo check
-        run: cargo check
+        run: cargo check --no-default-features --features "half,float"
 
   Test:
     runs-on: ${{ matrix.os }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,8 @@ arrow2 = { version = ">0.0", default-features = false, optional = true}
 # once_cell = "1.16.0"
 
 [features]
-default = ["float"]
+default = ["nightly_simd", "float"]
+nightly_simd = []
 float = []
 half = ["dep:half"]
 ndarray = ["dep:ndarray"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,8 @@ pub(crate) use simd::AVX512;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub(crate) use simd::{SIMDArgMinMax, AVX2, SSE};
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(feature = "nightly_simd")]
+// TODO: can be adapted when 64-bit aarch64 implementation is added
 pub(crate) use simd::{SIMDArgMinMax, NEON};
 
 #[cfg(feature = "half")]
@@ -277,14 +279,14 @@ macro_rules! impl_argminmax_int {
                             return unsafe { SSE::<Int>::argminmax(self) }
                         }
                     }
-                    #[cfg(target_arch = "aarch64")]
+                    #[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
                     {
                         if std::arch::is_aarch64_feature_detected!("neon") & (<$int_type>::NB_BITS < 64) {
                             // We miss some NEON instructions for 64-bit numbers
                             return unsafe { NEON::<Int>::argminmax(self) }
                         }
                     }
-                    #[cfg(target_arch = "arm")]
+                    #[cfg(all(target_arch = "arm", feature = "nightly_simd"))]
                     {
                         if std::arch::is_arm_feature_detected!("neon") & (<$int_type>::NB_BITS < 64) {
                             // TODO: requires v7?
@@ -322,14 +324,14 @@ macro_rules! impl_argminmax_int {
                             return unsafe { SSE::<Int>::argmin(self) }
                         }
                     }
-                    #[cfg(target_arch = "aarch64")]
+                    #[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
                     {
                         if std::arch::is_aarch64_feature_detected!("neon") & (<$int_type>::NB_BITS < 64) {
                             // We miss some NEON instructions for 64-bit numbers
                             return unsafe { NEON::<Int>::argmin(self) }
                         }
                     }
-                    #[cfg(target_arch = "arm")]
+                    #[cfg(all(target_arch = "arm", feature = "nightly_simd"))]
                     {
                         if std::arch::is_arm_feature_detected!("neon") & (<$int_type>::NB_BITS < 64) {
                             // We miss some NEON instructions for 64-bit numbers
@@ -366,14 +368,14 @@ macro_rules! impl_argminmax_int {
                             return unsafe { SSE::<Int>::argmax(self) }
                         }
                     }
-                    #[cfg(target_arch = "aarch64")]
+                    #[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
                     {
                         if std::arch::is_aarch64_feature_detected!("neon") & (<$int_type>::NB_BITS < 64) {
                             // We miss some NEON instructions for 64-bit numbers
                             return unsafe { NEON::<Int>::argmax(self) }
                         }
                     }
-                    #[cfg(target_arch = "arm")]
+                    #[cfg(all(target_arch = "arm", feature = "nightly_simd"))]
                     {
                         if std::arch::is_arm_feature_detected!("neon") & (<$int_type>::NB_BITS < 64) {
                             // We miss some NEON instructions for 64-bit numbers
@@ -418,14 +420,14 @@ macro_rules! impl_argminmax_float {
                             return unsafe { SSE::<FloatIgnoreNaN>::argminmax(self) }
                         }
                     }
-                    #[cfg(target_arch = "aarch64")]
+                    #[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
                     {
                         if std::arch::is_aarch64_feature_detected!("neon") & (<$float_type>::NB_BITS < 64) {
                             // We miss some NEON instructions for 64-bit numbers
                             return unsafe { NEON::<FloatIgnoreNaN>::argminmax(self) }
                         }
                     }
-                    #[cfg(target_arch = "arm")]
+                    #[cfg(all(target_arch = "arm", feature = "nightly_simd"))]
                     {
                         if std::arch::is_arm_feature_detected!("neon") & (<$float_type>::NB_BITS < 64) {
                             // We miss some NEON instructions for 64-bit numbers
@@ -458,14 +460,14 @@ macro_rules! impl_argminmax_float {
                             return unsafe { SSE::<FloatIgnoreNaN>::argmin(self) }
                         }
                     }
-                    #[cfg(target_arch = "aarch64")]
+                    #[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
                     {
                         if std::arch::is_aarch64_feature_detected!("neon") & (<$float_type>::NB_BITS < 64) {
                             // We miss some NEON instructions for 64-bit numbers
                             return unsafe { NEON::<FloatIgnoreNaN>::argmin(self) }
                         }
                     }
-                    #[cfg(target_arch = "arm")]
+                    #[cfg(all(target_arch = "arm", feature = "nightly_simd"))]
                     {
                         if std::arch::is_arm_feature_detected!("neon") & (<$float_type>::NB_BITS < 64) {
                             // We miss some NEON instructions for 64-bit numbers
@@ -498,14 +500,14 @@ macro_rules! impl_argminmax_float {
                             return unsafe { SSE::<FloatIgnoreNaN>::argmax(self) }
                         }
                     }
-                    #[cfg(target_arch = "aarch64")]
+                    #[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
                     {
                         if std::arch::is_aarch64_feature_detected!("neon") & (<$float_type>::NB_BITS < 64) {
                             // We miss some NEON instructions for 64-bit numbers
                             return unsafe { NEON::<FloatIgnoreNaN>::argmax(self) }
                         }
                     }
-                    #[cfg(target_arch = "arm")]
+                    #[cfg(all(target_arch = "arm", feature = "nightly_simd"))]
                     {
                         if std::arch::is_arm_feature_detected!("neon") & (<$float_type>::NB_BITS < 64) {
                             // We miss some NEON instructions for 64-bit numbers
@@ -538,14 +540,14 @@ macro_rules! impl_argminmax_float {
                             return unsafe { SSE::<FloatReturnNaN>::argminmax(self) }
                         }
                     }
-                    #[cfg(target_arch = "aarch64")]
+                    #[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
                     {
                         if std::arch::is_aarch64_feature_detected!("neon") & (<$float_type>::NB_BITS < 64) {
                             // We miss some NEON instructions for 64-bit numbers
                             return unsafe { NEON::<FloatReturnNaN>::argminmax(self) }
                         }
                     }
-                    #[cfg(target_arch = "arm")]
+                    #[cfg(all(target_arch = "arm", feature = "nightly_simd"))]
                     {
                         if std::arch::is_arm_feature_detected!("neon") & (<$float_type>::NB_BITS < 64) {
                             // We miss some NEON instructions for 64-bit numbers
@@ -576,14 +578,14 @@ macro_rules! impl_argminmax_float {
                             return unsafe { SSE::<FloatReturnNaN>::argmin(self) }
                         }
                     }
-                    #[cfg(target_arch = "aarch64")]
+                    #[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
                     {
                         if std::arch::is_aarch64_feature_detected!("neon") & (<$float_type>::NB_BITS < 64) {
                             // We miss some NEON instructions for 64-bit numbers
                             return unsafe { NEON::<FloatReturnNaN>::argmin(self) }
                         }
                     }
-                    #[cfg(target_arch = "arm")]
+                    #[cfg(all(target_arch = "arm", feature = "nightly_simd"))]
                     {
                         if std::arch::is_arm_feature_detected!("neon") & (<$float_type>::NB_BITS < 64) {
                             // We miss some NEON instructions for 64-bit numbers
@@ -614,14 +616,14 @@ macro_rules! impl_argminmax_float {
                             return unsafe { SSE::<FloatReturnNaN>::argmax(self) }
                         }
                     }
-                    #[cfg(target_arch = "aarch64")]
+                    #[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
                     {
                         if std::arch::is_aarch64_feature_detected!("neon") & (<$float_type>::NB_BITS < 64) {
                             // We miss some NEON instructions for 64-bit numbers
                             return unsafe { NEON::<FloatReturnNaN>::argmax(self) }
                         }
                     }
-                    #[cfg(target_arch = "arm")]
+                    #[cfg(all(target_arch = "arm", feature = "nightly_simd"))]
                     {
                         if std::arch::is_arm_feature_detected!("neon") & (<$float_type>::NB_BITS < 64) {
                             // We miss some NEON instructions for 64-bit numbers

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,9 +67,10 @@
 //!```
 //!
 
-#![feature(stdsimd)]
-#![feature(avx512_target_feature)]
-#![feature(arm_target_feature)]
+// enable SIMD nightly features when on nightly_simd enabled
+#![cfg_attr(feature = "nightly_simd", feature(stdsimd))]
+#![cfg_attr(feature = "nightly_simd", feature(avx512_target_feature))]
+#![cfg_attr(feature = "nightly_simd", feature(arm_target_feature))]
 
 // It is necessary to import this at the root of the crate
 // See: https://github.com/la10736/rstest/tree/master/rstest_reuse#use-rstest_resuse-at-the-top-of-your-crate
@@ -88,7 +89,10 @@ pub(crate) use dtype_strategy::Int;
 pub(crate) use dtype_strategy::{FloatIgnoreNaN, FloatReturnNaN};
 pub(crate) use scalar::{ScalarArgMinMax, SCALAR};
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-pub(crate) use simd::{SIMDArgMinMax, AVX2, AVX512, SSE};
+#[cfg(feature = "nightly_simd")]
+pub(crate) use simd::AVX512;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+pub(crate) use simd::{SIMDArgMinMax, AVX2, SSE};
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 pub(crate) use simd::{SIMDArgMinMax, NEON};
 
@@ -251,12 +255,18 @@ macro_rules! impl_argminmax_int {
                         if is_x86_feature_detected!("sse4.1") & (<$int_type>::NB_BITS == 8) {
                             // 8-bit numbers are best handled by SSE4.1
                             return unsafe { SSE::<Int>::argminmax(self) }
-                        } else if is_x86_feature_detected!("avx512bw") & (<$int_type>::NB_BITS <= 16) {
-                            // BW (ByteWord) instructions are needed for 8 or 16-bit avx512
-                            return unsafe { AVX512::<Int>::argminmax(self) }
-                        } else if is_x86_feature_detected!("avx512f") {  // TODO: check if avx512bw is included in avx512f
-                            return unsafe { AVX512::<Int>::argminmax(self) }
-                        } else if is_x86_feature_detected!("avx2") {
+                        }
+                        #[cfg(feature = "nightly_simd")]
+                        {
+                            if is_x86_feature_detected!("avx512bw") & (<$int_type>::NB_BITS <= 16) {
+                                // BW (ByteWord) instructions are needed for 8 or 16-bit avx512
+                                return unsafe { AVX512::<Int>::argminmax(self) }
+                            }
+                            else if is_x86_feature_detected!("avx512f") {  // TODO: check if avx512bw is included in avx512f
+                                return unsafe { AVX512::<Int>::argminmax(self) }
+                            }
+                        }
+                        if is_x86_feature_detected!("avx2") {
                             return unsafe { AVX2::<Int>::argminmax(self) }
                         // SKIP SSE4.2 bc scalar is faster or equivalent for 64 bit numbers
                         // // } else if is_x86_feature_detected!("sse4.2") & (<$int_type>::NB_BITS == 64) & (<$int_type>::IS_FLOAT == false) {
@@ -291,12 +301,17 @@ macro_rules! impl_argminmax_int {
                         if is_x86_feature_detected!("sse4.1") & (<$int_type>::NB_BITS == 8) {
                             // 8-bit numbers are best handled by SSE4.1
                             return unsafe { SSE::<Int>::argmin(self) }
-                        } else if is_x86_feature_detected!("avx512bw") & (<$int_type>::NB_BITS <= 16) {
-                            // BW (ByteWord) instructions are needed for 8 or 16-bit avx512
-                            return unsafe { AVX512::<Int>::argmin(self) }
-                        } else if is_x86_feature_detected!("avx512f") {
-                            return unsafe { AVX512::<Int>::argmin(self) }
-                        } else if is_x86_feature_detected!("avx2") {
+                        }
+                        #[cfg(feature = "nightly_simd")]
+                        {
+                            if is_x86_feature_detected!("avx512bw") & (<$int_type>::NB_BITS <= 16) {
+                                // BW (ByteWord) instructions are needed for 8 or 16-bit avx512
+                                return unsafe { AVX512::<Int>::argmin(self) }
+                            } else if is_x86_feature_detected!("avx512f") {
+                                return unsafe { AVX512::<Int>::argmin(self) }
+                            }
+                        }
+                        if is_x86_feature_detected!("avx2") {
                             return unsafe { AVX2::<Int>::argmin(self) }
                         // SKIP SSE4.2 bc scalar is faster or equivalent for 64 bit numbers
                         // // } else if is_x86_feature_detected!("sse4.2") & (<$int_type>::NB_BITS == 64) & (<$int_type>::IS_FLOAT == false) {
@@ -330,12 +345,17 @@ macro_rules! impl_argminmax_int {
                         if is_x86_feature_detected!("sse4.1") & (<$int_type>::NB_BITS == 8) {
                             // 8-bit numbers are best handled by SSE4.1
                             return unsafe { SSE::<Int>::argmax(self) }
-                        } else if is_x86_feature_detected!("avx512bw") & (<$int_type>::NB_BITS <= 16) {
-                            // BW (ByteWord) instructions are needed for 8 or 16-bit avx512
-                            return unsafe { AVX512::<Int>::argmax(self) }
-                        } else if is_x86_feature_detected!("avx512f") {
-                            return unsafe { AVX512::<Int>::argmax(self) }
-                        } else if is_x86_feature_detected!("avx2") {
+                        }
+                        #[cfg(feature = "nightly_simd")]
+                        {
+                            if is_x86_feature_detected!("avx512bw") & (<$int_type>::NB_BITS <= 16) {
+                                // BW (ByteWord) instructions are needed for 8 or 16-bit avx512
+                                return unsafe { AVX512::<Int>::argmax(self) }
+                            } else if is_x86_feature_detected!("avx512f") {
+                                return unsafe { AVX512::<Int>::argmax(self) }
+                            }
+                        }
+                        if is_x86_feature_detected!("avx2") {
                             return unsafe { AVX2::<Int>::argmax(self) }
                         // SKIP SSE4.2 bc scalar is faster or equivalent for 64 bit numbers
                         // // } else if is_x86_feature_detected!("sse4.2") & (<$int_type>::NB_BITS == 64) & (<$int_type>::IS_FLOAT == false) {
@@ -378,12 +398,16 @@ macro_rules! impl_argminmax_float {
                 fn argminmax(&self) -> (usize, usize) {
                     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
                     {
-                        if is_x86_feature_detected!("avx512bw") & (<$float_type>::NB_BITS == 16) {
-                            // BW (ByteWord) instructions are needed for 16-bit avx512
-                            return unsafe { AVX512::<FloatIgnoreNaN>::argminmax(self) }
-                        } else if is_x86_feature_detected!("avx512f") {
-                            return unsafe { AVX512::<FloatIgnoreNaN>::argminmax(self) }
-                        } else if is_x86_feature_detected!("avx2") {
+                        #[cfg(feature = "nightly_simd")]
+                        {
+                            if is_x86_feature_detected!("avx512bw") & (<$float_type>::NB_BITS == 16) {
+                                // BW (ByteWord) instructions are needed for 16-bit avx512
+                                return unsafe { AVX512::<FloatIgnoreNaN>::argminmax(self) }
+                            } else if is_x86_feature_detected!("avx512f") {
+                                return unsafe { AVX512::<FloatIgnoreNaN>::argminmax(self) }
+                            }
+                        }
+                        if is_x86_feature_detected!("avx2") {
                             // f16 requires avx2
                             return unsafe { AVX2::<FloatIgnoreNaN>::argminmax(self) }
                         } else if is_x86_feature_detected!("avx") & (<$float_type>::NB_BITS > 16) {
@@ -414,12 +438,16 @@ macro_rules! impl_argminmax_float {
                 fn argmin(&self) -> usize {
                     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
                     {
-                        if is_x86_feature_detected!("avx512bw") & (<$float_type>::NB_BITS == 16) {
-                            // BW (ByteWord) instructions are needed for 16-bit avx512
-                            return unsafe { AVX512::<FloatIgnoreNaN>::argmin(self) }
-                        } else if is_x86_feature_detected!("avx512f") {
-                            return unsafe { AVX512::<FloatIgnoreNaN>::argmin(self) }
-                        } else if is_x86_feature_detected!("avx2") {
+                        #[cfg(feature = "nightly_simd")]
+                        {
+                            if is_x86_feature_detected!("avx512bw") & (<$float_type>::NB_BITS == 16) {
+                                // BW (ByteWord) instructions are needed for 16-bit avx512
+                                return unsafe { AVX512::<FloatIgnoreNaN>::argmin(self) }
+                            } else if is_x86_feature_detected!("avx512f") {
+                                return unsafe { AVX512::<FloatIgnoreNaN>::argmin(self) }
+                            }
+                        }
+                        if is_x86_feature_detected!("avx2") {
                             // f16 requires avx2
                             return unsafe { AVX2::<FloatIgnoreNaN>::argmin(self) }
                         } else if is_x86_feature_detected!("avx") & (<$float_type>::NB_BITS > 16) {
@@ -450,12 +478,16 @@ macro_rules! impl_argminmax_float {
                 fn argmax(&self) -> usize {
                     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
                     {
-                        if is_x86_feature_detected!("avx512bw") & (<$float_type>::NB_BITS == 16) {
-                            // BW (ByteWord) instructions are needed for 16-bit avx512
-                            return unsafe { AVX512::<FloatIgnoreNaN>::argmax(self) }
-                        } else if is_x86_feature_detected!("avx512f") {
-                            return unsafe { AVX512::<FloatIgnoreNaN>::argmax(self) }
-                        } else if is_x86_feature_detected!("avx2") {
+                        #[cfg(feature = "nightly_simd")]
+                        {
+                            if is_x86_feature_detected!("avx512bw") & (<$float_type>::NB_BITS == 16) {
+                                // BW (ByteWord) instructions are needed for 16-bit avx512
+                                return unsafe { AVX512::<FloatIgnoreNaN>::argmax(self) }
+                            } else if is_x86_feature_detected!("avx512f") {
+                                return unsafe { AVX512::<FloatIgnoreNaN>::argmax(self) }
+                            }
+                        }
+                        if is_x86_feature_detected!("avx2") {
                             // f16 requires avx2
                             return unsafe { AVX2::<FloatIgnoreNaN>::argmax(self) }
                         } else if is_x86_feature_detected!("avx") & (<$float_type>::NB_BITS > 16) {
@@ -488,12 +520,16 @@ macro_rules! impl_argminmax_float {
                 fn nanargminmax(&self) -> (usize, usize) {
                     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
                     {
-                        if is_x86_feature_detected!("avx512bw") & (<$float_type>::NB_BITS == 16) {
-                            // BW (ByteWord) instructions are needed for 16-bit avx512
-                            return unsafe { AVX512::<FloatReturnNaN>::argminmax(self) }
-                        } else if is_x86_feature_detected!("avx512f") {
-                            return unsafe { AVX512::<FloatReturnNaN>::argminmax(self) }
-                        } else if is_x86_feature_detected!("avx2") {
+                        #[cfg(feature = "nightly_simd")]
+                        {
+                            if is_x86_feature_detected!("avx512bw") & (<$float_type>::NB_BITS == 16) {
+                                // BW (ByteWord) instructions are needed for 16-bit avx512
+                                return unsafe { AVX512::<FloatReturnNaN>::argminmax(self) }
+                            } else if is_x86_feature_detected!("avx512f") {
+                                return unsafe { AVX512::<FloatReturnNaN>::argminmax(self) }
+                            }
+                        }
+                        if is_x86_feature_detected!("avx2") {
                             return unsafe { AVX2::<FloatReturnNaN>::argminmax(self) }
                         // SKIP SSE4.2 bc scalar is faster or equivalent for 64 bit numbers
                         } else if is_x86_feature_detected!("sse4.1") & (<$float_type>::NB_BITS < 64) {
@@ -522,12 +558,16 @@ macro_rules! impl_argminmax_float {
                 fn nanargmin(&self) -> usize {
                     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
                     {
-                        if is_x86_feature_detected!("avx512bw") & (<$float_type>::NB_BITS == 16) {
-                            // BW (ByteWord) instructions are needed for 16-bit avx512
-                            return unsafe { AVX512::<FloatReturnNaN>::argmin(self) }
-                        } else if is_x86_feature_detected!("avx512f") {
-                            return unsafe { AVX512::<FloatReturnNaN>::argmin(self) }
-                        } else if is_x86_feature_detected!("avx2") {
+                        #[cfg(feature = "nightly_simd")]
+                        {
+                            if is_x86_feature_detected!("avx512bw") & (<$float_type>::NB_BITS == 16) {
+                                // BW (ByteWord) instructions are needed for 16-bit avx512
+                                return unsafe { AVX512::<FloatReturnNaN>::argmin(self) }
+                            } else if is_x86_feature_detected!("avx512f") {
+                                return unsafe { AVX512::<FloatReturnNaN>::argmin(self) }
+                            }
+                        }
+                        if is_x86_feature_detected!("avx2") {
                             return unsafe { AVX2::<FloatReturnNaN>::argmin(self) }
                         // SKIP SSE4.2 bc scalar is faster or equivalent for 64 bit numbers
                         } else if is_x86_feature_detected!("sse4.1") & (<$float_type>::NB_BITS < 64) {
@@ -556,12 +596,16 @@ macro_rules! impl_argminmax_float {
                 fn nanargmax(&self) -> usize {
                     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
                     {
-                        if is_x86_feature_detected!("avx512bw") & (<$float_type>::NB_BITS == 16) {
-                            // BW (ByteWord) instructions are needed for 16-bit avx512
-                            return unsafe { AVX512::<FloatReturnNaN>::argmax(self) }
-                        } else if is_x86_feature_detected!("avx512f") {
-                            return unsafe { AVX512::<FloatReturnNaN>::argmax(self) }
-                        } else if is_x86_feature_detected!("avx2") {
+                        #[cfg(feature = "nightly_simd")]
+                        {
+                            if is_x86_feature_detected!("avx512bw") & (<$float_type>::NB_BITS == 16) {
+                                // BW (ByteWord) instructions are needed for 16-bit avx512
+                                return unsafe { AVX512::<FloatReturnNaN>::argmax(self) }
+                            } else if is_x86_feature_detected!("avx512f") {
+                                return unsafe { AVX512::<FloatReturnNaN>::argmax(self) }
+                            }
+                        }
+                        if is_x86_feature_detected!("avx2") {
                             return unsafe { AVX2::<FloatReturnNaN>::argmax(self) }
                         // SKIP SSE4.2 bc scalar is faster or equivalent for 64 bit numbers
                         } else if is_x86_feature_detected!("sse4.1") & (<$float_type>::NB_BITS < 64) {

--- a/src/simd/config.rs
+++ b/src/simd/config.rs
@@ -84,10 +84,12 @@ impl<DTypeStrategy> SIMDInstructionSet for AVX2<DTypeStrategy> {
 // - uints (see simd_u*.rs files) - Int DTypeStrategy
 // - floats: returning NaNs (see simd_f*_return_nan.rs files) - FloatReturnNan DTypeStrategy
 // - floats: ignoring NaNs (see simd_f*_ignore_nan.rs files) - FloatIgnoreNaN DTypeStrategy
+#[cfg(feature = "nightly_simd")]
 pub struct AVX512<DTypeStrategy> {
     pub(crate) _dtype_strategy: PhantomData<DTypeStrategy>,
 }
 
+#[cfg(feature = "nightly_simd")]
 impl<DTypeStrategy> SIMDInstructionSet for AVX512<DTypeStrategy> {
     /// AVX512 register size is 512 bits
     /// https://en.wikipedia.org/wiki/Advanced_Vector_Extensions#AVX-512
@@ -153,6 +155,7 @@ mod tests {
     fn test_lane_size_f16<DTypeStrategy>(#[case] _dtype_strategy: DTypeStrategy) {
         assert_eq!(SSE::<DTypeStrategy>::get_lane_size::<f16>(), 8);
         assert_eq!(AVX2::<DTypeStrategy>::get_lane_size::<f16>(), 16);
+        #[cfg(feature = "nightly_simd")]
         assert_eq!(AVX512::<DTypeStrategy>::get_lane_size::<f16>(), 32);
         assert_eq!(NEON::<DTypeStrategy>::get_lane_size::<f16>(), 8);
     }
@@ -161,6 +164,7 @@ mod tests {
     fn test_lane_size_f32<DTypeStrategy>(#[case] _dtype_strategy: DTypeStrategy) {
         assert_eq!(SSE::<DTypeStrategy>::get_lane_size::<f32>(), 4);
         assert_eq!(AVX2::<DTypeStrategy>::get_lane_size::<f32>(), 8);
+        #[cfg(feature = "nightly_simd")]
         assert_eq!(AVX512::<DTypeStrategy>::get_lane_size::<f32>(), 16);
         assert_eq!(NEON::<DTypeStrategy>::get_lane_size::<f32>(), 4);
     }
@@ -169,6 +173,7 @@ mod tests {
     fn test_lane_size_f64<DTypeStrategy>(#[case] _dtype_strategy: DTypeStrategy) {
         assert_eq!(SSE::<DTypeStrategy>::get_lane_size::<f64>(), 2);
         assert_eq!(AVX2::<DTypeStrategy>::get_lane_size::<f64>(), 4);
+        #[cfg(feature = "nightly_simd")]
         assert_eq!(AVX512::<DTypeStrategy>::get_lane_size::<f64>(), 8);
         assert_eq!(NEON::<DTypeStrategy>::get_lane_size::<f64>(), 2);
     }
@@ -177,6 +182,7 @@ mod tests {
     fn test_lane_size_i8<DTypeStrategy>(#[case] _dtype_strategy: DTypeStrategy) {
         assert_eq!(SSE::<DTypeStrategy>::get_lane_size::<i8>(), 16);
         assert_eq!(AVX2::<DTypeStrategy>::get_lane_size::<i8>(), 32);
+        #[cfg(feature = "nightly_simd")]
         assert_eq!(AVX512::<DTypeStrategy>::get_lane_size::<i8>(), 64);
         assert_eq!(NEON::<DTypeStrategy>::get_lane_size::<i8>(), 16);
     }
@@ -185,6 +191,7 @@ mod tests {
     fn test_lane_size_i16<DTypeStrategy>(#[case] _dtype_strategy: DTypeStrategy) {
         assert_eq!(SSE::<DTypeStrategy>::get_lane_size::<i16>(), 8);
         assert_eq!(AVX2::<DTypeStrategy>::get_lane_size::<i16>(), 16);
+        #[cfg(feature = "nightly_simd")]
         assert_eq!(AVX512::<DTypeStrategy>::get_lane_size::<i16>(), 32);
         assert_eq!(NEON::<DTypeStrategy>::get_lane_size::<i16>(), 8);
     }
@@ -193,6 +200,7 @@ mod tests {
     fn test_lane_size_i32<DTypeStrategy>(#[case] _dtype_strategy: DTypeStrategy) {
         assert_eq!(SSE::<DTypeStrategy>::get_lane_size::<i32>(), 4);
         assert_eq!(AVX2::<DTypeStrategy>::get_lane_size::<i32>(), 8);
+        #[cfg(feature = "nightly_simd")]
         assert_eq!(AVX512::<DTypeStrategy>::get_lane_size::<i32>(), 16);
         assert_eq!(NEON::<DTypeStrategy>::get_lane_size::<i32>(), 4);
     }
@@ -201,6 +209,7 @@ mod tests {
     fn test_lane_size_i64<DTypeStrategy>(#[case] _dtype_strategy: DTypeStrategy) {
         assert_eq!(SSE::<DTypeStrategy>::get_lane_size::<i64>(), 2);
         assert_eq!(AVX2::<DTypeStrategy>::get_lane_size::<i64>(), 4);
+        #[cfg(feature = "nightly_simd")]
         assert_eq!(AVX512::<DTypeStrategy>::get_lane_size::<i64>(), 8);
         assert_eq!(NEON::<DTypeStrategy>::get_lane_size::<i64>(), 2);
     }
@@ -209,6 +218,7 @@ mod tests {
     fn test_lane_size_u8<DTypeStrategy>(#[case] _dtype_strategy: DTypeStrategy) {
         assert_eq!(SSE::<DTypeStrategy>::get_lane_size::<u8>(), 16);
         assert_eq!(AVX2::<DTypeStrategy>::get_lane_size::<u8>(), 32);
+        #[cfg(feature = "nightly_simd")]
         assert_eq!(AVX512::<DTypeStrategy>::get_lane_size::<u8>(), 64);
         assert_eq!(NEON::<DTypeStrategy>::get_lane_size::<u8>(), 16);
     }
@@ -217,6 +227,7 @@ mod tests {
     fn test_lane_size_u16<DTypeStrategy>(#[case] _dtype_strategy: DTypeStrategy) {
         assert_eq!(SSE::<DTypeStrategy>::get_lane_size::<u16>(), 8);
         assert_eq!(AVX2::<DTypeStrategy>::get_lane_size::<u16>(), 16);
+        #[cfg(feature = "nightly_simd")]
         assert_eq!(AVX512::<DTypeStrategy>::get_lane_size::<u16>(), 32);
         assert_eq!(NEON::<DTypeStrategy>::get_lane_size::<u16>(), 8);
     }
@@ -225,6 +236,7 @@ mod tests {
     fn test_lane_size_u32<DTypeStrategy>(#[case] _dtype_strategy: DTypeStrategy) {
         assert_eq!(SSE::<DTypeStrategy>::get_lane_size::<u32>(), 4);
         assert_eq!(AVX2::<DTypeStrategy>::get_lane_size::<u32>(), 8);
+        #[cfg(feature = "nightly_simd")]
         assert_eq!(AVX512::<DTypeStrategy>::get_lane_size::<u32>(), 16);
         assert_eq!(NEON::<DTypeStrategy>::get_lane_size::<u32>(), 4);
     }
@@ -233,6 +245,7 @@ mod tests {
     fn test_lane_size_u64<DTypeStrategy>(#[case] _dtype_strategy: DTypeStrategy) {
         assert_eq!(SSE::<DTypeStrategy>::get_lane_size::<u64>(), 2);
         assert_eq!(AVX2::<DTypeStrategy>::get_lane_size::<u64>(), 4);
+        #[cfg(feature = "nightly_simd")]
         assert_eq!(AVX512::<DTypeStrategy>::get_lane_size::<u64>(), 8);
         assert_eq!(NEON::<DTypeStrategy>::get_lane_size::<u64>(), 2);
     }

--- a/src/simd/generic.rs
+++ b/src/simd/generic.rs
@@ -181,6 +181,7 @@ where
 
 // --------------- Int (signed and unsigned)
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 macro_rules! impl_SIMDInit_Int {
     ($scalar_dtype:ty, $simd_vec_dtype:ty, $simd_mask_dtype:ty, $lane_size:expr, $simd_struct:ty) => {
         impl SIMDInit<$scalar_dtype, $simd_vec_dtype, $simd_mask_dtype, $lane_size>
@@ -191,11 +192,13 @@ macro_rules! impl_SIMDInit_Int {
     };
 }
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 pub(crate) use impl_SIMDInit_Int; // Now classic paths Just Work™
 
 // --------------- Float Return NaNs
 
 #[cfg(any(feature = "float", feature = "half"))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 macro_rules! impl_SIMDInit_FloatReturnNaN {
     ($scalar_dtype:ty, $simd_vec_dtype:ty, $simd_mask_dtype:ty, $lane_size:expr, $simd_struct:ty) => {
         impl SIMDInit<$scalar_dtype, $simd_vec_dtype, $simd_mask_dtype, $lane_size>
@@ -218,11 +221,13 @@ macro_rules! impl_SIMDInit_FloatReturnNaN {
 }
 
 #[cfg(any(feature = "float", feature = "half"))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 pub(crate) use impl_SIMDInit_FloatReturnNaN; // Now classic paths Just Work™
 
 // --------------- Float Ignore NaNs
 
 #[cfg(any(feature = "float", feature = "half"))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 macro_rules! impl_SIMDInit_FloatIgnoreNaN {
     ($($scalar_dtype:ty, $simd_vec_dtype:ty, $simd_mask_dtype:ty, $lane_size:expr, $simd_struct:ty),*) => {
         $(
@@ -276,6 +281,7 @@ macro_rules! impl_SIMDInit_FloatIgnoreNaN {
 }
 
 #[cfg(any(feature = "float", feature = "half"))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 pub(crate) use impl_SIMDInit_FloatIgnoreNaN; // Now classic paths Just Work™
 
 // ---------------------------------- SIMD algorithm -----------------------------------
@@ -732,6 +738,7 @@ where
     }
 }
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 macro_rules! impl_SIMDArgMinMax {
     ($($scalar_dtype:ty, $simd_vec_dtype:ty, $simd_mask_dtype:ty, $lane_size:expr, $scalar_struct:ty, $simd_struct:ty, $target:expr),*) => {
         $(
@@ -758,11 +765,13 @@ macro_rules! impl_SIMDArgMinMax {
     }
 }
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 pub(crate) use impl_SIMDArgMinMax; // Now classic paths Just Work™
 
 // --------------------------------- Unimplement Macros --------------------------------
 
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(feature = "nightly_simd")]
 macro_rules! unimpl_SIMDOps {
     ($scalar_type:ty, $reg:ty, $simd_struct:ty) => {
         impl SIMDOps<$scalar_type, $reg, $reg, 0> for $simd_struct {
@@ -798,6 +807,7 @@ macro_rules! unimpl_SIMDOps {
 }
 
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(feature = "nightly_simd")]
 macro_rules! unimpl_SIMDInit {
     ($scalar_type:ty, $reg:ty, $simd_struct:ty) => {
         impl SIMDInit<$scalar_type, $reg, $reg, 0> for $simd_struct {
@@ -807,6 +817,7 @@ macro_rules! unimpl_SIMDInit {
 }
 
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(feature = "nightly_simd")]
 macro_rules! unimpl_SIMDArgMinMax {
     ($scalar_type:ty, $reg:ty, $scalar:ty, $simd_struct:ty) => {
         impl SIMDArgMinMax<$scalar_type, $reg, $reg, 0, $scalar> for $simd_struct {
@@ -826,10 +837,13 @@ macro_rules! unimpl_SIMDArgMinMax {
 }
 
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(feature = "nightly_simd")]
 pub(crate) use unimpl_SIMDArgMinMax; // Now classic paths Just Work™
 
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(feature = "nightly_simd")]
 pub(crate) use unimpl_SIMDInit; // Now classic paths Just Work™
 
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(feature = "nightly_simd")]
 pub(crate) use unimpl_SIMDOps; // Now classic paths Just Work™

--- a/src/simd/mod.rs
+++ b/src/simd/mod.rs
@@ -36,4 +36,5 @@ mod simd_u8;
 
 // Test utils
 #[cfg(test)]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 mod test_utils;

--- a/src/simd/simd_f16_ignore_nan.rs
+++ b/src/simd/simd_f16_ignore_nan.rs
@@ -35,6 +35,7 @@ use num_traits::Zero;
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 #[cfg(target_arch = "arm")]
+#[cfg(feature = "nightly_simd")]
 use std::arch::arm::*;
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;

--- a/src/simd/simd_f16_ignore_nan.rs
+++ b/src/simd/simd_f16_ignore_nan.rs
@@ -25,12 +25,15 @@
 /// Note that most x86 CPUs do not support f16 instructions - making this implementation
 /// multitudes (up to 300x) faster than trying to use a vanilla scalar implementation.
 ///
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::config::SIMDInstructionSet;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::generic::{
     impl_SIMDArgMinMax, impl_SIMDInit_FloatIgnoreNaN, SIMDArgMinMax, SIMDInit, SIMDOps,
 };
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use crate::SCALAR;
-
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use num_traits::Zero;
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
@@ -42,21 +45,28 @@ use std::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use half::f16;
 
 /// The dtype-strategy for performing operations on f16 data: ignore NaN values
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::super::dtype_strategy::FloatIgnoreNaN;
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 const BIT_SHIFT: i32 = 15;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 const MASK_VALUE: i16 = 0x7FFF; // i16::MAX - masks everything but the sign bit
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 const NAN_VALUE: i16 = 0x7C00; // absolute values above this are NaN
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 #[inline(always)]
 fn _i16ord_to_f16(ord_i16: i16) -> f16 {
     let v = ((ord_i16 >> BIT_SHIFT) & MASK_VALUE) ^ ord_i16;
     f16::from_bits(v as u16)
 }
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 const MAX_INDEX: usize = i16::MAX as usize;
 
 // --------------------------------------- AVX2 ----------------------------------------
@@ -687,8 +697,8 @@ mod neon_ignore_nan {
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "arm",
-    target_arch = "aarch64",
+    all(target_arch = "arm", feature = "nightly_simd"),
+    all(target_arch = "aarch64", feature = "nightly_simd"),
 ))]
 #[cfg(test)]
 mod tests {
@@ -702,7 +712,6 @@ mod tests {
     #[cfg(feature = "nightly_simd")]
     use crate::simd::config::AVX512;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    #[cfg(feature = "nightly_simd")]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, SSE};
@@ -744,7 +753,6 @@ mod tests {
     // ------------ Template for ARM / AArch64 ------------
 
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    #[cfg(feature = "nightly_simd")]
     #[template]
     #[rstest]
     #[case::neon(NEON {_dtype_strategy: PhantomData::<FloatIgnoreNaN>}, true)]

--- a/src/simd/simd_f16_ignore_nan.rs
+++ b/src/simd/simd_f16_ignore_nan.rs
@@ -373,6 +373,7 @@ mod sse_ignore_nan {
 // -------------------------------------- AVX512 ---------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(feature = "nightly_simd")]
 mod avx512_ignore_nan {
     use super::super::config::AVX512;
     use super::*;
@@ -695,10 +696,13 @@ mod tests {
 
     use half::f16;
 
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(feature = "nightly_simd")]
+    use crate::simd::config::AVX512;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    use crate::simd::config::{AVX2, AVX512, SSE};
+    use crate::simd::config::{AVX2, SSE};
     use crate::{FloatIgnoreNaN, SIMDArgMinMax, SCALAR};
 
     use super::super::test_utils::{
@@ -727,7 +731,7 @@ mod tests {
     #[rstest]
     #[case::sse(SSE {_dtype_strategy: PhantomData::<FloatIgnoreNaN>}, is_x86_feature_detected!("sse4.1"))]
     #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<FloatIgnoreNaN>}, is_x86_feature_detected!("avx2"))]
-    #[case::avx512(AVX512 {_dtype_strategy: PhantomData::<FloatIgnoreNaN>}, is_x86_feature_detected!("avx512bw"))]
+    #[cfg_attr(feature = "nightly_simd", case::avx512(AVX512 {_dtype_strategy: PhantomData::<FloatIgnoreNaN>}, is_x86_feature_detected!("avx512bw")))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] simd: T,
         #[case] simd_available: bool,

--- a/src/simd/simd_f16_ignore_nan.rs
+++ b/src/simd/simd_f16_ignore_nan.rs
@@ -536,6 +536,7 @@ mod avx512_ignore_nan {
 // --------------------------------------- NEON ----------------------------------------
 
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(feature = "nightly_simd")]
 mod neon_ignore_nan {
     use super::super::config::NEON;
     use super::*;
@@ -700,6 +701,7 @@ mod tests {
     #[cfg(feature = "nightly_simd")]
     use crate::simd::config::AVX512;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(feature = "nightly_simd")]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, SSE};
@@ -741,6 +743,7 @@ mod tests {
     // ------------ Template for ARM / AArch64 ------------
 
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(feature = "nightly_simd")]
     #[template]
     #[rstest]
     #[case::neon(NEON {_dtype_strategy: PhantomData::<FloatIgnoreNaN>}, true)]

--- a/src/simd/simd_f16_return_nan.rs
+++ b/src/simd/simd_f16_return_nan.rs
@@ -506,6 +506,7 @@ mod avx512 {
 // --------------------------------------- NEON ----------------------------------------
 
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(feature = "nightly_simd")]
 mod neon {
     use super::super::config::NEON;
     use super::*;
@@ -663,6 +664,7 @@ mod tests {
     #[cfg(feature = "nightly_simd")]
     use crate::simd::config::AVX512;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(feature = "nightly_simd")]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, SSE};
@@ -704,6 +706,7 @@ mod tests {
     // ------------ Template for ARM / AArch64 ------------
 
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(feature = "nightly_simd")]
     #[template]
     #[rstest]
     #[case::neon(NEON {_dtype_strategy: PhantomData::<FloatReturnNaN>}, true)]

--- a/src/simd/simd_f16_return_nan.rs
+++ b/src/simd/simd_f16_return_nan.rs
@@ -352,6 +352,7 @@ mod sse {
 // -------------------------------------- AVX512 ---------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(feature = "nightly_simd")]
 mod avx512 {
     use super::super::config::AVX512;
     use super::*;
@@ -658,10 +659,13 @@ mod tests {
 
     use half::f16;
 
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(feature = "nightly_simd")]
+    use crate::simd::config::AVX512;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    use crate::simd::config::{AVX2, AVX512, SSE};
+    use crate::simd::config::{AVX2, SSE};
     use crate::{FloatReturnNaN, SIMDArgMinMax, SCALAR};
 
     use super::super::test_utils::{
@@ -690,7 +694,7 @@ mod tests {
     #[rstest]
     #[case::sse(SSE {_dtype_strategy: PhantomData::<FloatReturnNaN>}, is_x86_feature_detected!("sse4.1"))]
     #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<FloatReturnNaN>}, is_x86_feature_detected!("avx2"))]
-    #[case::avx512(AVX512 {_dtype_strategy: PhantomData::<FloatReturnNaN>}, is_x86_feature_detected!("avx512bw"))]
+    #[cfg_attr(feature = "nightly_simd", case::avx512(AVX512 {_dtype_strategy: PhantomData::<FloatReturnNaN>}, is_x86_feature_detected!("avx512bw")))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] simd: T,
         #[case] simd_available: bool,

--- a/src/simd/simd_f16_return_nan.rs
+++ b/src/simd/simd_f16_return_nan.rs
@@ -27,8 +27,11 @@
 /// SIMDOps::_get_overflow_lane_size_limit() chunk of the data - which is not
 /// necessarily the index of the first NaN value.
 ///
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::config::SIMDInstructionSet;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::generic::{impl_SIMDInit_FloatReturnNaN, SIMDArgMinMax, SIMDInit, SIMDOps};
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use crate::SCALAR;
 
 #[cfg(target_arch = "aarch64")]
@@ -41,20 +44,26 @@ use std::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use half::f16;
 
 /// The dtype-strategy for performing operations on f16 data: return NaN index
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::super::dtype_strategy::FloatReturnNaN;
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 const BIT_SHIFT: i32 = 15;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 const MASK_VALUE: i16 = 0x7FFF; // i16::MAX - masks everything but the sign bit
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 #[inline(always)]
 fn _i16ord_to_f16(ord_i16: i16) -> f16 {
     let v = ((ord_i16 >> BIT_SHIFT) & MASK_VALUE) ^ ord_i16;
     f16::from_bits(v as u16)
 }
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 const MAX_INDEX: usize = i16::MAX as usize;
 
 // --------------------------------------- AVX2 ----------------------------------------
@@ -650,8 +659,8 @@ mod neon {
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "arm",
-    target_arch = "aarch64",
+    all(target_arch = "arm", feature = "nightly_simd"),
+    all(target_arch = "aarch64", feature = "nightly_simd"),
 ))]
 #[cfg(test)]
 mod tests {
@@ -665,7 +674,6 @@ mod tests {
     #[cfg(feature = "nightly_simd")]
     use crate::simd::config::AVX512;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    #[cfg(feature = "nightly_simd")]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, SSE};
@@ -707,7 +715,6 @@ mod tests {
     // ------------ Template for ARM / AArch64 ------------
 
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    #[cfg(feature = "nightly_simd")]
     #[template]
     #[rstest]
     #[case::neon(NEON {_dtype_strategy: PhantomData::<FloatReturnNaN>}, true)]

--- a/src/simd/simd_f16_return_nan.rs
+++ b/src/simd/simd_f16_return_nan.rs
@@ -34,6 +34,7 @@ use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 #[cfg(target_arch = "arm")]
+#[cfg(feature = "nightly_simd")]
 use std::arch::arm::*;
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;

--- a/src/simd/simd_f32_ignore_nan.rs
+++ b/src/simd/simd_f32_ignore_nan.rs
@@ -20,6 +20,7 @@ use num_traits::Zero;
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 #[cfg(target_arch = "arm")]
+#[cfg(feature = "nightly_simd")]
 use std::arch::arm::*;
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;

--- a/src/simd/simd_f32_ignore_nan.rs
+++ b/src/simd/simd_f32_ignore_nan.rs
@@ -11,11 +11,15 @@
 /// As comparisons with NaN always return false, it is guaranteed that no NaN values
 /// are added to the accumulating SIMD register.
 ///
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::config::SIMDInstructionSet;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::generic::{
     impl_SIMDArgMinMax, impl_SIMDInit_FloatIgnoreNaN, SIMDArgMinMax, SIMDInit, SIMDOps,
 };
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use crate::SCALAR;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use num_traits::Zero;
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
@@ -28,9 +32,11 @@ use std::arch::x86::*;
 use std::arch::x86_64::*;
 
 /// The dtype-strategy for performing operations on f32 data: ignore NaN values
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::super::dtype_strategy::FloatIgnoreNaN;
 
 // https://stackoverflow.com/a/3793950
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 const MAX_INDEX: usize = 1 << f32::MANTISSA_DIGITS;
 
 // --------------------------------------- AVX2 ----------------------------------------
@@ -322,8 +328,8 @@ mod neon_ignore_nan {
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "arm",
-    target_arch = "aarch64",
+    all(target_arch = "arm", feature = "nightly_simd"),
+    all(target_arch = "aarch64", feature = "nightly_simd"),
 ))]
 #[cfg(test)]
 mod tests {
@@ -335,7 +341,6 @@ mod tests {
     #[cfg(feature = "nightly_simd")]
     use crate::simd::config::AVX512;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    #[cfg(feature = "nightly_simd")]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, SSE};
@@ -376,7 +381,6 @@ mod tests {
     // ------------ Template for ARM / AArch64 ------------
 
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    #[cfg(feature = "nightly_simd")]
     #[template]
     #[rstest]
     #[case::neon(NEON {_dtype_strategy: PhantomData::<FloatIgnoreNaN>}, true)]

--- a/src/simd/simd_f32_ignore_nan.rs
+++ b/src/simd/simd_f32_ignore_nan.rs
@@ -173,6 +173,7 @@ mod sse_ignore_nan {
 // -------------------------------------- AVX512 ---------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(feature = "nightly_simd")]
 mod avx512_ignore_nan {
     use super::super::config::AVX512;
     use super::*;
@@ -328,10 +329,13 @@ mod tests {
     use rstest_reuse::{self, *};
     use std::marker::PhantomData;
 
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(feature = "nightly_simd")]
+    use crate::simd::config::AVX512;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    use crate::simd::config::{AVX2, AVX512, SSE};
+    use crate::simd::config::{AVX2, SSE};
     use crate::{FloatIgnoreNaN, SIMDArgMinMax, SCALAR};
 
     use super::super::test_utils::{
@@ -359,7 +363,7 @@ mod tests {
     #[rstest]
     #[case::sse(SSE {_dtype_strategy: PhantomData::<FloatIgnoreNaN>}, is_x86_feature_detected!("sse4.1"))]
     #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<FloatIgnoreNaN>}, is_x86_feature_detected!("avx"))]
-    #[case::avx512(AVX512 {_dtype_strategy: PhantomData::<FloatIgnoreNaN>}, is_x86_feature_detected!("avx512f"))]
+    #[cfg_attr(feature = "nightly_simd", case::avx512(AVX512 {_dtype_strategy: PhantomData::<FloatIgnoreNaN>}, is_x86_feature_detected!("avx512f")))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] simd: T,
         #[case] simd_available: bool,

--- a/src/simd/simd_f32_ignore_nan.rs
+++ b/src/simd/simd_f32_ignore_nan.rs
@@ -245,6 +245,7 @@ mod avx512_ignore_nan {
 // --------------------------------------- NEON ----------------------------------------
 
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(feature = "nightly_simd")]
 mod neon_ignore_nan {
     use super::super::config::NEON;
     use super::*;
@@ -333,6 +334,7 @@ mod tests {
     #[cfg(feature = "nightly_simd")]
     use crate::simd::config::AVX512;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(feature = "nightly_simd")]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, SSE};
@@ -373,6 +375,7 @@ mod tests {
     // ------------ Template for ARM / AArch64 ------------
 
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(feature = "nightly_simd")]
     #[template]
     #[rstest]
     #[case::neon(NEON {_dtype_strategy: PhantomData::<FloatIgnoreNaN>}, true)]

--- a/src/simd/simd_f32_return_nan.rs
+++ b/src/simd/simd_f32_return_nan.rs
@@ -363,6 +363,7 @@ mod avx512 {
 // --------------------------------------- NEON ----------------------------------------
 
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(feature = "nightly_simd")]
 mod neon {
     use super::super::config::NEON;
     use super::*;
@@ -477,6 +478,7 @@ mod tests {
     #[cfg(feature = "nightly_simd")]
     use crate::simd::config::AVX512;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(feature = "nightly_simd")]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, SSE};
@@ -516,6 +518,7 @@ mod tests {
     // ------------ Template for ARM / AArch64 ------------
 
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(feature = "nightly_simd")]
     #[template]
     #[rstest]
     #[case::neon(NEON { _dtype_strategy: PhantomData::<FloatReturnNaN>}, true)]

--- a/src/simd/simd_f32_return_nan.rs
+++ b/src/simd/simd_f32_return_nan.rs
@@ -258,6 +258,7 @@ mod sse {
 // -------------------------------------- AVX512 ---------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(feature = "nightly_simd")]
 mod avx512 {
     use super::super::config::AVX512;
     use super::*;
@@ -472,10 +473,13 @@ mod tests {
     use rstest_reuse::{self, *};
     use std::marker::PhantomData;
 
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(feature = "nightly_simd")]
+    use crate::simd::config::AVX512;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    use crate::simd::config::{AVX2, AVX512, SSE};
+    use crate::simd::config::{AVX2, SSE};
     use crate::{FloatReturnNaN, SIMDArgMinMax, SCALAR};
 
     use super::super::test_utils::{
@@ -502,7 +506,7 @@ mod tests {
     #[rstest]
     #[case::sse(SSE {_dtype_strategy: PhantomData::<FloatReturnNaN>}, is_x86_feature_detected!("sse4.1"))]
     #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<FloatReturnNaN>}, is_x86_feature_detected!("avx2"))]
-    #[case::avx512(AVX512 {_dtype_strategy: PhantomData::<FloatReturnNaN>}, is_x86_feature_detected!("avx512f"))]
+    #[cfg_attr(feature = "nightly_simd", case::avx512(AVX512 {_dtype_strategy: PhantomData::<FloatReturnNaN>}, is_x86_feature_detected!("avx512f")))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] simd: T,
         #[case] simd_available: bool,

--- a/src/simd/simd_f32_return_nan.rs
+++ b/src/simd/simd_f32_return_nan.rs
@@ -28,8 +28,11 @@
 /// SIMDOps::_get_overflow_lane_size_limit() chunk of the data - which is not
 /// necessarily the index of the first NaN value.
 ///
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::config::SIMDInstructionSet;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::generic::{impl_SIMDInit_FloatReturnNaN, SIMDArgMinMax, SIMDInit, SIMDOps};
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
@@ -42,19 +45,25 @@ use std::arch::x86::*;
 use std::arch::x86_64::*;
 
 /// The dtype-strategy for performing operations on f32 data: return NaN index
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::super::dtype_strategy::FloatReturnNaN;
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::task::{max_index_value, min_index_value};
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 const BIT_SHIFT: i32 = 31;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 const MASK_VALUE: i32 = 0x7FFFFFFF; // i32::MAX - masks everything but the sign bit
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 #[inline(always)]
 fn _i32ord_to_f32(ord_i32: i32) -> f32 {
     let v = ((ord_i32 >> BIT_SHIFT) & MASK_VALUE) ^ ord_i32;
     f32::from_bits(v as u32)
 }
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 const MAX_INDEX: usize = i32::MAX as usize;
 
 // --------------------------------------- AVX2 ----------------------------------------
@@ -466,8 +475,8 @@ mod neon {
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "arm",
-    target_arch = "aarch64",
+    all(target_arch = "arm", feature = "nightly_simd"),
+    all(target_arch = "aarch64", feature = "nightly_simd"),
 ))]
 #[cfg(test)]
 mod tests {
@@ -479,7 +488,6 @@ mod tests {
     #[cfg(feature = "nightly_simd")]
     use crate::simd::config::AVX512;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    #[cfg(feature = "nightly_simd")]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, SSE};
@@ -519,7 +527,6 @@ mod tests {
     // ------------ Template for ARM / AArch64 ------------
 
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    #[cfg(feature = "nightly_simd")]
     #[template]
     #[rstest]
     #[case::neon(NEON { _dtype_strategy: PhantomData::<FloatReturnNaN>}, true)]

--- a/src/simd/simd_f32_return_nan.rs
+++ b/src/simd/simd_f32_return_nan.rs
@@ -34,6 +34,7 @@ use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 #[cfg(target_arch = "arm")]
+#[cfg(feature = "nightly_simd")]
 use std::arch::arm::*;
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;

--- a/src/simd/simd_f64_ignore_nan.rs
+++ b/src/simd/simd_f64_ignore_nan.rs
@@ -16,7 +16,9 @@
 use super::config::SIMDInstructionSet;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_FloatIgnoreNaN};
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::generic::{SIMDArgMinMax, SIMDInit, SIMDOps};
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use crate::SCALAR;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use num_traits::Zero;
@@ -26,6 +28,7 @@ use std::arch::x86::*;
 use std::arch::x86_64::*;
 
 /// The dtype-strategy for performing operations on f64 data: ignore NaN values
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::super::dtype_strategy::FloatIgnoreNaN;
 
 // https://stackoverflow.com/a/3793950

--- a/src/simd/simd_f64_ignore_nan.rs
+++ b/src/simd/simd_f64_ignore_nan.rs
@@ -171,6 +171,7 @@ mod sse_ignore_nan {
 // -------------------------------------- AVX512 ---------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(feature = "nightly_simd")]
 mod avx512_ignore_nan {
     use super::super::config::AVX512;
     use super::*;
@@ -269,7 +270,9 @@ mod tests {
     use rstest_reuse::{self, *};
     use std::marker::PhantomData;
 
-    use crate::simd::config::{AVX2, AVX512, SSE};
+    #[cfg(feature = "nightly_simd")]
+    use crate::simd::config::AVX512;
+    use crate::simd::config::{AVX2, SSE};
     use crate::{FloatIgnoreNaN, SIMDArgMinMax, SCALAR};
 
     use super::super::test_utils::{
@@ -295,7 +298,7 @@ mod tests {
     #[rstest]
     #[case::sse(SSE {_dtype_strategy: PhantomData::<FloatIgnoreNaN>}, is_x86_feature_detected!("sse4.1"))]
     #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<FloatIgnoreNaN>}, is_x86_feature_detected!("avx"))]
-    #[case::avx512(AVX512 {_dtype_strategy: PhantomData::<FloatIgnoreNaN>}, is_x86_feature_detected!("avx512f"))]
+    #[cfg_attr(feature = "nightly_simd", case::avx512(AVX512 {_dtype_strategy: PhantomData::<FloatIgnoreNaN>}, is_x86_feature_detected!("avx512f")))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] simd: T,
         #[case] simd_available: bool,

--- a/src/simd/simd_f64_ignore_nan.rs
+++ b/src/simd/simd_f64_ignore_nan.rs
@@ -247,6 +247,7 @@ mod avx512_ignore_nan {
 //   intrinsics: vadd_, vcgt_, vclt_
 
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(feature = "nightly_simd")]
 mod neon_ignore_nan {
     use super::super::config::NEON;
     use super::super::generic::{unimpl_SIMDArgMinMax, unimpl_SIMDInit, unimpl_SIMDOps};

--- a/src/simd/simd_f64_return_nan.rs
+++ b/src/simd/simd_f64_return_nan.rs
@@ -376,6 +376,7 @@ mod avx512 {
 //   intrinsics: vadd_, vcgt_, vclt_
 
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(feature = "nightly_simd")]
 mod neon {
     use super::super::config::NEON;
     use super::super::generic::{unimpl_SIMDArgMinMax, unimpl_SIMDInit, unimpl_SIMDOps};

--- a/src/simd/simd_f64_return_nan.rs
+++ b/src/simd/simd_f64_return_nan.rs
@@ -33,7 +33,9 @@
 use super::config::SIMDInstructionSet;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use super::generic::impl_SIMDInit_FloatReturnNaN;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::generic::{SIMDArgMinMax, SIMDInit, SIMDOps};
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use crate::SCALAR;
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;
@@ -41,6 +43,7 @@ use std::arch::x86::*;
 use std::arch::x86_64::*;
 
 /// The dtype-strategy for performing operations on f64 data: return NaN index
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::super::dtype_strategy::FloatReturnNaN;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]

--- a/src/simd/simd_f64_return_nan.rs
+++ b/src/simd/simd_f64_return_nan.rs
@@ -272,6 +272,7 @@ mod sse {
 // -------------------------------------- AVX512 ---------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(feature = "nightly_simd")]
 mod avx512 {
     use super::super::config::AVX512;
     use super::*;
@@ -398,7 +399,9 @@ mod tests {
     use rstest_reuse::{self, *};
     use std::marker::PhantomData;
 
-    use crate::simd::config::{AVX2, AVX512, SSE};
+    #[cfg(feature = "nightly_simd")]
+    use crate::simd::config::AVX512;
+    use crate::simd::config::{AVX2, SSE};
     use crate::{FloatReturnNaN, SIMDArgMinMax, SCALAR};
 
     use super::super::test_utils::{
@@ -424,7 +427,7 @@ mod tests {
     #[rstest]
     #[case::sse(SSE {_dtype_strategy: PhantomData::<FloatReturnNaN>}, is_x86_feature_detected!("sse4.2"))]
     #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<FloatReturnNaN>}, is_x86_feature_detected!("avx2"))]
-    #[case::avx512(AVX512 {_dtype_strategy: PhantomData::<FloatReturnNaN>}, is_x86_feature_detected!("avx512f"))]
+    #[cfg_attr(feature = "nightly_simd", case::avx512(AVX512 {_dtype_strategy: PhantomData::<FloatReturnNaN>}, is_x86_feature_detected!("avx512f")))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] simd: T,
         #[case] simd_available: bool,

--- a/src/simd/simd_i16.rs
+++ b/src/simd/simd_i16.rs
@@ -258,6 +258,7 @@ mod sse {
 // -------------------------------------- AVX512 ---------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(feature = "nightly_simd")]
 mod avx512 {
     use super::super::config::AVX512;
     use super::*;
@@ -514,10 +515,13 @@ mod tests {
     use rstest_reuse::{self, *};
     use std::marker::PhantomData;
 
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(feature = "nightly_simd")]
+    use crate::simd::config::AVX512;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    use crate::simd::config::{AVX2, AVX512, SSE};
+    use crate::simd::config::{AVX2, SSE};
     use crate::{Int, SIMDArgMinMax, SCALAR};
 
     use super::super::test_utils::{
@@ -543,7 +547,7 @@ mod tests {
     #[rstest]
     #[case::sse(SSE {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("sse4.1"))]
     #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx2"))]
-    #[case::avx512(AVX512 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx512bw"))]
+    #[cfg_attr(feature = "nightly_simd", case::avx512(AVX512 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx512bw")))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] simd: T,
         #[case] simd_available: bool,

--- a/src/simd/simd_i16.rs
+++ b/src/simd/simd_i16.rs
@@ -388,6 +388,7 @@ mod avx512 {
 // --------------------------------------- NEON ----------------------------------------
 
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(feature = "nightly_simd")]
 mod neon {
     use super::super::config::NEON;
     use super::*;
@@ -519,6 +520,7 @@ mod tests {
     #[cfg(feature = "nightly_simd")]
     use crate::simd::config::AVX512;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(feature = "nightly_simd")]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, SSE};
@@ -557,6 +559,7 @@ mod tests {
     // ------------ Template for ARM / AArch64 ------------
 
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(feature = "nightly_simd")]
     #[template]
     #[rstest]
     #[case::neon(NEON {_dtype_strategy: PhantomData::<Int>}, true)]

--- a/src/simd/simd_i16.rs
+++ b/src/simd/simd_i16.rs
@@ -1,5 +1,8 @@
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::config::SIMDInstructionSet;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
@@ -12,8 +15,10 @@ use std::arch::x86::*;
 use std::arch::x86_64::*;
 
 /// The dtype-strategy for performing operations on i16 data: (default) Int
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::super::dtype_strategy::Int;
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 const MAX_INDEX: usize = i16::MAX as usize;
 
 // --------------------------------------- AVX2 ----------------------------------------
@@ -508,8 +513,8 @@ mod neon {
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "arm",
-    target_arch = "aarch64",
+    all(target_arch = "arm", feature = "nightly_simd"),
+    all(target_arch = "aarch64", feature = "nightly_simd"),
 ))]
 #[cfg(test)]
 mod tests {
@@ -521,7 +526,6 @@ mod tests {
     #[cfg(feature = "nightly_simd")]
     use crate::simd::config::AVX512;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    #[cfg(feature = "nightly_simd")]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, SSE};
@@ -560,7 +564,6 @@ mod tests {
     // ------------ Template for ARM / AArch64 ------------
 
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    #[cfg(feature = "nightly_simd")]
     #[template]
     #[rstest]
     #[case::neon(NEON {_dtype_strategy: PhantomData::<Int>}, true)]

--- a/src/simd/simd_i16.rs
+++ b/src/simd/simd_i16.rs
@@ -4,6 +4,7 @@ use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 #[cfg(target_arch = "arm")]
+#[cfg(feature = "nightly_simd")]
 use std::arch::arm::*;
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;

--- a/src/simd/simd_i32.rs
+++ b/src/simd/simd_i32.rs
@@ -137,6 +137,7 @@ mod sse {
 // -------------------------------------- AVX512 ---------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(feature = "nightly_simd")]
 mod avx512 {
     use super::super::config::AVX512;
     use super::*;
@@ -271,10 +272,13 @@ mod tests {
     use rstest_reuse::{self, *};
     use std::marker::PhantomData;
 
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(feature = "nightly_simd")]
+    use crate::simd::config::AVX512;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    use crate::simd::config::{AVX2, AVX512, SSE};
+    use crate::simd::config::{AVX2, SSE};
     use crate::{Int, SIMDArgMinMax, SCALAR};
 
     use super::super::test_utils::{
@@ -299,7 +303,7 @@ mod tests {
     #[rstest]
     #[case::sse(SSE {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("sse4.1"))]
     #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx2"))]
-    #[case::avx512(AVX512 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx512f"))]
+    #[cfg_attr(feature = "nightly_simd", case::avx512(AVX512 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx512f")))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] simd: T,
         #[case] simd_available: bool,

--- a/src/simd/simd_i32.rs
+++ b/src/simd/simd_i32.rs
@@ -1,5 +1,8 @@
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::config::SIMDInstructionSet;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
@@ -12,8 +15,10 @@ use std::arch::x86::*;
 use std::arch::x86_64::*;
 
 /// The dtype-strategy for performing operations on i32 data: (default) Int
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::super::dtype_strategy::Int;
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 const MAX_INDEX: usize = i32::MAX as usize;
 
 // --------------------------------------- AVX2 ----------------------------------------
@@ -265,8 +270,8 @@ mod neon {
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "arm",
-    target_arch = "aarch64",
+    all(target_arch = "arm", feature = "nightly_simd"),
+    all(target_arch = "aarch64", feature = "nightly_simd"),
 ))]
 #[cfg(test)]
 mod tests {
@@ -278,7 +283,6 @@ mod tests {
     #[cfg(feature = "nightly_simd")]
     use crate::simd::config::AVX512;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    #[cfg(feature = "nightly_simd")]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, SSE};
@@ -316,7 +320,6 @@ mod tests {
     // ------------ Template for ARM / AArch64 ------------
 
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    #[cfg(feature = "nightly_simd")]
     #[template]
     #[rstest]
     #[case::neon(NEON {_dtype_strategy: PhantomData::<Int>}, true)]

--- a/src/simd/simd_i32.rs
+++ b/src/simd/simd_i32.rs
@@ -202,6 +202,7 @@ mod avx512 {
 // --------------------------------------- NEON ----------------------------------------
 
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(feature = "nightly_simd")]
 mod neon {
     use super::super::config::NEON;
     use super::*;
@@ -276,6 +277,7 @@ mod tests {
     #[cfg(feature = "nightly_simd")]
     use crate::simd::config::AVX512;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(feature = "nightly_simd")]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, SSE};
@@ -313,6 +315,7 @@ mod tests {
     // ------------ Template for ARM / AArch64 ------------
 
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(feature = "nightly_simd")]
     #[template]
     #[rstest]
     #[case::neon(NEON {_dtype_strategy: PhantomData::<Int>}, true)]

--- a/src/simd/simd_i32.rs
+++ b/src/simd/simd_i32.rs
@@ -4,6 +4,7 @@ use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 #[cfg(target_arch = "arm")]
+#[cfg(feature = "nightly_simd")]
 use std::arch::arm::*;
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;

--- a/src/simd/simd_i64.rs
+++ b/src/simd/simd_i64.rs
@@ -136,6 +136,7 @@ mod sse {
 // -------------------------------------- AVX512 ---------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(feature = "nightly_simd")]
 mod avx512 {
     use super::super::config::AVX512;
     use super::*;
@@ -224,7 +225,9 @@ mod tests {
     use rstest_reuse::{self, *};
     use std::marker::PhantomData;
 
-    use crate::simd::config::{AVX2, AVX512, SSE};
+    #[cfg(feature = "nightly_simd")]
+    use crate::simd::config::AVX512;
+    use crate::simd::config::{AVX2, SSE};
     use crate::{Int, SIMDArgMinMax, SCALAR};
 
     use super::super::test_utils::{
@@ -248,7 +251,7 @@ mod tests {
     #[rstest]
     #[case::sse(SSE {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("sse4.2"))]
     #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx2"))]
-    #[case::avx512(AVX512 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx512f"))]
+    #[cfg_attr(feature = "nightly_simd", case::avx512(AVX512 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx512f")))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] simd: T,
         #[case] simd_available: bool,

--- a/src/simd/simd_i64.rs
+++ b/src/simd/simd_i64.rs
@@ -202,6 +202,7 @@ mod avx512 {
 //   intrinsics: vadd_, vcgt_, vclt_
 
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(feature = "nightly_simd")]
 mod neon {
     use super::super::config::NEON;
     use super::super::generic::{unimpl_SIMDArgMinMax, unimpl_SIMDInit, unimpl_SIMDOps};

--- a/src/simd/simd_i64.rs
+++ b/src/simd/simd_i64.rs
@@ -2,7 +2,9 @@
 use super::config::SIMDInstructionSet;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int};
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::generic::{SIMDArgMinMax, SIMDInit, SIMDOps};
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use crate::SCALAR;
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;
@@ -10,6 +12,7 @@ use std::arch::x86::*;
 use std::arch::x86_64::*;
 
 /// The dtype-strategy for performing operations on i64 data: (default) Int
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::super::dtype_strategy::Int;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]

--- a/src/simd/simd_i8.rs
+++ b/src/simd/simd_i8.rs
@@ -406,6 +406,7 @@ mod avx512 {
 // --------------------------------------- NEON ----------------------------------------
 
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(feature = "nightly_simd")]
 mod neon {
     use super::super::config::NEON;
     use super::*;
@@ -546,6 +547,7 @@ mod tests {
     #[cfg(feature = "nightly_simd")]
     use crate::simd::config::AVX512;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(feature = "nightly_simd")]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, SSE};
@@ -584,6 +586,7 @@ mod tests {
     // ------------ Template for ARM / AArch64 ------------
 
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(feature = "nightly_simd")]
     #[template]
     #[rstest]
     #[case::neon(NEON {_dtype_strategy: PhantomData::<Int>}, true)]

--- a/src/simd/simd_i8.rs
+++ b/src/simd/simd_i8.rs
@@ -270,6 +270,7 @@ mod sse {
 // -------------------------------------- AVX512 ---------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(feature = "nightly_simd")]
 mod avx512 {
     use super::super::config::AVX512;
     use super::*;
@@ -541,10 +542,13 @@ mod tests {
     use rstest_reuse::{self, *};
     use std::marker::PhantomData;
 
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(feature = "nightly_simd")]
+    use crate::simd::config::AVX512;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    use crate::simd::config::{AVX2, AVX512, SSE};
+    use crate::simd::config::{AVX2, SSE};
     use crate::{Int, SIMDArgMinMax, SCALAR};
 
     use super::super::test_utils::{
@@ -570,7 +574,7 @@ mod tests {
     #[rstest]
     #[case::sse(SSE {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("sse4.1"))]
     #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx2"))]
-    #[case::avx512(AVX512 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx512bw"))]
+    #[cfg_attr(feature = "nightly_simd", case::avx512(AVX512 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx512bw")))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] simd: T,
         #[case] simd_available: bool,

--- a/src/simd/simd_i8.rs
+++ b/src/simd/simd_i8.rs
@@ -1,5 +1,8 @@
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::config::SIMDInstructionSet;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
@@ -12,8 +15,10 @@ use std::arch::x86::*;
 use std::arch::x86_64::*;
 
 /// The dtype-strategy for performing operations on i8 data: (default) Int
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::super::dtype_strategy::Int;
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 const MAX_INDEX: usize = i8::MAX as usize;
 
 // --------------------------------------- AVX2 ----------------------------------------
@@ -535,8 +540,8 @@ mod neon {
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "arm",
-    target_arch = "aarch64",
+    all(target_arch = "arm", feature = "nightly_simd"),
+    all(target_arch = "aarch64", feature = "nightly_simd"),
 ))]
 #[cfg(test)]
 mod tests {
@@ -548,7 +553,6 @@ mod tests {
     #[cfg(feature = "nightly_simd")]
     use crate::simd::config::AVX512;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    #[cfg(feature = "nightly_simd")]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, SSE};
@@ -587,7 +591,6 @@ mod tests {
     // ------------ Template for ARM / AArch64 ------------
 
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    #[cfg(feature = "nightly_simd")]
     #[template]
     #[rstest]
     #[case::neon(NEON {_dtype_strategy: PhantomData::<Int>}, true)]

--- a/src/simd/simd_i8.rs
+++ b/src/simd/simd_i8.rs
@@ -4,6 +4,7 @@ use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 #[cfg(target_arch = "arm")]
+#[cfg(feature = "nightly_simd")]
 use std::arch::arm::*;
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;

--- a/src/simd/simd_u16.rs
+++ b/src/simd/simd_u16.rs
@@ -10,8 +10,11 @@
 /// the ordinal integer values and then transform the result back to the original u16
 /// values.
 ///
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::config::SIMDInstructionSet;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
@@ -24,6 +27,7 @@ use std::arch::x86::*;
 use std::arch::x86_64::*;
 
 /// The dtype-strategy for performing operations on u16 data: (default) Int
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::super::dtype_strategy::Int;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -36,6 +40,7 @@ fn _i16ord_to_u16(ord_i16: i16) -> u16 {
     unsafe { std::mem::transmute::<i16, u16>(ord_i16 ^ XOR_VALUE) }
 }
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 const MAX_INDEX: usize = i16::MAX as usize;
 
 // --------------------------------------- AVX2 ----------------------------------------
@@ -578,8 +583,8 @@ mod neon {
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "arm",
-    target_arch = "aarch64",
+    all(target_arch = "arm", feature = "nightly_simd"),
+    all(target_arch = "aarch64", feature = "nightly_simd"),
 ))]
 #[cfg(test)]
 mod tests {
@@ -591,7 +596,6 @@ mod tests {
     #[cfg(feature = "nightly_simd")]
     use crate::simd::config::AVX512;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    #[cfg(feature = "nightly_simd")]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, SSE};
@@ -630,7 +634,6 @@ mod tests {
     // ------------ Template for ARM / AArch64 ------------
 
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    #[cfg(feature = "nightly_simd")]
     #[template]
     #[rstest]
     #[case::neon(NEON {_dtype_strategy: PhantomData::<Int>}, true)]

--- a/src/simd/simd_u16.rs
+++ b/src/simd/simd_u16.rs
@@ -458,6 +458,7 @@ mod avx512 {
 // --------------------------------------- NEON ----------------------------------------
 
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(feature = "nightly_simd")]
 mod neon {
     use super::super::config::NEON;
     use super::*;
@@ -589,6 +590,7 @@ mod tests {
     #[cfg(feature = "nightly_simd")]
     use crate::simd::config::AVX512;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(feature = "nightly_simd")]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, SSE};
@@ -627,6 +629,7 @@ mod tests {
     // ------------ Template for ARM / AArch64 ------------
 
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(feature = "nightly_simd")]
     #[template]
     #[rstest]
     #[case::neon(NEON {_dtype_strategy: PhantomData::<Int>}, true)]

--- a/src/simd/simd_u16.rs
+++ b/src/simd/simd_u16.rs
@@ -312,6 +312,7 @@ mod sse {
 // -------------------------------------- AVX512 ---------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(feature = "nightly_simd")]
 mod avx512 {
     use super::super::config::AVX512;
     use super::*;
@@ -584,10 +585,13 @@ mod tests {
     use rstest_reuse::{self, *};
     use std::marker::PhantomData;
 
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(feature = "nightly_simd")]
+    use crate::simd::config::AVX512;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    use crate::simd::config::{AVX2, AVX512, SSE};
+    use crate::simd::config::{AVX2, SSE};
     use crate::{Int, SIMDArgMinMax, SCALAR};
 
     use super::super::test_utils::{
@@ -613,7 +617,7 @@ mod tests {
     #[rstest]
     #[case::sse(SSE {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("sse4.1"))]
     #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx2"))]
-    #[case::avx512(AVX512 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx512bw"))]
+    #[cfg_attr(feature = "nightly_simd", case::avx512(AVX512 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx512bw")))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] simd: T,
         #[case] simd_available: bool,

--- a/src/simd/simd_u16.rs
+++ b/src/simd/simd_u16.rs
@@ -16,6 +16,7 @@ use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 #[cfg(target_arch = "arm")]
+#[cfg(feature = "nightly_simd")]
 use std::arch::arm::*;
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;

--- a/src/simd/simd_u32.rs
+++ b/src/simd/simd_u32.rs
@@ -323,6 +323,7 @@ mod avx512 {
 // --------------------------------------- NEON ----------------------------------------
 
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(feature = "nightly_simd")]
 mod neon {
     use super::super::config::NEON;
     use super::*;
@@ -397,6 +398,7 @@ mod tests {
     #[cfg(feature = "nightly_simd")]
     use crate::simd::config::AVX512;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(feature = "nightly_simd")]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, SSE};
@@ -434,6 +436,7 @@ mod tests {
     // ------------ Template for ARM / AArch64 ------------
 
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(feature = "nightly_simd")]
     #[template]
     #[rstest]
     #[case::neon(NEON {_dtype_strategy: PhantomData::<Int>}, true)]

--- a/src/simd/simd_u32.rs
+++ b/src/simd/simd_u32.rs
@@ -226,6 +226,7 @@ mod sse {
 // -------------------------------------- AVX512 ---------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(feature = "nightly_simd")]
 mod avx512 {
     use super::super::config::AVX512;
     use super::*;
@@ -392,10 +393,13 @@ mod tests {
     use rstest_reuse::{self, *};
     use std::marker::PhantomData;
 
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(feature = "nightly_simd")]
+    use crate::simd::config::AVX512;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    use crate::simd::config::{AVX2, AVX512, SSE};
+    use crate::simd::config::{AVX2, SSE};
     use crate::{Int, SIMDArgMinMax, SCALAR};
 
     use super::super::test_utils::{
@@ -420,7 +424,7 @@ mod tests {
     #[rstest]
     #[case::sse(SSE {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("sse4.1"))]
     #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx2"))]
-    #[case::avx512(AVX512 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx512f"))]
+    #[cfg_attr(feature = "nightly_simd", case::avx512(AVX512 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx512f")))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] simd: T,
         #[case] simd_available: bool,

--- a/src/simd/simd_u32.rs
+++ b/src/simd/simd_u32.rs
@@ -10,8 +10,11 @@
 /// the ordinal integer values and then transform the result back to the original u32
 /// values.
 ///
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::config::SIMDInstructionSet;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
@@ -24,6 +27,7 @@ use std::arch::x86::*;
 use std::arch::x86_64::*;
 
 /// The dtype-strategy for performing operations on u32 data: (default) Int
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::super::dtype_strategy::Int;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -39,6 +43,7 @@ fn _i32ord_to_u32(ord_i32: i32) -> u32 {
     unsafe { std::mem::transmute::<i32, u32>(ord_i32 ^ XOR_VALUE) }
 }
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 const MAX_INDEX: usize = i32::MAX as usize;
 
 // --------------------------------------- AVX2 ----------------------------------------
@@ -386,8 +391,8 @@ mod neon {
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "arm",
-    target_arch = "aarch64",
+    all(target_arch = "arm", feature = "nightly_simd"),
+    all(target_arch = "aarch64", feature = "nightly_simd"),
 ))]
 #[cfg(test)]
 mod tests {
@@ -399,7 +404,6 @@ mod tests {
     #[cfg(feature = "nightly_simd")]
     use crate::simd::config::AVX512;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    #[cfg(feature = "nightly_simd")]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, SSE};
@@ -437,7 +441,6 @@ mod tests {
     // ------------ Template for ARM / AArch64 ------------
 
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    #[cfg(feature = "nightly_simd")]
     #[template]
     #[rstest]
     #[case::neon(NEON {_dtype_strategy: PhantomData::<Int>}, true)]

--- a/src/simd/simd_u32.rs
+++ b/src/simd/simd_u32.rs
@@ -16,6 +16,7 @@ use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 #[cfg(target_arch = "arm")]
+#[cfg(feature = "nightly_simd")]
 use std::arch::arm::*;
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;

--- a/src/simd/simd_u64.rs
+++ b/src/simd/simd_u64.rs
@@ -226,6 +226,7 @@ mod sse {
 // -------------------------------------- AVX512 ---------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(feature = "nightly_simd")]
 mod avx512 {
     use super::super::config::AVX512;
     use super::*;
@@ -346,7 +347,9 @@ mod tests {
     use rstest_reuse::{self, *};
     use std::marker::PhantomData;
 
-    use crate::simd::config::{AVX2, AVX512, SSE};
+    #[cfg(feature = "nightly_simd")]
+    use crate::simd::config::AVX512;
+    use crate::simd::config::{AVX2, SSE};
     use crate::{Int, SIMDArgMinMax, SCALAR};
 
     use super::super::test_utils::{
@@ -371,7 +374,7 @@ mod tests {
     #[rstest]
     #[case::sse(SSE {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("sse4.2"))]
     #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx2"))]
-    #[case::avx512(AVX512 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx512f"))]
+    #[cfg_attr(feature = "nightly_simd", case::avx512(AVX512 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx512f")))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] simd: T,
         #[case] simd_available: bool,

--- a/src/simd/simd_u64.rs
+++ b/src/simd/simd_u64.rs
@@ -324,6 +324,7 @@ mod avx512 {
 //   intrinsics: vadd_, vcgt_, vclt_
 
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(feature = "nightly_simd")]
 mod neon {
     use super::super::config::NEON;
     use super::super::generic::{unimpl_SIMDArgMinMax, unimpl_SIMDInit, unimpl_SIMDOps};

--- a/src/simd/simd_u64.rs
+++ b/src/simd/simd_u64.rs
@@ -15,7 +15,9 @@
 use super::config::SIMDInstructionSet;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int};
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::generic::{SIMDArgMinMax, SIMDInit, SIMDOps};
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use crate::SCALAR;
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;
@@ -23,6 +25,7 @@ use std::arch::x86::*;
 use std::arch::x86_64::*;
 
 /// The dtype-strategy for performing operations on u64 data: (default) Int
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::super::dtype_strategy::Int;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]

--- a/src/simd/simd_u8.rs
+++ b/src/simd/simd_u8.rs
@@ -477,6 +477,7 @@ mod avx512 {
 // --------------------------------------- NEON ----------------------------------------
 
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(feature = "nightly_simd")]
 mod neon {
     use super::super::config::NEON;
     use super::*;
@@ -616,6 +617,7 @@ mod tests {
     #[cfg(feature = "nightly_simd")]
     use crate::simd::config::AVX512;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(feature = "nightly_simd")]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, SSE};
@@ -654,6 +656,7 @@ mod tests {
     // ------------ Template for ARM / AArch64 ------------
 
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(feature = "nightly_simd")]
     #[template]
     #[rstest]
     #[case::neon(NEON {_dtype_strategy: PhantomData::<Int>}, true)]

--- a/src/simd/simd_u8.rs
+++ b/src/simd/simd_u8.rs
@@ -10,8 +10,11 @@
 /// the ordinal integer values and then transform the result back to the original u8
 /// values.
 ///
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::config::SIMDInstructionSet;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
@@ -24,6 +27,7 @@ use std::arch::x86::*;
 use std::arch::x86_64::*;
 
 /// The dtype-strategy for performing operations on u8 data: (default) Int
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::super::dtype_strategy::Int;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -36,6 +40,7 @@ fn _i8ord_to_u8(ord_i8: i8) -> u8 {
     unsafe { std::mem::transmute::<i8, u8>(ord_i8 ^ XOR_VALUE) }
 }
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 const MAX_INDEX: usize = i8::MAX as usize;
 
 // --------------------------------------- AVX2 ----------------------------------------
@@ -605,8 +610,8 @@ mod neon {
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "arm",
-    target_arch = "aarch64",
+    all(target_arch = "arm", feature = "nightly_simd"),
+    all(target_arch = "aarch64", feature = "nightly_simd"),
 ))]
 #[cfg(test)]
 mod tests {
@@ -618,7 +623,6 @@ mod tests {
     #[cfg(feature = "nightly_simd")]
     use crate::simd::config::AVX512;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    #[cfg(feature = "nightly_simd")]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, SSE};
@@ -657,7 +661,6 @@ mod tests {
     // ------------ Template for ARM / AArch64 ------------
 
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    #[cfg(feature = "nightly_simd")]
     #[template]
     #[rstest]
     #[case::neon(NEON {_dtype_strategy: PhantomData::<Int>}, true)]

--- a/src/simd/simd_u8.rs
+++ b/src/simd/simd_u8.rs
@@ -325,6 +325,7 @@ mod sse {
 // -------------------------------------- AVX512 ---------------------------------------
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(feature = "nightly_simd")]
 mod avx512 {
     use super::super::config::AVX512;
     use super::*;
@@ -611,10 +612,13 @@ mod tests {
     use rstest_reuse::{self, *};
     use std::marker::PhantomData;
 
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(feature = "nightly_simd")]
+    use crate::simd::config::AVX512;
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    use crate::simd::config::{AVX2, AVX512, SSE};
+    use crate::simd::config::{AVX2, SSE};
     use crate::{Int, SIMDArgMinMax, SCALAR};
 
     use super::super::test_utils::{
@@ -640,7 +644,7 @@ mod tests {
     #[rstest]
     #[case::sse(SSE {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("sse4.1"))]
     #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx2"))]
-    #[case::avx512(AVX512 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx512bw"))]
+    #[cfg_attr(feature = "nightly_simd", case::avx512(AVX512 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx512bw")))]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] simd: T,
         #[case] simd_available: bool,

--- a/src/simd/simd_u8.rs
+++ b/src/simd/simd_u8.rs
@@ -16,6 +16,7 @@ use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 #[cfg(target_arch = "arm")]
+#[cfg(feature = "nightly_simd")]
 use std::arch::arm::*;
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;


### PR DESCRIPTION
- for `x86` / `x86_64`: this results in not allowing AVX512
- for `arm` / `aarch64`: currently no NEON features will be supported