### PR TITLE
feat: add 64-bit aarch64 SIMD implementation

### DIFF
--- a/benches/bench_f64_ignore_nan.rs
+++ b/benches/bench_f64_ignore_nan.rs
@@ -8,6 +8,8 @@ use argminmax::dtype_strategy::FloatIgnoreNaN;
 use argminmax::scalar::{ScalarArgMinMax, SCALAR};
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use argminmax::simd::{SIMDArgMinMax, AVX2, AVX512, SSE};
+#[cfg(target_arch = "aarch64")]
+use argminmax::simd::{SIMDArgMinMax, NEON};
 
 // _in stands for "ignore nan"
 
@@ -75,6 +77,24 @@ fn argminmax_in_f64_random_array_long(c: &mut Criterion) {
     if is_x86_feature_detected!("avx512f") {
         c.bench_function("avx512_f64_argmax_in", |b| {
             b.iter(|| unsafe { AVX512::<FloatIgnoreNaN>::argmax(black_box(data)) })
+        });
+    }
+    #[cfg(target_arch = "aarch64")]
+    if std::arch::is_aarch64_feature_detected!("neon") {
+        c.bench_function("neon_f64_argminmax_in", |b| {
+            b.iter(|| unsafe { NEON::<FloatIgnoreNaN>::argminmax(black_box(data)) })
+        });
+    }
+    #[cfg(target_arch = "aarch64")]
+    if std::arch::is_aarch64_feature_detected!("neon") {
+        c.bench_function("neon_f64_argmin_in", |b| {
+            b.iter(|| unsafe { NEON::<FloatIgnoreNaN>::argmin(black_box(data)) })
+        });
+    }
+    #[cfg(target_arch = "aarch64")]
+    if std::arch::is_aarch64_feature_detected!("neon") {
+        c.bench_function("neon_f64_argmax_in", |b| {
+            b.iter(|| unsafe { NEON::<FloatIgnoreNaN>::argmax(black_box(data)) })
         });
     }
     c.bench_function("impl_f64_argminmax_in", |b| {

--- a/benches/bench_f64_return_nan.rs
+++ b/benches/bench_f64_return_nan.rs
@@ -8,6 +8,8 @@ use argminmax::dtype_strategy::FloatReturnNaN;
 use argminmax::scalar::{ScalarArgMinMax, SCALAR};
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use argminmax::simd::{SIMDArgMinMax, AVX2, AVX512, SSE};
+#[cfg(target_arch = "aarch64")]
+use argminmax::simd::{SIMDArgMinMax, NEON};
 
 // _rn stands for "return nan"
 
@@ -75,6 +77,24 @@ fn argminmax_rn_f64_random_array_long(c: &mut Criterion) {
     if is_x86_feature_detected!("avx512f") {
         c.bench_function("avx512_f64_argmax_rn", |b| {
             b.iter(|| unsafe { AVX512::<FloatReturnNaN>::argmax(black_box(data)) })
+        });
+    }
+    #[cfg(target_arch = "aarch64")]
+    if std::arch::is_aarch64_feature_detected!("neon") {
+        c.bench_function("neon_f64_argminmax_rn", |b| {
+            b.iter(|| unsafe { NEON::<FloatReturnNaN>::argminmax(black_box(data)) })
+        });
+    }
+    #[cfg(target_arch = "aarch64")]
+    if std::arch::is_aarch64_feature_detected!("neon") {
+        c.bench_function("neon_f64_argmin_rn", |b| {
+            b.iter(|| unsafe { NEON::<FloatReturnNaN>::argmin(black_box(data)) })
+        });
+    }
+    #[cfg(target_arch = "aarch64")]
+    if std::arch::is_aarch64_feature_detected!("neon") {
+        c.bench_function("neon_f64_argmax_rn", |b| {
+            b.iter(|| unsafe { NEON::<FloatReturnNaN>::argmax(black_box(data)) })
         });
     }
     c.bench_function("impl_f64_argminmax_rn", |b| {

--- a/benches/bench_i64.rs
+++ b/benches/bench_i64.rs
@@ -7,6 +7,8 @@ use dev_utils::{config, utils};
 use argminmax::scalar::{ScalarArgMinMax, SCALAR};
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use argminmax::simd::{SIMDArgMinMax, AVX2, AVX512, SSE};
+#[cfg(target_arch = "aarch64")]
+use argminmax::simd::{SIMDArgMinMax, NEON};
 
 fn argminmax_i64_random_array_long(c: &mut Criterion) {
     let n = config::ARRAY_LENGTH_LONG;
@@ -72,6 +74,24 @@ fn argminmax_i64_random_array_long(c: &mut Criterion) {
     if is_x86_feature_detected!("avx512f") {
         c.bench_function("avx512_i64_argmax", |b| {
             b.iter(|| unsafe { AVX512::argmax(black_box(data)) })
+        });
+    }
+    #[cfg(target_arch = "aarch64")]
+    if std::arch::is_aarch64_feature_detected!("neon") {
+        c.bench_function("neon_i64_argminmax", |b| {
+            b.iter(|| unsafe { NEON::argminmax(black_box(data)) })
+        });
+    }
+    #[cfg(target_arch = "aarch64")]
+    if std::arch::is_aarch64_feature_detected!("neon") {
+        c.bench_function("neon_i64_argmin", |b| {
+            b.iter(|| unsafe { NEON::argmin(black_box(data)) })
+        });
+    }
+    #[cfg(target_arch = "aarch64")]
+    if std::arch::is_aarch64_feature_detected!("neon") {
+        c.bench_function("neon_i64_argmax", |b| {
+            b.iter(|| unsafe { NEON::argmax(black_box(data)) })
         });
     }
     c.bench_function("impl_i64_argminmax", |b| {

--- a/benches/bench_u64.rs
+++ b/benches/bench_u64.rs
@@ -7,6 +7,8 @@ use dev_utils::{config, utils};
 use argminmax::scalar::{ScalarArgMinMax, SCALAR};
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use argminmax::simd::{SIMDArgMinMax, AVX2, AVX512, SSE};
+#[cfg(target_arch = "aarch64")]
+use argminmax::simd::{SIMDArgMinMax, NEON};
 
 fn argminmax_u64_random_array_long(c: &mut Criterion) {
     let n = config::ARRAY_LENGTH_LONG;
@@ -72,6 +74,24 @@ fn argminmax_u64_random_array_long(c: &mut Criterion) {
     if is_x86_feature_detected!("avx512f") {
         c.bench_function("avx512_u64_argmax", |b| {
             b.iter(|| unsafe { AVX512::argmax(black_box(data)) })
+        });
+    }
+    #[cfg(target_arch = "aarch64")]
+    if std::arch::is_aarch64_feature_detected!("neon") {
+        c.bench_function("neon_u64_argminmax", |b| {
+            b.iter(|| unsafe { NEON::argminmax(black_box(data)) })
+        });
+    }
+    #[cfg(target_arch = "aarch64")]
+    if std::arch::is_aarch64_feature_detected!("neon") {
+        c.bench_function("neon_u64_argmin", |b| {
+            b.iter(|| unsafe { NEON::argmin(black_box(data)) })
+        });
+    }
+    #[cfg(target_arch = "aarch64")]
+    if std::arch::is_aarch64_feature_detected!("neon") {
+        c.bench_function("neon_u64_argmax", |b| {
+            b.iter(|| unsafe { NEON::argmax(black_box(data)) })
         });
     }
     c.bench_function("impl_u64_argminmax", |b| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -659,7 +659,7 @@ impl NaNArgMinMax for &[f64] {
         {
             if std::arch::is_aarch64_feature_detected!("neon") {
                 // We miss some NEON instructions for 64-bit numbers
-                return unsafe { NEON::<FloatReturnNaN>::argminmax(self) }
+                return unsafe { NEON::<FloatReturnNaN>::argminmax(self) };
             }
         }
         SCALAR::<FloatReturnNaN>::argminmax(self)
@@ -669,16 +669,17 @@ impl NaNArgMinMax for &[f64] {
         {
             if std::arch::is_aarch64_feature_detected!("neon") {
                 // We miss some NEON instructions for 64-bit numbers
-                return unsafe { NEON::<FloatReturnNaN>::argminmax(self) }
+                return unsafe { NEON::<FloatReturnNaN>::argminmax(self) };
             }
         }
-        SCALAR::<FloatReturnNaN>::argmin(self)    }
+        SCALAR::<FloatReturnNaN>::argmin(self)
+    }
     fn nanargmax(&self) -> usize {
         #[cfg(feature = "nightly_simd")]
         {
             if std::arch::is_aarch64_feature_detected!("neon") {
                 // We miss some NEON instructions for 64-bit numbers
-                return unsafe { NEON::<FloatReturnNaN>::argminmax(self) }
+                return unsafe { NEON::<FloatReturnNaN>::argminmax(self) };
             }
         }
         SCALAR::<FloatReturnNaN>::argmax(self)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,10 +95,8 @@ pub(crate) use simd::AVX512;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub(crate) use simd::{SIMDArgMinMax, AVX2, SSE};
 #[cfg(any(
-    target_arch = "x86",
-    target_arch = "x86_64",
     all(target_arch = "aarch64", feature = "float"), // is stable for f64
-    feature = "nightly_simd"
+    all(any(target_arch = "arm", target_arch = "aarch64"), feature = "nightly_simd"),
 ))]
 pub(crate) use simd::{SIMDArgMinMax, NEON};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,9 +94,12 @@ pub(crate) use scalar::{ScalarArgMinMax, SCALAR};
 pub(crate) use simd::AVX512;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub(crate) use simd::{SIMDArgMinMax, AVX2, SSE};
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-#[cfg(feature = "nightly_simd")]
-// TODO: can be adapted when 64-bit aarch64 implementation is added
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    all(target_arch = "aarch64", feature = "float"), // is stable for f64
+    feature = "nightly_simd"
+))]
 pub(crate) use simd::{SIMDArgMinMax, NEON};
 
 #[cfg(feature = "half")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -652,16 +652,36 @@ impl ArgMinMax for &[f64] {
     }
 }
 
-#[cfg(all(feature = "float", feature = "nightly_simd", target_arch = "aarch64"))]
+#[cfg(all(feature = "float", target_arch = "aarch64"))]
 impl NaNArgMinMax for &[f64] {
     fn nanargminmax(&self) -> (usize, usize) {
-        unsafe { NEON::<FloatReturnNaN>::argminmax(self) }
+        #[cfg(feature = "nightly_simd")]
+        {
+            if std::arch::is_aarch64_feature_detected!("neon") {
+                // We miss some NEON instructions for 64-bit numbers
+                return unsafe { NEON::<FloatReturnNaN>::argminmax(self) }
+            }
+        }
+        SCALAR::<FloatReturnNaN>::argminmax(self)
     }
     fn nanargmin(&self) -> usize {
-        unsafe { NEON::<FloatReturnNaN>::argmin(self) }
-    }
+        #[cfg(feature = "nightly_simd")]
+        {
+            if std::arch::is_aarch64_feature_detected!("neon") {
+                // We miss some NEON instructions for 64-bit numbers
+                return unsafe { NEON::<FloatReturnNaN>::argminmax(self) }
+            }
+        }
+        SCALAR::<FloatReturnNaN>::argmin(self)    }
     fn nanargmax(&self) -> usize {
-        unsafe { NEON::<FloatReturnNaN>::argmax(self) }
+        #[cfg(feature = "nightly_simd")]
+        {
+            if std::arch::is_aarch64_feature_detected!("neon") {
+                // We miss some NEON instructions for 64-bit numbers
+                return unsafe { NEON::<FloatReturnNaN>::argminmax(self) }
+            }
+        }
+        SCALAR::<FloatReturnNaN>::argmax(self)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -669,7 +669,7 @@ impl NaNArgMinMax for &[f64] {
         {
             if std::arch::is_aarch64_feature_detected!("neon") {
                 // We miss some NEON instructions for 64-bit numbers
-                return unsafe { NEON::<FloatReturnNaN>::argminmax(self) };
+                return unsafe { NEON::<FloatReturnNaN>::argmin(self) };
             }
         }
         SCALAR::<FloatReturnNaN>::argmin(self)
@@ -679,7 +679,7 @@ impl NaNArgMinMax for &[f64] {
         {
             if std::arch::is_aarch64_feature_detected!("neon") {
                 // We miss some NEON instructions for 64-bit numbers
-                return unsafe { NEON::<FloatReturnNaN>::argminmax(self) };
+                return unsafe { NEON::<FloatReturnNaN>::argmax(self) };
             }
         }
         SCALAR::<FloatReturnNaN>::argmax(self)

--- a/src/simd/generic.rs
+++ b/src/simd/generic.rs
@@ -227,7 +227,12 @@ pub(crate) use impl_SIMDInit_FloatReturnNaN; // Now classic paths Just Work™
 // --------------- Float Ignore NaNs
 
 #[cfg(any(feature = "float", feature = "half"))]
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    all(target_arch = "aarch64", feature= "float"), // is stable for f64
+    feature = "nightly_simd"
+))]
 macro_rules! impl_SIMDInit_FloatIgnoreNaN {
     ($($scalar_dtype:ty, $simd_vec_dtype:ty, $simd_mask_dtype:ty, $lane_size:expr, $simd_struct:ty),*) => {
         $(
@@ -281,7 +286,12 @@ macro_rules! impl_SIMDInit_FloatIgnoreNaN {
 }
 
 #[cfg(any(feature = "float", feature = "half"))]
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    all(target_arch = "aarch64", feature= "float"), // is stable for f64
+    feature = "nightly_simd"
+))]
 pub(crate) use impl_SIMDInit_FloatIgnoreNaN; // Now classic paths Just Work™
 
 // ---------------------------------- SIMD algorithm -----------------------------------
@@ -738,7 +748,12 @@ where
     }
 }
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    all(target_arch = "aarch64", feature = "float"),
+    feature = "nightly_simd"
+))]
 macro_rules! impl_SIMDArgMinMax {
     ($($scalar_dtype:ty, $simd_vec_dtype:ty, $simd_mask_dtype:ty, $lane_size:expr, $scalar_struct:ty, $simd_struct:ty, $target:expr),*) => {
         $(
@@ -765,13 +780,17 @@ macro_rules! impl_SIMDArgMinMax {
     }
 }
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    all(target_arch = "aarch64", feature = "float"),
+    feature = "nightly_simd"
+))]
 pub(crate) use impl_SIMDArgMinMax; // Now classic paths Just Work™
 
 // --------------------------------- Unimplement Macros --------------------------------
 
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-#[cfg(feature = "nightly_simd")]
+#[cfg(all(target_arch = "arm", feature = "nightly_simd"))]
 macro_rules! unimpl_SIMDOps {
     ($scalar_type:ty, $reg:ty, $simd_struct:ty) => {
         impl SIMDOps<$scalar_type, $reg, $reg, 0> for $simd_struct {
@@ -806,8 +825,7 @@ macro_rules! unimpl_SIMDOps {
     };
 }
 
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-#[cfg(feature = "nightly_simd")]
+#[cfg(all(target_arch = "arm", feature = "nightly_simd"))]
 macro_rules! unimpl_SIMDInit {
     ($scalar_type:ty, $reg:ty, $simd_struct:ty) => {
         impl SIMDInit<$scalar_type, $reg, $reg, 0> for $simd_struct {
@@ -816,8 +834,7 @@ macro_rules! unimpl_SIMDInit {
     };
 }
 
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-#[cfg(feature = "nightly_simd")]
+#[cfg(all(target_arch = "arm", feature = "nightly_simd"))]
 macro_rules! unimpl_SIMDArgMinMax {
     ($scalar_type:ty, $reg:ty, $scalar:ty, $simd_struct:ty) => {
         impl SIMDArgMinMax<$scalar_type, $reg, $reg, 0, $scalar> for $simd_struct {
@@ -836,14 +853,11 @@ macro_rules! unimpl_SIMDArgMinMax {
     };
 }
 
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-#[cfg(feature = "nightly_simd")]
+#[cfg(all(target_arch = "arm", feature = "nightly_simd"))]
 pub(crate) use unimpl_SIMDArgMinMax; // Now classic paths Just Work™
 
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-#[cfg(feature = "nightly_simd")]
+#[cfg(all(target_arch = "arm", feature = "nightly_simd"))]
 pub(crate) use unimpl_SIMDInit; // Now classic paths Just Work™
 
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-#[cfg(feature = "nightly_simd")]
+#[cfg(all(target_arch = "arm", feature = "nightly_simd"))]
 pub(crate) use unimpl_SIMDOps; // Now classic paths Just Work™

--- a/src/simd/generic.rs
+++ b/src/simd/generic.rs
@@ -230,7 +230,7 @@ pub(crate) use impl_SIMDInit_FloatReturnNaN; // Now classic paths Just Work™
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    all(target_arch = "aarch64", feature= "float"), // is stable for f64
+    all(target_arch = "aarch64", feature = "float"), // is stable for f64
     feature = "nightly_simd"
 ))]
 macro_rules! impl_SIMDInit_FloatIgnoreNaN {
@@ -289,7 +289,7 @@ macro_rules! impl_SIMDInit_FloatIgnoreNaN {
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    all(target_arch = "aarch64", feature= "float"), // is stable for f64
+    all(target_arch = "aarch64", feature = "float"), // is stable for f64
     feature = "nightly_simd"
 ))]
 pub(crate) use impl_SIMDInit_FloatIgnoreNaN; // Now classic paths Just Work™
@@ -751,7 +751,7 @@ where
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    all(target_arch = "aarch64", feature = "float"),
+    all(target_arch = "aarch64", feature = "float"), // is stable for f64
     feature = "nightly_simd"
 ))]
 macro_rules! impl_SIMDArgMinMax {
@@ -783,7 +783,7 @@ macro_rules! impl_SIMDArgMinMax {
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    all(target_arch = "aarch64", feature = "float"),
+    all(target_arch = "aarch64", feature = "float"), // is stable for f64
     feature = "nightly_simd"
 ))]
 pub(crate) use impl_SIMDArgMinMax; // Now classic paths Just Work™

