### PR TITLE
fix: remove `stdsimd` feature; add `stdarch_x86_avx512`

### DIFF
--- a/benches/bench_f16_ignore_nan.rs
+++ b/benches/bench_f16_ignore_nan.rs
@@ -1,5 +1,3 @@
-#![feature(stdsimd)]
-
 use argminmax::ArgMinMax;
 use codspeed_criterion_compat::*;
 use dev_utils::{config, utils};

--- a/benches/bench_f16_return_nan.rs
+++ b/benches/bench_f16_return_nan.rs
@@ -1,5 +1,3 @@
-#![feature(stdsimd)]
-
 use argminmax::NaNArgMinMax;
 use codspeed_criterion_compat::*;
 use dev_utils::{config, utils};

--- a/benches/bench_f32_ignore_nan.rs
+++ b/benches/bench_f32_ignore_nan.rs
@@ -1,5 +1,3 @@
-#![feature(stdsimd)]
-
 use argminmax::ArgMinMax;
 use codspeed_criterion_compat::*;
 use dev_utils::{config, utils};

--- a/benches/bench_f32_return_nan.rs
+++ b/benches/bench_f32_return_nan.rs
@@ -1,5 +1,3 @@
-#![feature(stdsimd)]
-
 use argminmax::NaNArgMinMax;
 use codspeed_criterion_compat::*;
 use dev_utils::{config, utils};

--- a/benches/bench_f64_ignore_nan.rs
+++ b/benches/bench_f64_ignore_nan.rs
@@ -1,5 +1,3 @@
-#![feature(stdsimd)]
-
 use argminmax::ArgMinMax;
 use codspeed_criterion_compat::*;
 use dev_utils::{config, utils};

--- a/benches/bench_f64_return_nan.rs
+++ b/benches/bench_f64_return_nan.rs
@@ -1,5 +1,3 @@
-#![feature(stdsimd)]
-
 use argminmax::NaNArgMinMax;
 use codspeed_criterion_compat::*;
 use dev_utils::{config, utils};

--- a/benches/bench_i16.rs
+++ b/benches/bench_i16.rs
@@ -1,5 +1,3 @@
-#![feature(stdsimd)]
-
 use argminmax::ArgMinMax;
 use codspeed_criterion_compat::*;
 use dev_utils::{config, utils};

--- a/benches/bench_i32.rs
+++ b/benches/bench_i32.rs
@@ -1,5 +1,3 @@
-#![feature(stdsimd)]
-
 use argminmax::ArgMinMax;
 use codspeed_criterion_compat::*;
 use dev_utils::{config, utils};

--- a/benches/bench_i64.rs
+++ b/benches/bench_i64.rs
@@ -1,5 +1,3 @@
-#![feature(stdsimd)]
-
 use argminmax::ArgMinMax;
 use codspeed_criterion_compat::*;
 use dev_utils::{config, utils};

--- a/benches/bench_i8.rs
+++ b/benches/bench_i8.rs
@@ -1,5 +1,3 @@
-#![feature(stdsimd)]
-
 use argminmax::ArgMinMax;
 use codspeed_criterion_compat::*;
 use dev_utils::{config, utils};

--- a/benches/bench_u16.rs
+++ b/benches/bench_u16.rs
@@ -1,5 +1,3 @@
-#![feature(stdsimd)]
-
 use argminmax::ArgMinMax;
 use codspeed_criterion_compat::*;
 use dev_utils::{config, utils};

--- a/benches/bench_u32.rs
+++ b/benches/bench_u32.rs
@@ -1,5 +1,3 @@
-#![feature(stdsimd)]
-
 use argminmax::ArgMinMax;
 use codspeed_criterion_compat::*;
 use dev_utils::{config, utils};

--- a/benches/bench_u64.rs
+++ b/benches/bench_u64.rs
@@ -1,5 +1,3 @@
-#![feature(stdsimd)]
-
 use argminmax::ArgMinMax;
 use codspeed_criterion_compat::*;
 use dev_utils::{config, utils};

--- a/benches/bench_u8.rs
+++ b/benches/bench_u8.rs
@@ -1,5 +1,3 @@
-#![feature(stdsimd)]
-
 use argminmax::ArgMinMax;
 use codspeed_criterion_compat::*;
 use dev_utils::{config, utils};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,8 +68,8 @@
 //!```
 //!
 
-#![feature(cfg_version)]
 // Enable SIMD nightly features when on nightly_simd enabled
+#![cfg_attr(feature = "nightly_simd", feature(cfg_version))]
 // ------- version 1.78 and above
 #![cfg_attr(
     all(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,10 +69,10 @@
 //!
 
 // enable SIMD nightly features when on nightly_simd enabled
-#![cfg_attr(feature = "nightly_simd", feature(stdsimd))]
 #![cfg_attr(feature = "nightly_simd", feature(avx512_target_feature))]
 #![cfg_attr(feature = "nightly_simd", feature(arm_target_feature))]
-
+// enable stdarch_x86_avx512 feature
+#![feature(stdarch_x86_avx512)]
 // It is necessary to import this at the root of the crate
 // See: https://github.com/la10736/rstest/tree/master/rstest_reuse#use-rstest_resuse-at-the-top-of-your-crate
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,21 +74,23 @@
 #![cfg_attr(
     all(
         feature = "nightly_simd",
-        version("1.78"),
         any(target_arch = "x86_64", target_arch = "x86")
     ),
-    feature(stdarch_x86_avx512)
+    cfg_attr(version("1.78"), feature(stdarch_x86_avx2))
 )]
 #![cfg_attr(
