### PR TITLE
perf: use uint `MAX_INDEX` on `arm` / `aarch64` for uint SIMD

### DIFF
--- a/src/simd/simd_u16.rs
+++ b/src/simd/simd_u16.rs
@@ -39,8 +39,11 @@ fn _i16ord_to_u16(ord_i16: i16) -> u16 {
     unsafe { std::mem::transmute::<i16, u16>(ord_i16 ^ XOR_VALUE) }
 }
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
-const MAX_INDEX: usize = i16::MAX as usize;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+const MAX_INDEX: usize = i16::MAX as usize; // SIMD operations on signed ints
+#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(feature = "nightly_simd")]
+const MAX_INDEX: usize = u8::MAX as usize; // SIMD operations on unsigned ints
 
 // --------------------------------------- AVX2 ----------------------------------------
 

--- a/src/simd/simd_u32.rs
+++ b/src/simd/simd_u32.rs
@@ -42,8 +42,11 @@ fn _i32ord_to_u32(ord_i32: i32) -> u32 {
     unsafe { std::mem::transmute::<i32, u32>(ord_i32 ^ XOR_VALUE) }
 }
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
-const MAX_INDEX: usize = i32::MAX as usize;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+const MAX_INDEX: usize = i32::MAX as usize; // SIMD operations on signed ints
+#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(feature = "nightly_simd")]
+const MAX_INDEX: usize = u8::MAX as usize; // SIMD operations on unsigned ints
 
 // --------------------------------------- AVX2 ----------------------------------------
 

--- a/src/simd/simd_u64.rs
+++ b/src/simd/simd_u64.rs
@@ -51,12 +51,10 @@ fn _i64ord_to_u64(ord_i64: i64) -> u64 {
     unsafe { std::mem::transmute::<i64, u64>(ord_i64 ^ XOR_VALUE) }
 }
 
-#[cfg(any(
-    target_arch = "x86",
-    target_arch = "x86_64",
-    all(target_arch = "aarch64", feature = "nightly_simd")
-))]
-const MAX_INDEX: usize = i64::MAX as usize;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64",))]
+const MAX_INDEX: usize = i64::MAX as usize; // SIMD operations on signed ints
+#[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
+const MAX_INDEX: usize = u64::MAX as usize; // SIMD operations on unsigned ints
 
 // --------------------------------------- AVX2 ----------------------------------------
 

--- a/src/simd/simd_u8.rs
+++ b/src/simd/simd_u8.rs
@@ -39,8 +39,11 @@ fn _i8ord_to_u8(ord_i8: i8) -> u8 {
     unsafe { std::mem::transmute::<i8, u8>(ord_i8 ^ XOR_VALUE) }
 }
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
-const MAX_INDEX: usize = i8::MAX as usize;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+const MAX_INDEX: usize = i8::MAX as usize; // SIMD operations on signed ints
+#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(feature = "nightly_simd")]
+const MAX_INDEX: usize = u8::MAX as usize; // SIMD operations on unsigned ints
 
 // --------------------------------------- AVX2 ----------------------------------------
 


### PR DESCRIPTION
Enhances the performance for `arm` / `aarch64` uint operations by using uint as `MAX_INDEX` instead of int.
This results in 2x fewer exits from the inner SIMD loop (and thus 2x less - much slower - horizontal SIMD ops) :tada: 

## Illustration of the performance gain

main branch :arrow_down:
```txt
scalar_u8_argminmax     time:   [274.45 µs 274.47 µs 274.48 µs]
scalar_u8_argmin        time:   [274.52 µs 274.53 µs 274.54 µs]
scalar_u8_argmax        time:   [274.51 µs 274.52 µs 274.54 µs]
neon_u8_argminmax       time:   [58.060 µs 58.072 µs 58.089 µs]
neon_u8_argmin          time:   [38.840 µs 38.843 µs 38.846 µs]
neon_u8_argmax          time:   [38.836 µs 38.837 µs 38.840 µs]
impl_u8_argminmax       time:   [58.059 µs 58.062 µs 58.065 µs]
impl_u8_argmin          time:   [38.869 µs 38.870 µs 38.871 µs]
impl_u8_argmax          time:   [38.873 µs 38.886 µs 38.912 µs]
```

this PR :arrow_down:
```txt
scalar_u8_argminmax     time:   [274.43 µs 274.44 µs 274.44 µs]
scalar_u8_argmin        time:   [274.53 µs 274.54 µs 274.54 µs]
scalar_u8_argmax        time:   [274.49 µs 274.50 µs 274.52 µs]
neon_u8_argminmax       time:   [39.193 µs 39.194 µs 39.195 µs]
neon_u8_argmin          time:   [29.295 µs 29.295 µs 29.296 µs]
neon_u8_argmax          time:   [29.298 µs 29.301 µs 29.307 µs]
impl_u8_argminmax       time:   [39.194 µs 39.195 µs 39.196 µs]
impl_u8_argmin          time:   [29.299 µs 29.300 µs 29.300 µs]
impl_u8_argmax          time:   [29.299 µs 29.300 µs 29.301 µs]
```

We see here 30-40% better performance. This improvement becomes smaller when increasing in bit-size of the underlying uint datatype.