--- a/src/simd/mod.rs
+++ b/src/simd/mod.rs
@@ -36,5 +36,10 @@ mod simd_u8;
 
 // Test utils
 #[cfg(test)]
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    all(target_arch = "aarch64", feature = "float"), // is stable for f64
+    feature = "nightly_simd"
+))]
 mod test_utils;

--- a/src/simd/simd_f16_ignore_nan.rs
+++ b/src/simd/simd_f16_ignore_nan.rs
@@ -35,10 +35,9 @@ use super::generic::{
 use crate::SCALAR;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use num_traits::Zero;
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
 use std::arch::aarch64::*;
-#[cfg(target_arch = "arm")]
-#[cfg(feature = "nightly_simd")]
+#[cfg(all(target_arch = "arm", feature = "nightly_simd"))]
 use std::arch::arm::*;
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;

--- a/src/simd/simd_f16_return_nan.rs
+++ b/src/simd/simd_f16_return_nan.rs
@@ -33,11 +33,9 @@ use super::config::SIMDInstructionSet;
 use super::generic::{impl_SIMDInit_FloatReturnNaN, SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use crate::SCALAR;
-
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
 use std::arch::aarch64::*;
-#[cfg(target_arch = "arm")]
-#[cfg(feature = "nightly_simd")]
+#[cfg(all(target_arch = "arm", feature = "nightly_simd"))]
 use std::arch::arm::*;
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;

--- a/src/simd/simd_f32_ignore_nan.rs
+++ b/src/simd/simd_f32_ignore_nan.rs
@@ -21,10 +21,9 @@ use super::generic::{
 use crate::SCALAR;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use num_traits::Zero;
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
 use std::arch::aarch64::*;
-#[cfg(target_arch = "arm")]
-#[cfg(feature = "nightly_simd")]
+#[cfg(all(target_arch = "arm", feature = "nightly_simd"))]
 use std::arch::arm::*;
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;

--- a/src/simd/simd_f32_return_nan.rs
+++ b/src/simd/simd_f32_return_nan.rs
@@ -34,10 +34,9 @@ use super::config::SIMDInstructionSet;
 use super::generic::{impl_SIMDInit_FloatReturnNaN, SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use crate::SCALAR;
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
 use std::arch::aarch64::*;
-#[cfg(target_arch = "arm")]
-#[cfg(feature = "nightly_simd")]
+#[cfg(all(target_arch = "arm", feature = "nightly_simd"))]
 use std::arch::arm::*;
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;

--- a/src/simd/simd_f64_ignore_nan.rs
+++ b/src/simd/simd_f64_ignore_nan.rs
@@ -12,16 +12,28 @@
 /// are added to the accumulating SIMD register.
 ///
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64",))]
 use super::config::SIMDInstructionSet;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64",))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_FloatIgnoreNaN};
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use super::generic::{SIMDArgMinMax, SIMDInit, SIMDOps};
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use crate::SCALAR;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use num_traits::Zero;
+#[cfg(target_arch = "aarch64")]
+use std::arch::aarch64::*;
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
@@ -244,12 +256,10 @@ mod avx512_ignore_nan {
 
 // --------------------------------------- NEON ----------------------------------------
 
-// There are no NEON intrinsics for f64, so we need to use the scalar version.
-//   although NEON intrinsics exist for i64 and u64, we cannot use them as
-//   they there is no 64-bit variant (of any data type) for the following three
-//   intrinsics: vadd_, vcgt_, vclt_
+// There are no NEON intrinsics for f64 on arm.
+// But fore aarch64 we can use the neon intrinsics (on stable!!)
 
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(target_arch = "arm")]
 #[cfg(feature = "nightly_simd")]
 mod neon_ignore_nan {
     use super::super::config::NEON;
@@ -265,17 +275,91 @@ mod neon_ignore_nan {
     unimpl_SIMDArgMinMax!(f64, usize, SCALAR<FloatIgnoreNaN>, NEON<FloatIgnoreNaN>);
 }
 
+#[cfg(target_arch = "aarch64")]
+mod neon_ignore_nan {
+    use super::super::config::NEON;
+    use super::*;
+
+    const LANE_SIZE: usize = NEON::<FloatIgnoreNaN>::LANE_SIZE_64;
+
+    impl SIMDOps<f64, float64x2_t, uint64x2_t, LANE_SIZE> for NEON<FloatIgnoreNaN> {
+        const INITIAL_INDEX: float64x2_t = unsafe { std::mem::transmute([0.0f64, 1.0f64]) };
+        const INDEX_INCREMENT: float64x2_t =
+            unsafe { std::mem::transmute([LANE_SIZE as f64; LANE_SIZE]) };
+        const MAX_INDEX: usize = MAX_INDEX;
+
+        #[inline(always)]
+        unsafe fn _reg_to_arr(reg: float64x2_t) -> [f64; LANE_SIZE] {
+            std::mem::transmute::<float64x2_t, [f64; LANE_SIZE]>(reg)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_loadu(data: *const f64) -> float64x2_t {
+            vld1q_f64(data as *const f64)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_add(a: float64x2_t, b: float64x2_t) -> float64x2_t {
+            vaddq_f64(a, b)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_cmpgt(a: float64x2_t, b: float64x2_t) -> uint64x2_t {
+            vcgtq_f64(a, b)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_cmplt(a: float64x2_t, b: float64x2_t) -> uint64x2_t {
+            vcltq_f64(a, b)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_blendv(a: float64x2_t, b: float64x2_t, mask: uint64x2_t) -> float64x2_t {
+            vbslq_f64(mask, b, a)
+        }
+
+        // --- Necessary for impl_SIMDInit_FloatIgnoreNaN
+
+        #[inline(always)]
+        unsafe fn _mm_set1(val: f64) -> float64x2_t {
+            vdupq_n_f64(val)
+        }
+    }
+
+    impl_SIMDInit_FloatIgnoreNaN!(
+        f64,
+        float64x2_t,
+        uint64x2_t,
+        LANE_SIZE,
+        NEON<FloatIgnoreNaN>
+    );
+
+    impl_SIMDArgMinMax!(
+        f64,
+        float64x2_t,
+        uint64x2_t,
+        LANE_SIZE,
+        SCALAR<FloatIgnoreNaN>,
+        NEON<FloatIgnoreNaN>,
+        "neon"
+    );
+}
+
 // ======================================= TESTS =======================================
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
     use rstest_reuse::{self, *};
     use std::marker::PhantomData;
 
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[cfg(feature = "nightly_simd")]
     use crate::simd::config::AVX512;
+    #[cfg(target_arch = "aarch64")]
+    use crate::simd::config::NEON;
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, SSE};
     use crate::{FloatIgnoreNaN, SIMDArgMinMax, SCALAR};
 
@@ -298,11 +382,24 @@ mod tests {
 
     // ------------ Template for x86 / x86_64 -------------
 
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[template]
     #[rstest]
     #[case::sse(SSE {_dtype_strategy: PhantomData::<FloatIgnoreNaN>}, is_x86_feature_detected!("sse4.1"))]
     #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<FloatIgnoreNaN>}, is_x86_feature_detected!("avx"))]
     #[cfg_attr(feature = "nightly_simd", case::avx512(AVX512 {_dtype_strategy: PhantomData::<FloatIgnoreNaN>}, is_x86_feature_detected!("avx512f")))]
+    fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] simd: T,
+        #[case] simd_available: bool,
+    ) {
+    }
+
+    // --------------- Template for AArch64 ---------------
+
+    #[cfg(target_arch = "aarch64")]
+    #[template]
+    #[rstest]
+    #[case::neon(NEON {_dtype_strategy: PhantomData::<Int>}, true)]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] simd: T,
         #[case] simd_available: bool,

--- a/src/simd/simd_f64_ignore_nan.rs
+++ b/src/simd/simd_f64_ignore_nan.rs
@@ -14,7 +14,7 @@
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64",))]
 use super::config::SIMDInstructionSet;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64",))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_FloatIgnoreNaN};
 #[cfg(any(
     target_arch = "x86",
@@ -30,7 +30,7 @@ use super::generic::{SIMDArgMinMax, SIMDInit, SIMDOps};
     feature = "nightly_simd"
 ))]
 use crate::SCALAR;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64",))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
 use num_traits::Zero;
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
@@ -49,7 +49,7 @@ use std::arch::x86_64::*;
 use super::super::dtype_strategy::FloatIgnoreNaN;
 
 // https://stackoverflow.com/a/3793950
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 const MAX_INDEX: usize = 1 << f64::MANTISSA_DIGITS;
 #[cfg(target_arch = "x86")] // https://stackoverflow.com/a/29592369
 const MAX_INDEX: usize = u32::MAX as usize;

--- a/src/simd/simd_f64_ignore_nan.rs
+++ b/src/simd/simd_f64_ignore_nan.rs
@@ -404,7 +404,7 @@ mod tests {
     #[cfg(target_arch = "aarch64")]
     #[template]
     #[rstest]
-    #[case::neon(NEON {_dtype_strategy: PhantomData::<Int>}, true)]
+    #[case::neon(NEON {_dtype_strategy: PhantomData::<FloatIgnoreNaN>}, true)]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] simd: T,
         #[case] simd_available: bool,

--- a/src/simd/simd_f64_ignore_nan.rs
+++ b/src/simd/simd_f64_ignore_nan.rs
@@ -30,7 +30,7 @@ use super::generic::{SIMDArgMinMax, SIMDInit, SIMDOps};
     feature = "nightly_simd"
 ))]
 use crate::SCALAR;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64",))]
 use num_traits::Zero;
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
@@ -40,7 +40,12 @@ use std::arch::x86::*;
 use std::arch::x86_64::*;
 
 /// The dtype-strategy for performing operations on f64 data: ignore NaN values
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use super::super::dtype_strategy::FloatIgnoreNaN;
 
 // https://stackoverflow.com/a/3793950
@@ -257,7 +262,7 @@ mod avx512_ignore_nan {
 // --------------------------------------- NEON ----------------------------------------
 
 // There are no NEON intrinsics for f64 on arm.
-// But fore aarch64 we can use the neon intrinsics (on stable!!)
+// But fore aarch64 we can use the NEON intrinsics (on stable!!)
 
 #[cfg(target_arch = "arm")]
 #[cfg(feature = "nightly_simd")]

--- a/src/simd/simd_f64_ignore_nan.rs
+++ b/src/simd/simd_f64_ignore_nan.rs
@@ -261,7 +261,7 @@ mod avx512_ignore_nan {
 
 // --------------------------------------- NEON ----------------------------------------
 
-// There are no NEON intrinsics for f64 on arm.
+// There are no NEON SIMD intrinsics for f64 on arm.
 // But fore aarch64 we can use the NEON intrinsics (on stable!!)
 
 #[cfg(target_arch = "arm")]

--- a/src/simd/simd_f64_return_nan.rs
+++ b/src/simd/simd_f64_return_nan.rs
@@ -45,6 +45,8 @@ use super::generic::impl_SIMDInit_FloatReturnNaN;
 use super::generic::{SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use crate::SCALAR;
+#[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
+use std::arch::aarch64::*;
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;
 #[cfg(target_arch = "x86_64")]

--- a/src/simd/simd_f64_return_nan.rs
+++ b/src/simd/simd_f64_return_nan.rs
@@ -403,7 +403,7 @@ mod avx512 {
 
 // --------------------------------------- NEON ----------------------------------------
 
-// There are SIMD intrinsics i64 (used after ord_transform), but
+// There are NEON SIMD intrinsics for i64 (used after ord_transform), but
 //  - for arm we miss the vcgt_ and vclt_ intrinsics.
 //  - for aarch64 the required intrinsics are present (on nightly)
 
@@ -537,7 +537,7 @@ mod tests {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[cfg(feature = "nightly_simd")]
     use crate::simd::config::AVX512;
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     use crate::simd::config::NEON;
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, SSE};
@@ -574,9 +574,9 @@ mod tests {
     ) {
     }
 
-    // ------------ Template for ARM / AArch64 ------------
+    // --------------- Template for AArch64 ---------------
 
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     #[template]
     #[rstest]
     #[case::neon(NEON { _dtype_strategy: PhantomData::<FloatReturnNaN>}, true)]

--- a/src/simd/simd_f64_return_nan.rs
+++ b/src/simd/simd_f64_return_nan.rs
@@ -434,10 +434,10 @@ mod neon {
 
     #[inline(always)]
     unsafe fn _f64_as_int64x2_to_i64ord(f64_as_int64x2: int64x2_t) -> int64x2_t {
-        // on a scalar: ((v >> 31) & 0x7FFFFFFF) ^ v
-        let sign_bit_shifted = vshrq_n_s32(f64_as_int64x2, BIT_SHIFT);
-        let sign_bit_masked = vandq_s32(sign_bit_shifted, LOWER_31_MASK);
-        veorq_s32(sign_bit_masked, f64_as_int64x2)
+        // on a scalar: ((v >> 63) & 0x7FFFFFFFFFFFFFFF) ^ v
+        let sign_bit_shifted = vshrq_n_s64(f64_as_int64x2, BIT_SHIFT);
+        let sign_bit_masked = vandq_s64(sign_bit_shifted, LOWER_31_MASK);
+        veorq_s64(sign_bit_masked, f64_as_int64x2)
     }
 
     #[inline(always)]

--- a/src/simd/simd_f64_return_nan.rs
+++ b/src/simd/simd_f64_return_nan.rs
@@ -29,9 +29,17 @@
 /// necessarily the index of the first NaN value.
 ///
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    all(target_arch = "aarch64", feature = "nightly_simd")
+))]
 use super::config::SIMDInstructionSet;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    all(target_arch = "aarch64", feature = "nightly_simd")
+))]
 use super::generic::impl_SIMDInit_FloatReturnNaN;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::generic::{SIMDArgMinMax, SIMDInit, SIMDOps};
@@ -46,22 +54,42 @@ use std::arch::x86_64::*;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::super::dtype_strategy::FloatReturnNaN;
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    all(target_arch = "aarch64", feature = "nightly_simd")
+))]
 use super::task::{max_index_value, min_index_value};
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    all(target_arch = "aarch64", feature = "nightly_simd")
+))]
 const BIT_SHIFT: i32 = 63;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    all(target_arch = "aarch64", feature = "nightly_simd")