-    all(feature = "nightly_simd", version("1.78"), target_arch = "arm"),
-    feature(stdarch_arm_neon_intrinsics)
+    all(feature = "nightly_simd", target_arch = "arm"),
+    cfg_attr(version("1.78"), feature(stdarch_arm_neon_intrinsics)) // TODO: Aarch64 is stable now - check if this is under nightly_simd https://github.com/rust-lang/rust/issues/111800
 )]
 #![cfg_attr(
-    all(feature = "nightly_simd", version("1.78"), target_arch = "arm"),
-    feature(stdarch_arm_feature_detection)
+    all(feature = "nightly_simd", target_arch = "arm"),
+    cfg_attr(version("1.78"), feature(stdarch_arm_feature_detection))
 )]
 // ------- version 1.77 and below
-#![cfg_attr(all(feature = "nightly_simd", not(version("1.78"))), feature(stdsimd))]
+#![cfg_attr(
+    feature = "nightly_simd",
+    cfg_attr(not(version("1.78")), feature(stdsimd))
+)]
 // ------- any version
 #![cfg_attr(feature = "nightly_simd", feature(avx512_target_feature))]
 #![cfg_attr(feature = "nightly_simd", feature(arm_target_feature))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,24 +68,31 @@
 //!```
 //!
 
-// enable SIMD nightly features when on nightly_simd enabled
+#![feature(cfg_version)]
+// Enable SIMD nightly features when on nightly_simd enabled
+// ------- version 1.78 and above
 #![cfg_attr(
     all(
         feature = "nightly_simd",
+        version("1.78"),
         any(target_arch = "x86_64", target_arch = "x86")
     ),
     feature(stdarch_x86_avx512)
 )]
 #![cfg_attr(
-    all(feature = "nightly_simd", target_arch = "arm"),
+    all(feature = "nightly_simd", version("1.78"), target_arch = "arm"),
     feature(stdarch_arm_neon_intrinsics)
 )]
 #![cfg_attr(
-    all(feature = "nightly_simd", target_arch = "arm"),
+    all(feature = "nightly_simd", version("1.78"), target_arch = "arm"),
     feature(stdarch_arm_feature_detection)
 )]
+// ------- version 1.77 and below
+#![cfg_attr(all(feature = "nightly_simd", not(version("1.78"))), feature(stdsimd))]
+// ------- any version
 #![cfg_attr(feature = "nightly_simd", feature(avx512_target_feature))]
 #![cfg_attr(feature = "nightly_simd", feature(arm_target_feature))]
+
 // It is necessary to import this at the root of the crate
 // See: https://github.com/la10736/rstest/tree/master/rstest_reuse#use-rstest_resuse-at-the-top-of-your-crate
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,10 +69,23 @@
 //!
 
 // enable SIMD nightly features when on nightly_simd enabled
+#![cfg_attr(
+    all(
+        feature = "nightly_simd",
+        any(target_arch = "x86_64", target_arch = "x86")
+    ),
+    feature(stdarch_x86_avx512)
+)]
+#![cfg_attr(
+    all(feature = "nightly_simd", target_arch = "arm"),
+    feature(stdarch_arm_neon_intrinsics)
+)]
+#![cfg_attr(
+    all(feature = "nightly_simd", target_arch = "arm"),
+    feature(stdarch_arm_feature_detection)
+)]
 #![cfg_attr(feature = "nightly_simd", feature(avx512_target_feature))]
 #![cfg_attr(feature = "nightly_simd", feature(arm_target_feature))]
-// enable stdarch_x86_avx512 feature
-#![feature(stdarch_x86_avx512)]
 // It is necessary to import this at the root of the crate
 // See: https://github.com/la10736/rstest/tree/master/rstest_reuse#use-rstest_resuse-at-the-top-of-your-crate
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,13 +78,14 @@
     ),
     cfg_attr(version("1.78"), feature(stdarch_x86_avx512))
 )]
+// TODO: Aarch64 is stable now - check if this is under nightly_simd https://github.com/rust-lang/rust/issues/111800
 #![cfg_attr(
     all(feature = "nightly_simd", target_arch = "arm"),
-    cfg_attr(version("1.78"), feature(stdarch_arm_neon_intrinsics)) // TODO: Aarch64 is stable now - check if this is under nightly_simd https://github.com/rust-lang/rust/issues/111800
-)]
-#![cfg_attr(
-    all(feature = "nightly_simd", target_arch = "arm"),
-    cfg_attr(version("1.78"), feature(stdarch_arm_feature_detection))
+    cfg_attr(
+        version("1.78"),
+        feature(stdarch_arm_neon_intrinsics),
+        feature(stdarch_arm_feature_detection)
+    )
 )]
 // ------- version 1.77 and below
 #![cfg_attr(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@
         feature = "nightly_simd",
         any(target_arch = "x86_64", target_arch = "x86")
     ),
-    cfg_attr(version("1.78"), feature(stdarch_x86_avx2))
+    cfg_attr(version("1.78"), feature(stdarch_x86_avx512))
 )]
 #![cfg_attr(
     all(feature = "nightly_simd", target_arch = "arm"),


### PR DESCRIPTION
Closes #61