+))]
 const MASK_VALUE: i64 = 0x7FFFFFFFFFFFFFFF; // i64::MAX - masks everything but the sign bit
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    all(target_arch = "aarch64", feature = "nightly_simd")
+))]
 #[inline(always)]
 fn _i64ord_to_f64(ord_i64: i64) -> f64 {
     let v = ((ord_i64 >> BIT_SHIFT) & MASK_VALUE) ^ ord_i64;
     f64::from_bits(v as u64)
 }
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    all(target_arch = "aarch64", feature = "nightly_simd")
+))]
 const MAX_INDEX: usize = i64::MAX as usize;
 
 // --------------------------------------- AVX2 ----------------------------------------
@@ -373,12 +401,11 @@ mod avx512 {
 
 // --------------------------------------- NEON ----------------------------------------
 
-// There are no NEON intrinsics for f64, so we need to use the scalar version.
-//   although NEON intrinsics exist for i64 and u64, we cannot use them as
-//   they there is no 64-bit variant (of any data type) for the following three
-//   intrinsics: vadd_, vcgt_, vclt_
+// There are SIMD intrinsics i64 (used after ord_transform), but
+//  - for arm we miss the vcgt_ and vclt_ intrinsics.
+//  - for aarch64 the required intrinsics are present (on nightly)
 
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(target_arch = "arm")]
 #[cfg(feature = "nightly_simd")]
 mod neon {
     use super::super::config::NEON;
@@ -394,17 +421,123 @@ mod neon {
     unimpl_SIMDArgMinMax!(f64, usize, SCALAR<FloatReturnNaN>, NEON<FloatReturnNaN>);
 }
 
+#[cfg(target_arch = "aarch64")]
+#[cfg(feature = "nightly_simd")]
+mod neon {
+    use super::super::config::NEON;
+    use super::*;
+
+    const LANE_SIZE: usize = NEON::<FloatReturnNaN>::LANE_SIZE_64;
+    const LOWER_31_MASK: int64x2_t = unsafe { std::mem::transmute([MASK_VALUE; LANE_SIZE]) };
+
+    #[inline(always)]
+    unsafe fn _f64_as_int64x2_to_i64ord(f64_as_int64x2: int64x2_t) -> int64x2_t {
+        // on a scalar: ((v >> 31) & 0x7FFFFFFF) ^ v
+        let sign_bit_shifted = vshrq_n_s32(f64_as_int64x2, BIT_SHIFT);
+        let sign_bit_masked = vandq_s32(sign_bit_shifted, LOWER_31_MASK);
+        veorq_s32(sign_bit_masked, f64_as_int64x2)
+    }
+
+    #[inline(always)]
+    unsafe fn _reg_to_i64_arr(reg: int64x2_t) -> [i64; LANE_SIZE] {
+        std::mem::transmute::<int64x2_t, [i64; LANE_SIZE]>(reg)
+    }
+
+    impl SIMDOps<f64, int64x2_t, uint64x2_t, LANE_SIZE> for NEON<FloatReturnNaN> {
+        const INITIAL_INDEX: int64x2_t = unsafe { std::mem::transmute([0i64, 1i64]) };
+        const INDEX_INCREMENT: int64x2_t =
+            unsafe { std::mem::transmute([LANE_SIZE as i64; LANE_SIZE]) };
+        const MAX_INDEX: usize = MAX_INDEX;
+
+        #[inline(always)]
+        unsafe fn _reg_to_arr(_: int64x2_t) -> [f64; LANE_SIZE] {
+            // Not implemented because we will perform the horizontal operations on the
+            // signed integer values instead of trying to retransform **only** the values
+            // (and thus not the indices) to floats.
+            unimplemented!()
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_loadu(data: *const f64) -> int64x2_t {
+            _f64_as_int64x2_to_i64ord(vld1q_s64(data as *const i64))
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_add(a: int64x2_t, b: int64x2_t) -> int64x2_t {
+            vaddq_s64(a, b)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_cmpgt(a: int64x2_t, b: int64x2_t) -> uint64x2_t {
+            vcgtq_s64(a, b)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_cmplt(a: int64x2_t, b: int64x2_t) -> uint64x2_t {
+            vcltq_s64(a, b)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_blendv(a: int64x2_t, b: int64x2_t, mask: uint64x2_t) -> int64x2_t {
+            vbslq_s64(mask, b, a)
+        }
+
+        #[inline(always)]
+        unsafe fn _horiz_min(index: int64x2_t, value: int64x2_t) -> (usize, f64) {
+            let index_arr: [i64; LANE_SIZE] = _reg_to_i64_arr(index);
+            let value_arr: [i64; LANE_SIZE] = _reg_to_i64_arr(value);
+            let (min_index, min_value) = min_index_value(&index_arr, &value_arr);
+            (min_index as usize, _i64ord_to_f64(min_value))
+        }
+
+        #[inline(always)]
+        unsafe fn _horiz_max(index: int64x2_t, value: int64x2_t) -> (usize, f64) {
+            let index_arr: [i64; LANE_SIZE] = _reg_to_i64_arr(index);
+            let value_arr: [i64; LANE_SIZE] = _reg_to_i64_arr(value);
+            let (max_index, max_value) = max_index_value(&index_arr, &value_arr);
+            (max_index as usize, _i64ord_to_f64(max_value))
+        }
+    }
+
+    impl_SIMDInit_FloatReturnNaN!(f64, int64x2_t, uint64x2_t, LANE_SIZE, NEON<FloatReturnNaN>);
+
+    impl SIMDArgMinMax<f64, int64x2_t, uint64x2_t, LANE_SIZE, SCALAR<FloatReturnNaN>>
+        for NEON<FloatReturnNaN>
+    {
+        #[target_feature(enable = "neon")]
+        unsafe fn argminmax(data: &[f64]) -> (usize, usize) {
+            Self::_argminmax(data)
+        }
+
+        unsafe fn argmin(data: &[f64]) -> usize {
+            Self::argminmax(data).0
+        }
+
+        unsafe fn argmax(data: &[f64]) -> usize {
+            Self::argminmax(data).1
+        }
+    }
+}
+
 // ======================================= TESTS =======================================
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    all(target_arch = "aarch64", feature = "nightly_simd")
+))]
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
     use rstest_reuse::{self, *};
     use std::marker::PhantomData;
 
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[cfg(feature = "nightly_simd")]
     use crate::simd::config::AVX512;
+    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    use crate::simd::config::NEON;
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, SSE};
     use crate::{FloatReturnNaN, SIMDArgMinMax, SCALAR};
 
@@ -427,11 +560,24 @@ mod tests {
 
     // ------------ Template for x86 / x86_64 -------------
 
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[template]
     #[rstest]
     #[case::sse(SSE {_dtype_strategy: PhantomData::<FloatReturnNaN>}, is_x86_feature_detected!("sse4.2"))]
     #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<FloatReturnNaN>}, is_x86_feature_detected!("avx2"))]
     #[cfg_attr(feature = "nightly_simd", case::avx512(AVX512 {_dtype_strategy: PhantomData::<FloatReturnNaN>}, is_x86_feature_detected!("avx512f")))]
+    fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] simd: T,
+        #[case] simd_available: bool,
+    ) {
+    }
+
+    // ------------ Template for ARM / AArch64 ------------
+
+    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[template]
+    #[rstest]
+    #[case::neon(NEON { _dtype_strategy: PhantomData::<FloatReturnNaN>}, true)]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] simd: T,
         #[case] simd_available: bool,

--- a/src/simd/simd_i16.rs
+++ b/src/simd/simd_i16.rs
@@ -4,10 +4,9 @@ use super::config::SIMDInstructionSet;
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use crate::SCALAR;
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
 use std::arch::aarch64::*;
-#[cfg(target_arch = "arm")]
-#[cfg(feature = "nightly_simd")]
+#[cfg(all(target_arch = "arm", feature = "nightly_simd"))]
 use std::arch::arm::*;
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;

--- a/src/simd/simd_i32.rs
+++ b/src/simd/simd_i32.rs
@@ -4,10 +4,9 @@ use super::config::SIMDInstructionSet;
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use crate::SCALAR;
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
 use std::arch::aarch64::*;
-#[cfg(target_arch = "arm")]
-#[cfg(feature = "nightly_simd")]
+#[cfg(all(target_arch = "arm", feature = "nightly_simd"))]
 use std::arch::arm::*;
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;

--- a/src/simd/simd_i64.rs
+++ b/src/simd/simd_i64.rs
@@ -213,7 +213,7 @@ mod avx512 {
 
 // --------------------------------------- NEON ----------------------------------------
 
-// There are SIMD intrinsics i64, but
+// There are NEON SIMD intrinsics for i64, but
 //  - for arm we miss the vcgt_ and vclt_ intrinsics.
 //  - for aarch64 the required intrinsics are present (on nightly)
 

--- a/src/simd/simd_i64.rs
+++ b/src/simd/simd_i64.rs
@@ -1,11 +1,21 @@
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    all(target_arch = "aarch64", feature = "nighly_simd")
+))]
 use super::config::SIMDInstructionSet;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    all(target_arch = "aarch64", feature = "nighly_simd")
+))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int};
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::generic::{SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use crate::SCALAR;
+#[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
+use std::arch::aarch64::*;
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
@@ -15,7 +25,11 @@ use std::arch::x86_64::*;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::super::dtype_strategy::Int;
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    all(target_arch = "aarch64", feature = "nighly_simd")
+))]
 const MAX_INDEX: usize = i64::MAX as usize;
 
 // --------------------------------------- AVX2 ----------------------------------------
@@ -199,12 +213,11 @@ mod avx512 {
 
 // --------------------------------------- NEON ----------------------------------------
 
-// There are no NEON intrinsics for f64, so we need to use the scalar version.
-//   although NEON intrinsics exist for i64 and u64, we cannot use them as
-//   they there is no 64-bit variant (of any data type) for the following three
-//   intrinsics: vadd_, vcgt_, vclt_
+// There are SIMD intrinsics i64, but
+//  - for arm we miss the vcgt_ and vclt_ intrinsics.
+//  - for aarch64 the required intrinsics are present (on nightly)
 
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(target_arch = "arm")]
 #[cfg(feature = "nightly_simd")]
 mod neon {
     use super::super::config::NEON;
@@ -220,17 +233,83 @@ mod neon {
     unimpl_SIMDArgMinMax!(i64, usize, SCALAR<Int>, NEON<Int>);
 }
 
+#[cfg(target_arch = "aarch64")]
+#[cfg(feature = "nightly_simd")]
+mod neon {
+    use super::super::config::NEON;
+    use super::*;
+
+    const LANE_SIZE: usize = NEON::<Int>::LANE_SIZE_64;
+
+    impl SIMDOps<i64, int64x2_t, uint64x2_t, LANE_SIZE> for NEON<Int> {
+        const INITIAL_INDEX: int64x2_t = unsafe { std::mem::transmute([0i64, 1i64]) };
+        const INDEX_INCREMENT: int64x2_t =
+            unsafe { std::mem::transmute([LANE_SIZE as i64; LANE_SIZE]) };
+        const MAX_INDEX: usize = MAX_INDEX;
+
+        #[inline(always)]
+        unsafe fn _reg_to_arr(reg: int64x2_t) -> [i64; LANE_SIZE] {
+            std::mem::transmute::<int64x2_t, [i64; LANE_SIZE]>(reg)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_loadu(data: *const i64) -> int64x2_t {
+            vld1q_s64(data)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_add(a: int64x2_t, b: int64x2_t) -> int64x2_t {
+            vaddq_s64(a, b)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_cmpgt(a: int64x2_t, b: int64x2_t) -> uint64x2_t {
+            vcgtq_s64(a, b)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_cmplt(a: int64x2_t, b: int64x2_t) -> uint64x2_t {
+            vcltq_s64(a, b)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_blendv(a: int64x2_t, b: int64x2_t, mask: uint64x2_t) -> int64x2_t {
+            vbslq_s64(mask, b, a)
+        }
+    }
+
+    impl_SIMDInit_Int!(i64, int64x2_t, uint64x2_t, LANE_SIZE, NEON<Int>);
+
+    impl_SIMDArgMinMax!(
+        i64,
+        int64x2_t,
+        uint64x2_t,
+        LANE_SIZE,
+        SCALAR<Int>,
+        NEON<Int>,
+        "neon"
+    );
+}
+
 // ======================================= TESTS =======================================
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    all(target_arch = "aarch64", feature = "nightly_simd"),
+))]
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
     use rstest_reuse::{self, *};
     use std::marker::PhantomData;
 
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[cfg(feature = "nightly_simd")]
     use crate::simd::config::AVX512;
+    #[cfg(target_arch = "aarch64")]
+    use crate::simd::config::NEON;
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, SSE};
     use crate::{Int, SIMDArgMinMax, SCALAR};
 
@@ -251,11 +330,24 @@ mod tests {
 
     // ------------ Template for x86 / x86_64 -------------
 
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[template]
     #[rstest]
     #[case::sse(SSE {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("sse4.2"))]
     #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx2"))]
     #[cfg_attr(feature = "nightly_simd", case::avx512(AVX512 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx512f")))]
+    fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] simd: T,
+        #[case] simd_available: bool,
+    ) {
+    }
+
+    // --------------- Template for AArch64 ---------------
+
+    #[cfg(target_arch = "aarch64")]
+    #[template]
+    #[rstest]
+    #[case::neon(NEON {_dtype_strategy: PhantomData::<Int>}, true)]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] simd: T,
         #[case] simd_available: bool,

--- a/src/simd/simd_i64.rs
+++ b/src/simd/simd_i64.rs
@@ -1,13 +1,13 @@
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    all(target_arch = "aarch64", feature = "nighly_simd")
+    all(target_arch = "aarch64", feature = "nightly_simd")
 ))]
 use super::config::SIMDInstructionSet;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    all(target_arch = "aarch64", feature = "nighly_simd")
+    all(target_arch = "aarch64", feature = "nightly_simd")
 ))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int};
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
@@ -28,7 +28,7 @@ use super::super::dtype_strategy::Int;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    all(target_arch = "aarch64", feature = "nighly_simd")
+    all(target_arch = "aarch64", feature = "nightly_simd")
 ))]
 const MAX_INDEX: usize = i64::MAX as usize;
 

--- a/src/simd/simd_i8.rs
+++ b/src/simd/simd_i8.rs
@@ -4,10 +4,9 @@ use super::config::SIMDInstructionSet;
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use crate::SCALAR;
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
 use std::arch::aarch64::*;
-#[cfg(target_arch = "arm")]
-#[cfg(feature = "nightly_simd")]
+#[cfg(all(target_arch = "arm", feature = "nightly_simd"))]
 use std::arch::arm::*;
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;

--- a/src/simd/simd_u16.rs
+++ b/src/simd/simd_u16.rs
@@ -16,10 +16,9 @@ use super::config::SIMDInstructionSet;
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use crate::SCALAR;
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
 use std::arch::aarch64::*;
-#[cfg(target_arch = "arm")]
-#[cfg(feature = "nightly_simd")]
+#[cfg(all(target_arch = "arm", feature = "nightly_simd"))]
 use std::arch::arm::*;
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;

--- a/src/simd/simd_u32.rs
+++ b/src/simd/simd_u32.rs
@@ -16,10 +16,9 @@ use super::config::SIMDInstructionSet;
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use crate::SCALAR;
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
 use std::arch::aarch64::*;
-#[cfg(target_arch = "arm")]
-#[cfg(feature = "nightly_simd")]
+#[cfg(all(target_arch = "arm", feature = "nightly_simd"))]
 use std::arch::arm::*;
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;

--- a/src/simd/simd_u64.rs
+++ b/src/simd/simd_u64.rs
@@ -335,7 +335,7 @@ mod avx512 {
 
 // --------------------------------------- NEON ----------------------------------------
 
-// There are SIMD intrinsics u64, but
+// There are NEON SIMD intrinsics for u64, but
 //  - for arm we miss the vcgt_ and vclt_ intrinsics.
 //  - for aarch64 the required intrinsics are present (on nightly)
 

--- a/src/simd/simd_u64.rs
+++ b/src/simd/simd_u64.rs
@@ -361,7 +361,7 @@ mod neon {
     use super::super::config::NEON;
     use super::*;
 
-    const LANE_SIZE: usize = NEON::<Int>::LANE_SIZE_32;
+    const LANE_SIZE: usize = NEON::<Int>::LANE_SIZE_64;
 
     impl SIMDOps<u64, uint64x2_t, uint64x2_t, LANE_SIZE> for NEON<Int> {
         const INITIAL_INDEX: uint64x2_t = unsafe { std::mem::transmute([0u64, 1u64]) };

--- a/src/simd/simd_u64.rs
+++ b/src/simd/simd_u64.rs
@@ -14,13 +14,13 @@
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    all(target_arch = "aarch64", feature = "nighly_simd")
+    all(target_arch = "aarch64", feature = "nightly_simd")
 ))]
 use super::config::SIMDInstructionSet;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    all(target_arch = "aarch64", feature = "nighly_simd")
+    all(target_arch = "aarch64", feature = "nightly_simd")
 ))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int};
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
@@ -54,7 +54,7 @@ fn _i64ord_to_u64(ord_i64: i64) -> u64 {
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    all(target_arch = "aarch64", feature = "nighly_simd")
+    all(target_arch = "aarch64", feature = "nightly_simd")
 ))]
 const MAX_INDEX: usize = i64::MAX as usize;
 
@@ -335,7 +335,7 @@ mod avx512 {
 
 // --------------------------------------- NEON ----------------------------------------
 
-// There are SIMD intrinsics i64, but
+// There are SIMD intrinsics u64, but
 //  - for arm we miss the vcgt_ and vclt_ intrinsics.
 //  - for aarch64 the required intrinsics are present (on nightly)
 
@@ -420,6 +420,7 @@ mod neon {
     target_arch = "x86_64",
     all(target_arch = "aarch64", feature = "nightly_simd"),
 ))]
+#[cfg(test)]
 mod tests {
     use rstest::rstest;
     use rstest_reuse::{self, *};

--- a/src/simd/simd_u64.rs
+++ b/src/simd/simd_u64.rs
@@ -11,14 +11,24 @@
 /// values.
 ///
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    all(target_arch = "aarch64", feature = "nighly_simd")
+))]
 use super::config::SIMDInstructionSet;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    all(target_arch = "aarch64", feature = "nighly_simd")
+))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int};
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::generic::{SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use crate::SCALAR;
+#[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
+use std::arch::aarch64::*;
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
@@ -41,7 +51,11 @@ fn _i64ord_to_u64(ord_i64: i64) -> u64 {
     unsafe { std::mem::transmute::<i64, u64>(ord_i64 ^ XOR_VALUE) }
 }
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    all(target_arch = "aarch64", feature = "nighly_simd")
+))]
 const MAX_INDEX: usize = i64::MAX as usize;
 
 // --------------------------------------- AVX2 ----------------------------------------
@@ -321,12 +335,11 @@ mod avx512 {
 
 // --------------------------------------- NEON ----------------------------------------
 
-// There are no NEON intrinsics for f64, so we need to use the scalar version.
-//   although NEON intrinsics exist for i64 and u64, we cannot use them as
-//   they there is no 64-bit variant (of any data type) for the following three
-//   intrinsics: vadd_, vcgt_, vclt_
+// There are SIMD intrinsics i64, but
+//  - for arm we miss the vcgt_ and vclt_ intrinsics.
+//  - for aarch64 the required intrinsics are present (on nightly)
 
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(target_arch = "arm")]
 #[cfg(feature = "nightly_simd")]
 mod neon {
     use super::super::config::NEON;
@@ -342,17 +355,82 @@ mod neon {
     unimpl_SIMDArgMinMax!(u64, usize, SCALAR<Int>, NEON<Int>);
 }
 
+#[cfg(target_arch = "aarch64")]
+#[cfg(feature = "nightly_simd")]
+mod neon {
+    use super::super::config::NEON;
+    use super::*;
+
+    const LANE_SIZE: usize = NEON::<Int>::LANE_SIZE_32;
+
+    impl SIMDOps<u64, uint64x2_t, uint64x2_t, LANE_SIZE> for NEON<Int> {
+        const INITIAL_INDEX: uint64x2_t = unsafe { std::mem::transmute([0u64, 1u64]) };
+        const INDEX_INCREMENT: uint64x2_t =
+            unsafe { std::mem::transmute([LANE_SIZE as i64; LANE_SIZE]) };
+        const MAX_INDEX: usize = MAX_INDEX;
+
+        #[inline(always)]
+        unsafe fn _reg_to_arr(reg: uint64x2_t) -> [u64; LANE_SIZE] {
+            std::mem::transmute::<uint64x2_t, [u64; LANE_SIZE]>(reg)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_loadu(data: *const u64) -> uint64x2_t {
+            vld1q_u64(data)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_add(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
+            vaddq_u64(a, b)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_cmpgt(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
+            vcgtq_u64(a, b)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_cmplt(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
+            vcltq_u64(a, b)
+        }
+
+        #[inline(always)]
+        unsafe fn _mm_blendv(a: uint64x2_t, b: uint64x2_t, mask: uint64x2_t) -> uint64x2_t {
+            vbslq_u64(mask, b, a)
+        }
+    }
+
+    impl_SIMDInit_Int!(u64, uint64x2_t, uint64x2_t, LANE_SIZE, NEON<Int>);
+
+    impl_SIMDArgMinMax!(
+        u64,
+        uint64x2_t,
+        uint64x2_t,
+        LANE_SIZE,
+        SCALAR<Int>,
+        NEON<Int>,
+        "neon"
+    );
+}
+
 // ======================================= TESTS =======================================
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-#[cfg(test)]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    all(target_arch = "aarch64", feature = "nightly_simd"),
+))]
 mod tests {
     use rstest::rstest;
     use rstest_reuse::{self, *};
     use std::marker::PhantomData;
 
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[cfg(feature = "nightly_simd")]
     use crate::simd::config::AVX512;
+    #[cfg(target_arch = "aarch64")]
+    use crate::simd::config::NEON;
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     use crate::simd::config::{AVX2, SSE};
     use crate::{Int, SIMDArgMinMax, SCALAR};
 
@@ -379,6 +457,18 @@ mod tests {
     #[case::sse(SSE {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("sse4.2"))]
     #[case::avx2(AVX2 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx2"))]
     #[cfg_attr(feature = "nightly_simd", case::avx512(AVX512 {_dtype_strategy: PhantomData::<Int>}, is_x86_feature_detected!("avx512f")))]
+    fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
+        #[case] simd: T,
+        #[case] simd_available: bool,
+    ) {
+    }
+
+    // --------------- Template for AArch64 ---------------
+
+    #[cfg(target_arch = "aarch64")]
+    #[template]
+    #[rstest]
+    #[case::neon(NEON {_dtype_strategy: PhantomData::<Int>}, true)]
     fn simd_implementations<T, SIMDV, SIMDM, const LANE_SIZE: usize>(
         #[case] simd: T,
         #[case] simd_available: bool,

--- a/src/simd/simd_u8.rs
+++ b/src/simd/simd_u8.rs
@@ -16,10 +16,9 @@ use super::config::SIMDInstructionSet;
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use crate::SCALAR;
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
 use std::arch::aarch64::*;
-#[cfg(target_arch = "arm")]
-#[cfg(feature = "nightly_simd")]
+#[cfg(all(target_arch = "arm", feature = "nightly_simd"))]
 use std::arch::arm::*;
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;


### PR DESCRIPTION
Closes #51 

- Add SIMD implementations + trigger tests
 - [x] `i64` -> unstable
 - [x] `u64` -> unstable
 - [x] `f64` ignore nan -> stable :tada: 
 - [x] `f64` return nan -> unstable

Other TODO's
- [x] Update benchmarks
  - [x] check for new compilation scheme for 64-bit `aarch64`

---

Also a big thanks to @matdemeue for lending me a rpi4, allowing to tune & validate the `aarch64` code