### PR TITLE
enh: remove `simd_nightly` feature flag for `aarch64`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ exclude = [".git*", "dev_utils/**/*", "tests/**/*"]
 
 
 [dependencies]
-num-traits = { version = "0.2.17", default-features = false }
+num-traits = { version = "0.2", default-features = false }
 half = { version = "2.3.1", default-features = false, features=["num-traits"], optional = true }
-ndarray = { version = "0.15.6", default-features = false, optional = true}
-arrow = { version = ">0", default-features = false, optional = true}
-arrow2 = { version = ">0.0", default-features = false, optional = true}
+ndarray = { version = "0.15.6", default-features = false, optional = true }
+arrow = { version = ">0", default-features = false, optional = true }
+arrow2 = { version = ">0.0", default-features = false, optional = true }
 # once_cell = "1.16.0"
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,8 +118,8 @@ pub(crate) use simd::AVX512;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub(crate) use simd::{SIMDArgMinMax, AVX2, SSE};
 #[cfg(any(
-    all(target_arch = "aarch64", feature = "float"), // is stable for f64
-    all(any(target_arch = "arm", target_arch = "aarch64"), feature = "nightly_simd"),
+    all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64"
 ))]
 pub(crate) use simd::{SIMDArgMinMax, NEON};
 
@@ -304,9 +304,9 @@ macro_rules! impl_argminmax_int {
                             return unsafe { SSE::<Int>::argminmax(self) }
                         }
                     }
-                    #[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
+                    #[cfg(target_arch = "aarch64")]
                     {
-                        if std::arch::is_aarch64_feature_detected!("neon") & (<$int_type>::NB_BITS < 64) {
+                        if std::arch::is_aarch64_feature_detected!("neon") {
                             // Scalar is faster for 64-bit numbers
                             return unsafe { NEON::<Int>::argminmax(self) }
                         }
@@ -349,7 +349,7 @@ macro_rules! impl_argminmax_int {
                             return unsafe { SSE::<Int>::argmin(self) }
                         }
                     }
-                    #[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
+                    #[cfg(target_arch = "aarch64")]
                     {
                         if std::arch::is_aarch64_feature_detected!("neon") {
                             return unsafe { NEON::<Int>::argmin(self) }
@@ -392,7 +392,7 @@ macro_rules! impl_argminmax_int {
                             return unsafe { SSE::<Int>::argmax(self) }
                         }
                     }
-                    #[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
+                    #[cfg(target_arch = "aarch64")]
                     {
                         if std::arch::is_aarch64_feature_detected!("neon") {
                             return unsafe { NEON::<Int>::argmax(self) }
@@ -443,10 +443,9 @@ macro_rules! impl_argminmax_float {
                             return unsafe { SSE::<FloatIgnoreNaN>::argminmax(self) }
                         }
                     }
-                    #[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
+                    #[cfg(target_arch = "aarch64")]
                     {
-                        if std::arch::is_aarch64_feature_detected!("neon") & (<$float_type>::NB_BITS < 64) {
-                            // NEON f64 is part of stable Rust (see code below this macro)
+                        if std::arch::is_aarch64_feature_detected!("neon") {
                             return unsafe { NEON::<FloatIgnoreNaN>::argminmax(self) }
                         }
                     }
@@ -483,10 +482,9 @@ macro_rules! impl_argminmax_float {
                             return unsafe { SSE::<FloatIgnoreNaN>::argmin(self) }
                         }
                     }
-                    #[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
+                    #[cfg(target_arch = "aarch64")]
                     {
-                        if std::arch::is_aarch64_feature_detected!("neon") & (<$float_type>::NB_BITS < 64) {
-                            // NEON f64 is part of stable Rust (see code below this macro)
+                        if std::arch::is_aarch64_feature_detected!("neon") {
                             return unsafe { NEON::<FloatIgnoreNaN>::argmin(self) }
                         }
                     }
@@ -523,10 +521,9 @@ macro_rules! impl_argminmax_float {
                             return unsafe { SSE::<FloatIgnoreNaN>::argmax(self) }
                         }
                     }
-                    #[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
+                    #[cfg(target_arch = "aarch64")]
                     {
-                        if std::arch::is_aarch64_feature_detected!("neon") & (<$float_type>::NB_BITS < 64) {
-                            // NEON f64 is part of stable Rust (see code below this macro)
+                        if std::arch::is_aarch64_feature_detected!("neon") {
                             return unsafe { NEON::<FloatIgnoreNaN>::argmax(self) }
                         }
                     }
@@ -563,10 +560,9 @@ macro_rules! impl_argminmax_float {
                             return unsafe { SSE::<FloatReturnNaN>::argminmax(self) }
                         }
                     }
-                    #[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
+                    #[cfg(target_arch = "aarch64")]
                     {
-                        if std::arch::is_aarch64_feature_detected!("neon") & (<$float_type>::NB_BITS < 64) {
-                            // We miss some NEON instructions for 64-bit numbers
+                        if std::arch::is_aarch64_feature_detected!("neon") {
                             return unsafe { NEON::<FloatReturnNaN>::argminmax(self) }
                         }
                     }
@@ -601,10 +597,9 @@ macro_rules! impl_argminmax_float {
                             return unsafe { SSE::<FloatReturnNaN>::argmin(self) }
                         }
                     }
-                    #[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
+                    #[cfg(target_arch = "aarch64")]
                     {
-                        if std::arch::is_aarch64_feature_detected!("neon") & (<$float_type>::NB_BITS < 64) {
-                            // We miss some NEON instructions for 64-bit numbers
+                        if std::arch::is_aarch64_feature_detected!("neon") {
                             return unsafe { NEON::<FloatReturnNaN>::argmin(self) }
                         }
                     }
@@ -639,10 +634,9 @@ macro_rules! impl_argminmax_float {
                             return unsafe { SSE::<FloatReturnNaN>::argmax(self) }
                         }
                     }
-                    #[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
+                    #[cfg(target_arch = "aarch64")]
                     {
-                        if std::arch::is_aarch64_feature_detected!("neon") & (<$float_type>::NB_BITS < 64) {
-                            // We miss some NEON instructions for 64-bit numbers
+                        if std::arch::is_aarch64_feature_detected!("neon") {
                             return unsafe { NEON::<FloatReturnNaN>::argmax(self) }
                         }
                     }
@@ -660,68 +654,11 @@ macro_rules! impl_argminmax_float {
     };
 }
 
-/// Implement ArgMinMax for &[f64] on aarch64 as NEON intrinsics for f64
-/// are part of stable Rust on aarch64.
-// Note: implementing this in a distinct impl block seemed more clean than
-// hacking with unimpl_ macros in the simd_.rs files to avoid complaints
-// from the compiler..
-#[cfg(all(feature = "float", target_arch = "aarch64"))]
-impl ArgMinMax for &[f64] {
-    fn argminmax(&self) -> (usize, usize) {
-        unsafe { NEON::<FloatIgnoreNaN>::argminmax(self) }
-    }
-    fn argmin(&self) -> usize {
-        unsafe { NEON::<FloatIgnoreNaN>::argmin(self) }
-    }
-    fn argmax(&self) -> usize {
-        unsafe { NEON::<FloatIgnoreNaN>::argmax(self) }
-    }
-}
-
-/// Implement NaNArgMinMax for &[f64] on aarch64 - the required intrinsics
-/// for return nan are not part of stable Rust.
-// Note: implementing this in a distinct impl block seemed more clean than
-// hacking with unimpl_ macros in the simd_.rs files to avoid complaints
-// from the compiler..
-#[cfg(all(feature = "float", target_arch = "aarch64"))]
-impl NaNArgMinMax for &[f64] {
-    fn nanargminmax(&self) -> (usize, usize) {
-        #[cfg(feature = "nightly_simd")]
-        {
-            if std::arch::is_aarch64_feature_detected!("neon") {
-                return unsafe { NEON::<FloatReturnNaN>::argminmax(self) };
-            }
-        }
-        SCALAR::<FloatReturnNaN>::argminmax(self)
-    }
-    fn nanargmin(&self) -> usize {
-        #[cfg(feature = "nightly_simd")]
-        {
-            if std::arch::is_aarch64_feature_detected!("neon") {
-                return unsafe { NEON::<FloatReturnNaN>::argmin(self) };
-            }
-        }
-        SCALAR::<FloatReturnNaN>::argmin(self)
-    }
-    fn nanargmax(&self) -> usize {
-        #[cfg(feature = "nightly_simd")]
-        {
-            if std::arch::is_aarch64_feature_detected!("neon") {
-                return unsafe { NEON::<FloatReturnNaN>::argmax(self) };
-            }
-        }
-        SCALAR::<FloatReturnNaN>::argmax(self)
-    }
-}
-
 // Implement ArgMinMax for (non-optional) integer rust primitive types
 impl_argminmax_int!(i8, i16, i32, i64, u8, u16, u32, u64);
 // Implement for (optional) float rust primitive types
-#[cfg(all(feature = "float", not(target_arch = "aarch64")))]
+#[cfg(feature = "float")]
 impl_argminmax_float!(f32, f64);
-// For aarch64 f64 is implemented in the two impl blocks above
-#[cfg(all(feature = "float", target_arch = "aarch64"))]
-impl_argminmax_float!(f32);
 
 // Implement ArgMinMax for other data types
 #[cfg(feature = "half")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,7 +306,7 @@ macro_rules! impl_argminmax_int {
                     }
                     #[cfg(target_arch = "aarch64")]
                     {
-                        if std::arch::is_aarch64_feature_detected!("neon")  & (<$int_type>::NB_BITS < 64) {
+                        if std::arch::is_aarch64_feature_detected!("neon") & (<$int_type>::NB_BITS < 64) {
                             // Scalar is faster for 64-bit numbers
                             return unsafe { NEON::<Int>::argminmax(self) }
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,7 +306,7 @@ macro_rules! impl_argminmax_int {
                     }
                     #[cfg(target_arch = "aarch64")]
                     {
-                        if std::arch::is_aarch64_feature_detected!("neon") {
+                        if std::arch::is_aarch64_feature_detected!("neon")  & (<$int_type>::NB_BITS < 64) {
                             // Scalar is faster for 64-bit numbers
                             return unsafe { NEON::<Int>::argminmax(self) }
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,6 @@
     ),
     cfg_attr(version("1.78"), feature(stdarch_x86_avx512))
 )]
-// TODO: Aarch64 is stable now - check if this is under nightly_simd https://github.com/rust-lang/rust/issues/111800
 #![cfg_attr(
     all(feature = "nightly_simd", target_arch = "arm"),
     cfg_attr(

--- a/src/simd/generic.rs
+++ b/src/simd/generic.rs
@@ -778,7 +778,7 @@ where
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    all(target_arch = "aarch64", feature = "float"), // is stable for f64
+    target_arch = "aarch64",
     feature = "nightly_simd"
 ))]
 macro_rules! impl_SIMDArgMinMax {
@@ -816,7 +816,7 @@ macro_rules! impl_SIMDArgMinMax {
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    all(target_arch = "aarch64", feature = "float"), // is stable for f64
+    target_arch = "aarch64",
     feature = "nightly_simd"
 ))]
 pub(crate) use impl_SIMDArgMinMax; // Now classic paths Just Work™

--- a/src/simd/generic.rs
+++ b/src/simd/generic.rs
@@ -185,7 +185,7 @@ where
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(feature = "nightly_simd", target_arch = "arm")
+    feature = "nightly_simd"
 ))]
 macro_rules! impl_SIMDInit_Int {
     ($scalar_dtype:ty, $simd_vec_dtype:ty, $simd_mask_dtype:ty, $lane_size:expr, $simd_struct:ty) => {
@@ -201,7 +201,7 @@ macro_rules! impl_SIMDInit_Int {
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(feature = "nightly_simd", target_arch = "arm")
+    feature = "nightly_simd"
 ))]
 pub(crate) use impl_SIMDInit_Int; // Now classic paths Just Work™
 
@@ -212,7 +212,7 @@ pub(crate) use impl_SIMDInit_Int; // Now classic paths Just Work™
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(feature = "nightly_simd", target_arch = "arm")
+    feature = "nightly_simd"
 ))]
 macro_rules! impl_SIMDInit_FloatReturnNaN {
     ($scalar_dtype:ty, $simd_vec_dtype:ty, $simd_mask_dtype:ty, $lane_size:expr, $simd_struct:ty) => {
@@ -240,7 +240,7 @@ macro_rules! impl_SIMDInit_FloatReturnNaN {
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(feature = "nightly_simd", target_arch = "arm") // TODO: all like this?
+    feature = "nightly_simd"
 ))]
 pub(crate) use impl_SIMDInit_FloatReturnNaN; // Now classic paths Just Work™
 

--- a/src/simd/generic.rs
+++ b/src/simd/generic.rs
@@ -184,8 +184,8 @@ where
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
+    all(target_arch = "arm", feature = "nightly_simd"),
     target_arch = "aarch64",
-    feature = "nightly_simd"
 ))]
 macro_rules! impl_SIMDInit_Int {
     ($scalar_dtype:ty, $simd_vec_dtype:ty, $simd_mask_dtype:ty, $lane_size:expr, $simd_struct:ty) => {
@@ -200,8 +200,8 @@ macro_rules! impl_SIMDInit_Int {
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
+    all(target_arch = "arm", feature = "nightly_simd"),
     target_arch = "aarch64",
-    feature = "nightly_simd"
 ))]
 pub(crate) use impl_SIMDInit_Int; // Now classic paths Just Work™
 
@@ -211,8 +211,8 @@ pub(crate) use impl_SIMDInit_Int; // Now classic paths Just Work™
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
+    all(target_arch = "arm", feature = "nightly_simd"),
     target_arch = "aarch64",
-    feature = "nightly_simd"
 ))]
 macro_rules! impl_SIMDInit_FloatReturnNaN {
     ($scalar_dtype:ty, $simd_vec_dtype:ty, $simd_mask_dtype:ty, $lane_size:expr, $simd_struct:ty) => {
@@ -239,8 +239,8 @@ macro_rules! impl_SIMDInit_FloatReturnNaN {
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
+    all(target_arch = "arm", feature = "nightly_simd"),
     target_arch = "aarch64",
-    feature = "nightly_simd"
 ))]
 pub(crate) use impl_SIMDInit_FloatReturnNaN; // Now classic paths Just Work™
 
@@ -250,8 +250,8 @@ pub(crate) use impl_SIMDInit_FloatReturnNaN; // Now classic paths Just Work™
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64", // is stable for f64
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 macro_rules! impl_SIMDInit_FloatIgnoreNaN {
     ($scalar_dtype:ty, $simd_vec_dtype:ty, $simd_mask_dtype:ty, $lane_size:expr, $simd_struct:ty) => {
@@ -326,8 +326,8 @@ macro_rules! impl_SIMDInit_FloatIgnoreNaN {
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64", // is stable for f64
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 pub(crate) use impl_SIMDInit_FloatIgnoreNaN; // Now classic paths Just Work™
 
@@ -788,8 +788,8 @@ where
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
+    all(target_arch = "arm", feature = "nightly_simd"),
     target_arch = "aarch64",
-    feature = "nightly_simd"
 ))]
 macro_rules! impl_SIMDArgMinMax {
     ($scalar_dtype:ty, $simd_vec_dtype:ty, $simd_mask_dtype:ty, $lane_size:expr, $scalar_struct:ty, $simd_struct:ty, $target:expr) => {
@@ -826,8 +826,8 @@ macro_rules! impl_SIMDArgMinMax {
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
+    all(target_arch = "arm", feature = "nightly_simd"),
     target_arch = "aarch64",
-    feature = "nightly_simd"
 ))]
 pub(crate) use impl_SIMDArgMinMax; // Now classic paths Just Work™
 

--- a/src/simd/generic.rs
+++ b/src/simd/generic.rs
@@ -185,7 +185,7 @@ where
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(feature = "nightly_simd", target_arch = "arm")
 ))]
 macro_rules! impl_SIMDInit_Int {
     ($scalar_dtype:ty, $simd_vec_dtype:ty, $simd_mask_dtype:ty, $lane_size:expr, $simd_struct:ty) => {
@@ -201,14 +201,19 @@ macro_rules! impl_SIMDInit_Int {
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(feature = "nightly_simd", target_arch = "arm")
 ))]
 pub(crate) use impl_SIMDInit_Int; // Now classic paths Just Work™
 
 // --------------- Float Return NaNs
 
 #[cfg(any(feature = "float", feature = "half"))]
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    all(feature = "nightly_simd", target_arch = "arm")
+))]
 macro_rules! impl_SIMDInit_FloatReturnNaN {
     ($scalar_dtype:ty, $simd_vec_dtype:ty, $simd_mask_dtype:ty, $lane_size:expr, $simd_struct:ty) => {
         impl SIMDInit<$scalar_dtype, $simd_vec_dtype, $simd_mask_dtype, $lane_size>
@@ -231,7 +236,12 @@ macro_rules! impl_SIMDInit_FloatReturnNaN {
 }
 
 #[cfg(any(feature = "float", feature = "half"))]
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    all(feature = "nightly_simd", target_arch = "arm") // TODO: all like this?
+))]
 pub(crate) use impl_SIMDInit_FloatReturnNaN; // Now classic paths Just Work™
 
 // --------------- Float Ignore NaNs

--- a/src/simd/generic.rs
+++ b/src/simd/generic.rs
@@ -111,9 +111,9 @@ where
 /// - `impl_SIMDInit_Int!`
 ///     - called in the `simd_i*.rs` files
 ///     - called in the `simd_u*.rs` files
-/// - `impl_SIMDInit_FloatIgnoreNaN!`
-///     - see the `simd_f*_return_nan.rs` files
 /// - `impl_SIMDInit_FloatReturnNaN!`
+///     - see the `simd_f*_return_nan.rs` files
+/// - `impl_SIMDInit_FloatIgnoreNaN!`
 ///     - see the `simd_f*_ignore_nan.rs` files
 ///
 /// The current (default) implementation is for the Int case - see `impl_SIMDInit_Int!`
@@ -250,7 +250,7 @@ pub(crate) use impl_SIMDInit_FloatReturnNaN; // Now classic paths Just Work™
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    all(target_arch = "aarch64", feature = "float"), // is stable for f64
+    target_arch = "aarch64", // is stable for f64
     feature = "nightly_simd"
 ))]
 macro_rules! impl_SIMDInit_FloatIgnoreNaN {
@@ -326,7 +326,7 @@ macro_rules! impl_SIMDInit_FloatIgnoreNaN {
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    all(target_arch = "aarch64", feature = "float"), // is stable for f64
+    target_arch = "aarch64", // is stable for f64
     feature = "nightly_simd"
 ))]
 pub(crate) use impl_SIMDInit_FloatIgnoreNaN; // Now classic paths Just Work™

--- a/src/simd/generic.rs
+++ b/src/simd/generic.rs
@@ -181,7 +181,12 @@ where
 
 // --------------- Int (signed and unsigned)
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 macro_rules! impl_SIMDInit_Int {
     ($scalar_dtype:ty, $simd_vec_dtype:ty, $simd_mask_dtype:ty, $lane_size:expr, $simd_struct:ty) => {
         impl SIMDInit<$scalar_dtype, $simd_vec_dtype, $simd_mask_dtype, $lane_size>
@@ -192,7 +197,12 @@ macro_rules! impl_SIMDInit_Int {
     };
 }
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 pub(crate) use impl_SIMDInit_Int; // Now classic paths Just Work™
 
 // --------------- Float Return NaNs

--- a/src/simd/simd_f16_ignore_nan.rs
+++ b/src/simd/simd_f16_ignore_nan.rs
@@ -29,14 +29,14 @@
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 use super::config::SIMDInstructionSet;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 use super::generic::{
     impl_SIMDArgMinMax, impl_SIMDInit_FloatIgnoreNaN, SIMDArgMinMax, SIMDInit, SIMDOps,
@@ -45,14 +45,14 @@ use super::generic::{
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 use crate::SCALAR;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 use num_traits::Zero;
 #[cfg(target_arch = "aarch64")]
@@ -68,7 +68,7 @@ use std::arch::x86_64::*;
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 use half::f16;
 
@@ -77,7 +77,7 @@ use half::f16;
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 use super::super::dtype_strategy::FloatIgnoreNaN;
 
@@ -85,21 +85,21 @@ use super::super::dtype_strategy::FloatIgnoreNaN;
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 const BIT_SHIFT: i32 = 15;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 const MASK_VALUE: i16 = 0x7FFF; // i16::MAX - masks everything but the sign bit
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 const NAN_VALUE: i16 = 0x7C00; // absolute values above this are NaN
 
@@ -107,7 +107,7 @@ const NAN_VALUE: i16 = 0x7C00; // absolute values above this are NaN
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 #[inline(always)]
 fn _i16ord_to_f16(ord_i16: i16) -> f16 {
@@ -119,7 +119,7 @@ fn _i16ord_to_f16(ord_i16: i16) -> f16 {
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 const MAX_INDEX: usize = i16::MAX as usize;
 
@@ -753,8 +753,8 @@ mod neon_ignore_nan {
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    all(target_arch = "arm", feature = "nightly_simd"),
     target_arch = "aarch64",
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 #[cfg(test)]
 mod tests {

--- a/src/simd/simd_f16_ignore_nan.rs
+++ b/src/simd/simd_f16_ignore_nan.rs
@@ -28,15 +28,15 @@
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
+    all(target_arch = "arm", feature = "nightly_simd"),
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 use super::config::SIMDInstructionSet;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
+    all(target_arch = "arm", feature = "nightly_simd"),
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 use super::generic::{
     impl_SIMDArgMinMax, impl_SIMDInit_FloatIgnoreNaN, SIMDArgMinMax, SIMDInit, SIMDOps,
@@ -44,15 +44,15 @@ use super::generic::{
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
+    all(target_arch = "arm", feature = "nightly_simd"),
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 use crate::SCALAR;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
+    all(target_arch = "arm", feature = "nightly_simd"),
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 use num_traits::Zero;
 #[cfg(target_arch = "aarch64")]
@@ -67,8 +67,8 @@ use std::arch::x86_64::*;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
+    all(target_arch = "arm", feature = "nightly_simd"),
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 use half::f16;
 
@@ -76,38 +76,38 @@ use half::f16;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
+    all(target_arch = "arm", feature = "nightly_simd"),
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 use super::super::dtype_strategy::FloatIgnoreNaN;
 
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
+    all(target_arch = "arm", feature = "nightly_simd"),
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 const BIT_SHIFT: i32 = 15;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
+    all(target_arch = "arm", feature = "nightly_simd"),
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 const MASK_VALUE: i16 = 0x7FFF; // i16::MAX - masks everything but the sign bit
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
+    all(target_arch = "arm", feature = "nightly_simd"),
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 const NAN_VALUE: i16 = 0x7C00; // absolute values above this are NaN
 
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
+    all(target_arch = "arm", feature = "nightly_simd"),
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 #[inline(always)]
 fn _i16ord_to_f16(ord_i16: i16) -> f16 {
@@ -118,8 +118,8 @@ fn _i16ord_to_f16(ord_i16: i16) -> f16 {
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
+    all(target_arch = "arm", feature = "nightly_simd"),
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 const MAX_INDEX: usize = i16::MAX as usize;
 

--- a/src/simd/simd_f16_ignore_nan.rs
+++ b/src/simd/simd_f16_ignore_nan.rs
@@ -753,8 +753,8 @@ mod neon_ignore_nan {
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 #[cfg(test)]
 mod tests {

--- a/src/simd/simd_f16_ignore_nan.rs
+++ b/src/simd/simd_f16_ignore_nan.rs
@@ -25,17 +25,37 @@
 /// Note that most x86 CPUs do not support f16 instructions - making this implementation
 /// multitudes (up to 300x) faster than trying to use a vanilla scalar implementation.
 ///
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+))]
 use super::config::SIMDInstructionSet;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+))]
 use super::generic::{
     impl_SIMDArgMinMax, impl_SIMDInit_FloatIgnoreNaN, SIMDArgMinMax, SIMDInit, SIMDOps,
 };
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+))]
 use crate::SCALAR;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+))]
 use num_traits::Zero;
-#[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
+#[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 #[cfg(all(target_arch = "arm", feature = "nightly_simd"))]
 use std::arch::arm::*;
@@ -44,28 +64,63 @@ use std::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+))]
 use half::f16;
 
 /// The dtype-strategy for performing operations on f16 data: ignore NaN values
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+))]
 use super::super::dtype_strategy::FloatIgnoreNaN;
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+))]
 const BIT_SHIFT: i32 = 15;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+))]
 const MASK_VALUE: i16 = 0x7FFF; // i16::MAX - masks everything but the sign bit
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+))]
 const NAN_VALUE: i16 = 0x7C00; // absolute values above this are NaN
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+))]
 #[inline(always)]
 fn _i16ord_to_f16(ord_i16: i16) -> f16 {
     let v = ((ord_i16 >> BIT_SHIFT) & MASK_VALUE) ^ ord_i16;
     f16::from_bits(v as u16)
 }
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+))]
 const MAX_INDEX: usize = i16::MAX as usize;
 
 // --------------------------------------- AVX2 ----------------------------------------
@@ -545,8 +600,10 @@ mod avx512_ignore_nan {
 
 // --------------------------------------- NEON ----------------------------------------
 
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-#[cfg(feature = "nightly_simd")]
+#[cfg(any(
+    all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64" // stable for AArch64
+))]
 mod neon_ignore_nan {
     use super::super::config::NEON;
     use super::*;
@@ -697,7 +754,7 @@ mod neon_ignore_nan {
     target_arch = "x86",
     target_arch = "x86_64",
     all(target_arch = "arm", feature = "nightly_simd"),
-    all(target_arch = "aarch64", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 #[cfg(test)]
 mod tests {

--- a/src/simd/simd_f16_return_nan.rs
+++ b/src/simd/simd_f16_return_nan.rs
@@ -30,22 +30,22 @@
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
+    all(target_arch = "arm", feature = "nightly_simd"),
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 use super::config::SIMDInstructionSet;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
+    all(target_arch = "arm", feature = "nightly_simd"),
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 use super::generic::{impl_SIMDInit_FloatReturnNaN, SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
+    all(target_arch = "arm", feature = "nightly_simd"),
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
@@ -60,8 +60,8 @@ use std::arch::x86_64::*;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
+    all(target_arch = "arm", feature = "nightly_simd"),
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 use half::f16;
 
@@ -69,31 +69,31 @@ use half::f16;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
+    all(target_arch = "arm", feature = "nightly_simd"),
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 use super::super::dtype_strategy::FloatReturnNaN;
 
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
+    all(target_arch = "arm", feature = "nightly_simd"),
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 const BIT_SHIFT: i32 = 15;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
+    all(target_arch = "arm", feature = "nightly_simd"),
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 const MASK_VALUE: i16 = 0x7FFF; // i16::MAX - masks everything but the sign bit
 
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
+    all(target_arch = "arm", feature = "nightly_simd"),
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 #[inline(always)]
 fn _i16ord_to_f16(ord_i16: i16) -> f16 {
@@ -104,8 +104,8 @@ fn _i16ord_to_f16(ord_i16: i16) -> f16 {
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
+    all(target_arch = "arm", feature = "nightly_simd"),
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 const MAX_INDEX: usize = i16::MAX as usize;
 

--- a/src/simd/simd_f16_return_nan.rs
+++ b/src/simd/simd_f16_return_nan.rs
@@ -704,8 +704,8 @@ mod neon {
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 #[cfg(test)]
 mod tests {

--- a/src/simd/simd_f16_return_nan.rs
+++ b/src/simd/simd_f16_return_nan.rs
@@ -31,21 +31,21 @@
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 use super::config::SIMDInstructionSet;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 use super::generic::{impl_SIMDInit_FloatReturnNaN, SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
@@ -61,7 +61,7 @@ use std::arch::x86_64::*;
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 use half::f16;
 
@@ -70,7 +70,7 @@ use half::f16;
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 use super::super::dtype_strategy::FloatReturnNaN;
 
@@ -78,14 +78,14 @@ use super::super::dtype_strategy::FloatReturnNaN;
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 const BIT_SHIFT: i32 = 15;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 const MASK_VALUE: i16 = 0x7FFF; // i16::MAX - masks everything but the sign bit
 
@@ -93,7 +93,7 @@ const MASK_VALUE: i16 = 0x7FFF; // i16::MAX - masks everything but the sign bit
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 #[inline(always)]
 fn _i16ord_to_f16(ord_i16: i16) -> f16 {
@@ -105,7 +105,7 @@ fn _i16ord_to_f16(ord_i16: i16) -> f16 {
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 const MAX_INDEX: usize = i16::MAX as usize;
 
@@ -704,8 +704,8 @@ mod neon {
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    all(target_arch = "arm", feature = "nightly_simd"),
     target_arch = "aarch64",
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 #[cfg(test)]
 mod tests {

--- a/src/simd/simd_f16_return_nan.rs
+++ b/src/simd/simd_f16_return_nan.rs
@@ -27,13 +27,28 @@
 /// SIMDOps::_get_overflow_lane_size_limit() chunk of the data - which is not
 /// necessarily the index of the first NaN value.
 ///
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+))]
 use super::config::SIMDInstructionSet;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+))]
 use super::generic::{impl_SIMDInit_FloatReturnNaN, SIMDArgMinMax, SIMDInit, SIMDOps};
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+))]
 use crate::SCALAR;
-#[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
+#[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 #[cfg(all(target_arch = "arm", feature = "nightly_simd"))]
 use std::arch::arm::*;
@@ -42,26 +57,56 @@ use std::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+))]
 use half::f16;
 
 /// The dtype-strategy for performing operations on f16 data: return NaN index
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+))]
 use super::super::dtype_strategy::FloatReturnNaN;
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+))]
 const BIT_SHIFT: i32 = 15;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+))]
 const MASK_VALUE: i16 = 0x7FFF; // i16::MAX - masks everything but the sign bit
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+))]
 #[inline(always)]
 fn _i16ord_to_f16(ord_i16: i16) -> f16 {
     let v = ((ord_i16 >> BIT_SHIFT) & MASK_VALUE) ^ ord_i16;
     f16::from_bits(v as u16)
 }
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+))]
 const MAX_INDEX: usize = i16::MAX as usize;
 
 // --------------------------------------- AVX2 ----------------------------------------
@@ -513,8 +558,10 @@ mod avx512 {
 
 // --------------------------------------- NEON ----------------------------------------
 
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-#[cfg(feature = "nightly_simd")]
+#[cfg(any(
+    all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64" // stable for AArch64
+))]
 mod neon {
     use super::super::config::NEON;
     use super::*;
@@ -658,7 +705,7 @@ mod neon {
     target_arch = "x86",
     target_arch = "x86_64",
     all(target_arch = "arm", feature = "nightly_simd"),
-    all(target_arch = "aarch64", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 #[cfg(test)]
 mod tests {

--- a/src/simd/simd_f32_ignore_nan.rs
+++ b/src/simd/simd_f32_ignore_nan.rs
@@ -14,15 +14,15 @@
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use super::config::SIMDInstructionSet;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use super::generic::{
     impl_SIMDArgMinMax, impl_SIMDInit_FloatIgnoreNaN, SIMDArgMinMax, SIMDInit, SIMDOps,
@@ -30,15 +30,15 @@ use super::generic::{
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use crate::SCALAR;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use num_traits::Zero;
 #[cfg(target_arch = "aarch64")]
@@ -54,8 +54,8 @@ use std::arch::x86_64::*;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use super::super::dtype_strategy::FloatIgnoreNaN;
 
@@ -63,8 +63,8 @@ use super::super::dtype_strategy::FloatIgnoreNaN;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 const MAX_INDEX: usize = 1 << f32::MANTISSA_DIGITS;
 

--- a/src/simd/simd_f32_ignore_nan.rs
+++ b/src/simd/simd_f32_ignore_nan.rs
@@ -11,17 +11,37 @@
 /// As comparisons with NaN always return false, it is guaranteed that no NaN values
 /// are added to the accumulating SIMD register.
 ///
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use super::config::SIMDInstructionSet;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use super::generic::{
     impl_SIMDArgMinMax, impl_SIMDInit_FloatIgnoreNaN, SIMDArgMinMax, SIMDInit, SIMDOps,
 };
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use crate::SCALAR;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use num_traits::Zero;
-#[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
+#[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 #[cfg(all(target_arch = "arm", feature = "nightly_simd"))]
 use std::arch::arm::*;
@@ -31,11 +51,21 @@ use std::arch::x86::*;
 use std::arch::x86_64::*;
 
 /// The dtype-strategy for performing operations on f32 data: ignore NaN values
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use super::super::dtype_strategy::FloatIgnoreNaN;
 
 // https://stackoverflow.com/a/3793950
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 const MAX_INDEX: usize = 1 << f32::MANTISSA_DIGITS;
 
 // --------------------------------------- AVX2 ----------------------------------------
@@ -250,8 +280,10 @@ mod avx512_ignore_nan {
 
 // --------------------------------------- NEON ----------------------------------------
 
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-#[cfg(feature = "nightly_simd")]
+#[cfg(any(
+    all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64" // stable for AArch64
+))]
 mod neon_ignore_nan {
     use super::super::config::NEON;
     use super::*;
@@ -328,7 +360,7 @@ mod neon_ignore_nan {
     target_arch = "x86",
     target_arch = "x86_64",
     all(target_arch = "arm", feature = "nightly_simd"),
-    all(target_arch = "aarch64", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 #[cfg(test)]
 mod tests {

--- a/src/simd/simd_f32_ignore_nan.rs
+++ b/src/simd/simd_f32_ignore_nan.rs
@@ -15,14 +15,14 @@
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use super::config::SIMDInstructionSet;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use super::generic::{
     impl_SIMDArgMinMax, impl_SIMDInit_FloatIgnoreNaN, SIMDArgMinMax, SIMDInit, SIMDOps,
@@ -31,14 +31,14 @@ use super::generic::{
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use crate::SCALAR;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use num_traits::Zero;
 #[cfg(target_arch = "aarch64")]
@@ -55,7 +55,7 @@ use std::arch::x86_64::*;
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use super::super::dtype_strategy::FloatIgnoreNaN;
 
@@ -64,7 +64,7 @@ use super::super::dtype_strategy::FloatIgnoreNaN;
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 const MAX_INDEX: usize = 1 << f32::MANTISSA_DIGITS;
 

--- a/src/simd/simd_f32_return_nan.rs
+++ b/src/simd/simd_f32_return_nan.rs
@@ -31,22 +31,22 @@
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
+    all(target_arch = "arm", feature = "nightly_simd"),
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 use super::config::SIMDInstructionSet;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
+    all(target_arch = "arm", feature = "nightly_simd"),
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 use super::generic::{impl_SIMDInit_FloatReturnNaN, SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
+    all(target_arch = "arm", feature = "nightly_simd"),
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
@@ -62,24 +62,24 @@ use std::arch::x86_64::*;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
+    all(target_arch = "arm", feature = "nightly_simd"),
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 use super::super::dtype_strategy::FloatReturnNaN;
 
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
+    all(target_arch = "arm", feature = "nightly_simd"),
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 use super::task::{max_index_value, min_index_value};
 
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
+    all(target_arch = "arm", feature = "nightly_simd"),
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 const BIT_SHIFT: i32 = 31;
 #[cfg(any(
@@ -93,8 +93,8 @@ const MASK_VALUE: i32 = 0x7FFFFFFF; // i32::MAX - masks everything but the sign 
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
+    all(target_arch = "arm", feature = "nightly_simd"),
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 #[inline(always)]
 fn _i32ord_to_f32(ord_i32: i32) -> f32 {

--- a/src/simd/simd_f32_return_nan.rs
+++ b/src/simd/simd_f32_return_nan.rs
@@ -28,13 +28,28 @@
 /// SIMDOps::_get_overflow_lane_size_limit() chunk of the data - which is not
 /// necessarily the index of the first NaN value.
 ///
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use super::config::SIMDInstructionSet;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use super::generic::{impl_SIMDInit_FloatReturnNaN, SIMDArgMinMax, SIMDInit, SIMDOps};
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use crate::SCALAR;
-#[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
+#[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 #[cfg(all(target_arch = "arm", feature = "nightly_simd"))]
 use std::arch::arm::*;
@@ -44,25 +59,55 @@ use std::arch::x86::*;
 use std::arch::x86_64::*;
 
 /// The dtype-strategy for performing operations on f32 data: return NaN index
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use super::super::dtype_strategy::FloatReturnNaN;
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use super::task::{max_index_value, min_index_value};
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 const BIT_SHIFT: i32 = 31;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 const MASK_VALUE: i32 = 0x7FFFFFFF; // i32::MAX - masks everything but the sign bit
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 #[inline(always)]
 fn _i32ord_to_f32(ord_i32: i32) -> f32 {
     let v = ((ord_i32 >> BIT_SHIFT) & MASK_VALUE) ^ ord_i32;
     f32::from_bits(v as u32)
 }
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 const MAX_INDEX: usize = i32::MAX as usize;
 
 // --------------------------------------- AVX2 ----------------------------------------
@@ -371,8 +416,10 @@ mod avx512 {
 
 // --------------------------------------- NEON ----------------------------------------
 
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-#[cfg(feature = "nightly_simd")]
+#[cfg(any(
+    all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64" // stable for AArch64
+))]
 mod neon {
     use super::super::config::NEON;
     use super::*;
@@ -475,7 +522,7 @@ mod neon {
     target_arch = "x86",
     target_arch = "x86_64",
     all(target_arch = "arm", feature = "nightly_simd"),
-    all(target_arch = "aarch64", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 #[cfg(test)]
 mod tests {

--- a/src/simd/simd_f32_return_nan.rs
+++ b/src/simd/simd_f32_return_nan.rs
@@ -32,21 +32,21 @@
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 use super::config::SIMDInstructionSet;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 use super::generic::{impl_SIMDInit_FloatReturnNaN, SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
@@ -63,7 +63,7 @@ use std::arch::x86_64::*;
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 use super::super::dtype_strategy::FloatReturnNaN;
 
@@ -71,7 +71,7 @@ use super::super::dtype_strategy::FloatReturnNaN;
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 use super::task::{max_index_value, min_index_value};
 
@@ -79,14 +79,14 @@ use super::task::{max_index_value, min_index_value};
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 const BIT_SHIFT: i32 = 31;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 const MASK_VALUE: i32 = 0x7FFFFFFF; // i32::MAX - masks everything but the sign bit
 
@@ -94,7 +94,7 @@ const MASK_VALUE: i32 = 0x7FFFFFFF; // i32::MAX - masks everything but the sign 
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+    all(target_arch = "arm", feature = "nightly_simd")
 ))]
 #[inline(always)]
 fn _i32ord_to_f32(ord_i32: i32) -> f32 {
@@ -106,7 +106,7 @@ fn _i32ord_to_f32(ord_i32: i32) -> f32 {
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 const MAX_INDEX: usize = i32::MAX as usize;
 

--- a/src/simd/simd_f32_return_nan.rs
+++ b/src/simd/simd_f32_return_nan.rs
@@ -32,21 +32,21 @@
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
 ))]
 use super::config::SIMDInstructionSet;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
 ))]
 use super::generic::{impl_SIMDInit_FloatReturnNaN, SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
 ))]
 use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
@@ -63,7 +63,7 @@ use std::arch::x86_64::*;
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
 ))]
 use super::super::dtype_strategy::FloatReturnNaN;
 
@@ -71,7 +71,7 @@ use super::super::dtype_strategy::FloatReturnNaN;
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
 ))]
 use super::task::{max_index_value, min_index_value};
 
@@ -79,7 +79,7 @@ use super::task::{max_index_value, min_index_value};
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
 ))]
 const BIT_SHIFT: i32 = 31;
 #[cfg(any(
@@ -94,7 +94,7 @@ const MASK_VALUE: i32 = 0x7FFFFFFF; // i32::MAX - masks everything but the sign 
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
 ))]
 #[inline(always)]
 fn _i32ord_to_f32(ord_i32: i32) -> f32 {

--- a/src/simd/simd_f32_return_nan.rs
+++ b/src/simd/simd_f32_return_nan.rs
@@ -85,8 +85,8 @@ const BIT_SHIFT: i32 = 31;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 const MASK_VALUE: i32 = 0x7FFFFFFF; // i32::MAX - masks everything but the sign bit
 
@@ -105,8 +105,8 @@ fn _i32ord_to_f32(ord_i32: i32) -> f32 {
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 const MAX_INDEX: usize = i32::MAX as usize;
 

--- a/src/simd/simd_f64_ignore_nan.rs
+++ b/src/simd/simd_f64_ignore_nan.rs
@@ -20,14 +20,14 @@ use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_FloatIgnoreNaN};
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
 ))]
 use super::generic::{SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
 ))]
 use crate::SCALAR;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
@@ -44,7 +44,7 @@ use std::arch::x86_64::*;
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
 ))]
 use super::super::dtype_strategy::FloatIgnoreNaN;
 

--- a/src/simd/simd_f64_ignore_nan.rs
+++ b/src/simd/simd_f64_ignore_nan.rs
@@ -19,15 +19,15 @@ use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_FloatIgnoreNaN};
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use super::generic::{SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use crate::SCALAR;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
@@ -43,8 +43,8 @@ use std::arch::x86_64::*;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use super::super::dtype_strategy::FloatIgnoreNaN;
 

--- a/src/simd/simd_f64_ignore_nan.rs
+++ b/src/simd/simd_f64_ignore_nan.rs
@@ -20,14 +20,14 @@ use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_FloatIgnoreNaN};
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use super::generic::{SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use crate::SCALAR;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
@@ -44,7 +44,7 @@ use std::arch::x86_64::*;
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use super::super::dtype_strategy::FloatIgnoreNaN;
 

--- a/src/simd/simd_f64_ignore_nan.rs
+++ b/src/simd/simd_f64_ignore_nan.rs
@@ -280,7 +280,7 @@ mod neon_ignore_nan {
     unimpl_SIMDArgMinMax!(f64, usize, SCALAR<FloatIgnoreNaN>, NEON<FloatIgnoreNaN>);
 }
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(target_arch = "aarch64")] // stable for AArch64
 mod neon_ignore_nan {
     use super::super::config::NEON;
     use super::*;

--- a/src/simd/simd_f64_return_nan.rs
+++ b/src/simd/simd_f64_return_nan.rs
@@ -29,23 +29,25 @@
 /// necessarily the index of the first NaN value.
 ///
 
-#[cfg(any(
-    target_arch = "x86",
-    target_arch = "x86_64",
-    all(target_arch = "aarch64", feature = "nightly_simd")
-))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
 use super::config::SIMDInstructionSet;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
+use super::generic::impl_SIMDInit_FloatReturnNaN;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    all(target_arch = "aarch64", feature = "nightly_simd")
+    target_arch = "aarch64",
+    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
 ))]
-use super::generic::impl_SIMDInit_FloatReturnNaN;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use super::generic::{SIMDArgMinMax, SIMDInit, SIMDOps};
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+))]
 use crate::SCALAR;
-#[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
+#[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;
@@ -53,45 +55,30 @@ use std::arch::x86::*;
 use std::arch::x86_64::*;
 
 /// The dtype-strategy for performing operations on f64 data: return NaN index
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+))]
 use super::super::dtype_strategy::FloatReturnNaN;
 
-#[cfg(any(
-    target_arch = "x86",
-    target_arch = "x86_64",
-    all(target_arch = "aarch64", feature = "nightly_simd")
-))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
 use super::task::{max_index_value, min_index_value};
 
-#[cfg(any(
-    target_arch = "x86",
-    target_arch = "x86_64",
-    all(target_arch = "aarch64", feature = "nightly_simd")
-))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
 const BIT_SHIFT: i32 = 63;
-#[cfg(any(
-    target_arch = "x86",
-    target_arch = "x86_64",
-    all(target_arch = "aarch64", feature = "nightly_simd")
-))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
 const MASK_VALUE: i64 = 0x7FFFFFFFFFFFFFFF; // i64::MAX - masks everything but the sign bit
 
-#[cfg(any(
-    target_arch = "x86",
-    target_arch = "x86_64",
-    all(target_arch = "aarch64", feature = "nightly_simd")
-))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
 #[inline(always)]
 fn _i64ord_to_f64(ord_i64: i64) -> f64 {
     let v = ((ord_i64 >> BIT_SHIFT) & MASK_VALUE) ^ ord_i64;
     f64::from_bits(v as u64)
 }
 
-#[cfg(any(
-    target_arch = "x86",
-    target_arch = "x86_64",
-    all(target_arch = "aarch64", feature = "nightly_simd")
-))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
 const MAX_INDEX: usize = i64::MAX as usize;
 
 // --------------------------------------- AVX2 ----------------------------------------
@@ -424,7 +411,6 @@ mod neon {
 }
 
 #[cfg(target_arch = "aarch64")]
-#[cfg(feature = "nightly_simd")]
 mod neon {
     use super::super::config::NEON;
     use super::*;
@@ -523,11 +509,7 @@ mod neon {
 
 // ======================================= TESTS =======================================
 
-#[cfg(any(
-    target_arch = "x86",
-    target_arch = "x86_64",
-    all(target_arch = "aarch64", feature = "nightly_simd")
-))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
 #[cfg(test)]
 mod tests {
     use rstest::rstest;

--- a/src/simd/simd_f64_return_nan.rs
+++ b/src/simd/simd_f64_return_nan.rs
@@ -37,14 +37,14 @@ use super::generic::impl_SIMDInit_FloatReturnNaN;
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use super::generic::{SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
@@ -59,7 +59,7 @@ use std::arch::x86_64::*;
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    all(target_arch = "arm", feature = "nightly_simd") // TODO: all like this?
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use super::super::dtype_strategy::FloatReturnNaN;
 

--- a/src/simd/simd_f64_return_nan.rs
+++ b/src/simd/simd_f64_return_nan.rs
@@ -392,7 +392,7 @@ mod avx512 {
 
 // There are NEON SIMD intrinsics for i64 (used after ord_transform), but
 //  - for arm we miss the vcgt_ and vclt_ intrinsics.
-//  - for aarch64 the required intrinsics are present (on nightly)
+//  - for aarch64 the required intrinsics are present (on stable!!)
 
 #[cfg(target_arch = "arm")]
 #[cfg(feature = "nightly_simd")]
@@ -410,7 +410,7 @@ mod neon {
     unimpl_SIMDArgMinMax!(f64, usize, SCALAR<FloatReturnNaN>, NEON<FloatReturnNaN>);
 }
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(target_arch = "aarch64")] // stable for AArch64
 mod neon {
     use super::super::config::NEON;
     use super::*;

--- a/src/simd/simd_f64_return_nan.rs
+++ b/src/simd/simd_f64_return_nan.rs
@@ -36,15 +36,15 @@ use super::generic::impl_SIMDInit_FloatReturnNaN;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use super::generic::{SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
@@ -58,8 +58,8 @@ use std::arch::x86_64::*;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use super::super::dtype_strategy::FloatReturnNaN;
 

--- a/src/simd/simd_i16.rs
+++ b/src/simd/simd_i16.rs
@@ -1,22 +1,22 @@
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use super::config::SIMDInstructionSet;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
@@ -32,16 +32,16 @@ use std::arch::x86_64::*;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use super::super::dtype_strategy::Int;
 
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 const MAX_INDEX: usize = i16::MAX as usize;
 

--- a/src/simd/simd_i16.rs
+++ b/src/simd/simd_i16.rs
@@ -1,8 +1,23 @@
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use super::config::SIMDInstructionSet;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
@@ -14,10 +29,20 @@ use std::arch::x86::*;
 use std::arch::x86_64::*;
 
 /// The dtype-strategy for performing operations on i16 data: (default) Int
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use super::super::dtype_strategy::Int;
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 const MAX_INDEX: usize = i16::MAX as usize;
 
 // --------------------------------------- AVX2 ----------------------------------------
@@ -394,7 +419,7 @@ mod avx512 {
 
 #[cfg(any(
     all(target_arch = "arm", feature = "nightly_simd"),
-    target_arch = "aarch64"
+    target_arch = "aarch64"  // stable for AArch64
 ))]
 mod neon {
     use super::super::config::NEON;

--- a/src/simd/simd_i16.rs
+++ b/src/simd/simd_i16.rs
@@ -4,7 +4,7 @@ use super::config::SIMDInstructionSet;
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
 use crate::SCALAR;
-#[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
+#[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 #[cfg(all(target_arch = "arm", feature = "nightly_simd"))]
 use std::arch::arm::*;
@@ -392,8 +392,10 @@ mod avx512 {
 
 // --------------------------------------- NEON ----------------------------------------
 
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-#[cfg(feature = "nightly_simd")]
+#[cfg(any(
+    all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64"
+))]
 mod neon {
     use super::super::config::NEON;
     use super::*;
@@ -414,6 +416,7 @@ mod neon {
 
         #[inline(always)]
         unsafe fn _mm_loadu(data: *const i16) -> int16x8_t {
+            // experimental on arm
             vld1q_s16(data as *const i16)
         }
 
@@ -513,7 +516,7 @@ mod neon {
     target_arch = "x86",
     target_arch = "x86_64",
     all(target_arch = "arm", feature = "nightly_simd"),
-    all(target_arch = "aarch64", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 #[cfg(test)]
 mod tests {

--- a/src/simd/simd_i16.rs
+++ b/src/simd/simd_i16.rs
@@ -441,7 +441,6 @@ mod neon {
 
         #[inline(always)]
         unsafe fn _mm_loadu(data: *const i16) -> int16x8_t {
-            // experimental on arm
             vld1q_s16(data as *const i16)
         }
 

--- a/src/simd/simd_i16.rs
+++ b/src/simd/simd_i16.rs
@@ -2,21 +2,21 @@
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use super::config::SIMDInstructionSet;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
@@ -33,7 +33,7 @@ use std::arch::x86_64::*;
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use super::super::dtype_strategy::Int;
 
@@ -41,7 +41,7 @@ use super::super::dtype_strategy::Int;
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 const MAX_INDEX: usize = i16::MAX as usize;
 

--- a/src/simd/simd_i16.rs
+++ b/src/simd/simd_i16.rs
@@ -419,7 +419,7 @@ mod avx512 {
 
 #[cfg(any(
     all(target_arch = "arm", feature = "nightly_simd"),
-    target_arch = "aarch64"  // stable for AArch64
+    target_arch = "aarch64" // stable for AArch64
 ))]
 mod neon {
     use super::super::config::NEON;

--- a/src/simd/simd_i32.rs
+++ b/src/simd/simd_i32.rs
@@ -2,21 +2,21 @@
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use super::config::SIMDInstructionSet;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
@@ -33,7 +33,7 @@ use std::arch::x86_64::*;
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use super::super::dtype_strategy::Int;
 
@@ -41,7 +41,7 @@ use super::super::dtype_strategy::Int;
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 const MAX_INDEX: usize = i32::MAX as usize;
 

--- a/src/simd/simd_i32.rs
+++ b/src/simd/simd_i32.rs
@@ -1,10 +1,25 @@
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use super::config::SIMDInstructionSet;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use crate::SCALAR;
-#[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
+#[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 #[cfg(all(target_arch = "arm", feature = "nightly_simd"))]
 use std::arch::arm::*;
@@ -14,10 +29,20 @@ use std::arch::x86::*;
 use std::arch::x86_64::*;
 
 /// The dtype-strategy for performing operations on i32 data: (default) Int
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use super::super::dtype_strategy::Int;
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 const MAX_INDEX: usize = i32::MAX as usize;
 
 // --------------------------------------- AVX2 ----------------------------------------
@@ -206,8 +231,10 @@ mod avx512 {
 
 // --------------------------------------- NEON ----------------------------------------
 
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-#[cfg(feature = "nightly_simd")]
+#[cfg(any(
+    all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64"  // stable for AArch64
+))]
 mod neon {
     use super::super::config::NEON;
     use super::*;
@@ -270,7 +297,7 @@ mod neon {
     target_arch = "x86",
     target_arch = "x86_64",
     all(target_arch = "arm", feature = "nightly_simd"),
-    all(target_arch = "aarch64", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 #[cfg(test)]
 mod tests {

--- a/src/simd/simd_i32.rs
+++ b/src/simd/simd_i32.rs
@@ -1,22 +1,22 @@
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use super::config::SIMDInstructionSet;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
@@ -32,16 +32,16 @@ use std::arch::x86_64::*;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use super::super::dtype_strategy::Int;
 
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 const MAX_INDEX: usize = i32::MAX as usize;
 

--- a/src/simd/simd_i32.rs
+++ b/src/simd/simd_i32.rs
@@ -233,7 +233,7 @@ mod avx512 {
 
 #[cfg(any(
     all(target_arch = "arm", feature = "nightly_simd"),
-    target_arch = "aarch64"  // stable for AArch64
+    target_arch = "aarch64" // stable for AArch64
 ))]
 mod neon {
     use super::super::config::NEON;

--- a/src/simd/simd_i64.rs
+++ b/src/simd/simd_i64.rs
@@ -5,15 +5,15 @@ use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int};
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use super::generic::{SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
@@ -27,8 +27,8 @@ use std::arch::x86_64::*;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use super::super::dtype_strategy::Int;
 

--- a/src/simd/simd_i64.rs
+++ b/src/simd/simd_i64.rs
@@ -2,9 +2,19 @@
 use super::config::SIMDInstructionSet;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int};
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use super::generic::{SIMDArgMinMax, SIMDInit, SIMDOps};
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
@@ -14,7 +24,12 @@ use std::arch::x86::*;
 use std::arch::x86_64::*;
 
 /// The dtype-strategy for performing operations on i64 data: (default) Int
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use super::super::dtype_strategy::Int;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]

--- a/src/simd/simd_i64.rs
+++ b/src/simd/simd_i64.rs
@@ -6,14 +6,14 @@ use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int};
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use super::generic::{SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
@@ -28,7 +28,7 @@ use std::arch::x86_64::*;
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use super::super::dtype_strategy::Int;
 

--- a/src/simd/simd_i64.rs
+++ b/src/simd/simd_i64.rs
@@ -1,20 +1,12 @@
-#[cfg(any(
-    target_arch = "x86",
-    target_arch = "x86_64",
-    all(target_arch = "aarch64", feature = "nightly_simd")
-))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
 use super::config::SIMDInstructionSet;
-#[cfg(any(
-    target_arch = "x86",
-    target_arch = "x86_64",
-    all(target_arch = "aarch64", feature = "nightly_simd")
-))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int};
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
 use super::generic::{SIMDArgMinMax, SIMDInit, SIMDOps};
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
 use crate::SCALAR;
-#[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
+#[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;
@@ -22,14 +14,10 @@ use std::arch::x86::*;
 use std::arch::x86_64::*;
 
 /// The dtype-strategy for performing operations on i64 data: (default) Int
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
 use super::super::dtype_strategy::Int;
 
-#[cfg(any(
-    target_arch = "x86",
-    target_arch = "x86_64",
-    all(target_arch = "aarch64", feature = "nightly_simd")
-))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
 const MAX_INDEX: usize = i64::MAX as usize;
 
 // --------------------------------------- AVX2 ----------------------------------------
@@ -234,7 +222,6 @@ mod neon {
 }
 
 #[cfg(target_arch = "aarch64")]
-#[cfg(feature = "nightly_simd")]
 mod neon {
     use super::super::config::NEON;
     use super::*;
@@ -293,11 +280,7 @@ mod neon {
 
 // ======================================= TESTS =======================================
 
-#[cfg(any(
-    target_arch = "x86",
-    target_arch = "x86_64",
-    all(target_arch = "aarch64", feature = "nightly_simd"),
-))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
 #[cfg(test)]
 mod tests {
     use rstest::rstest;

--- a/src/simd/simd_i64.rs
+++ b/src/simd/simd_i64.rs
@@ -221,7 +221,7 @@ mod neon {
     unimpl_SIMDArgMinMax!(i64, usize, SCALAR<Int>, NEON<Int>);
 }
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(target_arch = "aarch64")] // stable for AArch64
 mod neon {
     use super::super::config::NEON;
     use super::*;

--- a/src/simd/simd_i8.rs
+++ b/src/simd/simd_i8.rs
@@ -2,21 +2,21 @@
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use super::config::SIMDInstructionSet;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
@@ -33,7 +33,7 @@ use std::arch::x86_64::*;
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use super::super::dtype_strategy::Int;
 
@@ -41,7 +41,7 @@ use super::super::dtype_strategy::Int;
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 const MAX_INDEX: usize = i8::MAX as usize;
 

--- a/src/simd/simd_i8.rs
+++ b/src/simd/simd_i8.rs
@@ -437,7 +437,7 @@ mod avx512 {
 
 #[cfg(any(
     all(target_arch = "arm", feature = "nightly_simd"),
-    target_arch = "aarch64"  // stable for AArch64
+    target_arch = "aarch64" // stable for AArch64
 ))]
 mod neon {
     use super::super::config::NEON;

--- a/src/simd/simd_i8.rs
+++ b/src/simd/simd_i8.rs
@@ -1,10 +1,25 @@
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use super::config::SIMDInstructionSet;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use crate::SCALAR;
-#[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
+#[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 #[cfg(all(target_arch = "arm", feature = "nightly_simd"))]
 use std::arch::arm::*;
@@ -14,10 +29,20 @@ use std::arch::x86::*;
 use std::arch::x86_64::*;
 
 /// The dtype-strategy for performing operations on i8 data: (default) Int
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use super::super::dtype_strategy::Int;
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 const MAX_INDEX: usize = i8::MAX as usize;
 
 // --------------------------------------- AVX2 ----------------------------------------
@@ -410,8 +435,10 @@ mod avx512 {
 
 // --------------------------------------- NEON ----------------------------------------
 
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-#[cfg(feature = "nightly_simd")]
+#[cfg(any(
+    all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64"  // stable for AArch64
+))]
 mod neon {
     use super::super::config::NEON;
     use super::*;
@@ -540,7 +567,7 @@ mod neon {
     target_arch = "x86",
     target_arch = "x86_64",
     all(target_arch = "arm", feature = "nightly_simd"),
-    all(target_arch = "aarch64", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 #[cfg(test)]
 mod tests {

--- a/src/simd/simd_i8.rs
+++ b/src/simd/simd_i8.rs
@@ -1,22 +1,22 @@
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use super::config::SIMDInstructionSet;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
@@ -32,16 +32,16 @@ use std::arch::x86_64::*;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use super::super::dtype_strategy::Int;
 
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 const MAX_INDEX: usize = i8::MAX as usize;
 

--- a/src/simd/simd_u16.rs
+++ b/src/simd/simd_u16.rs
@@ -14,21 +14,21 @@
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use super::config::SIMDInstructionSet;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
@@ -45,7 +45,7 @@ use std::arch::x86_64::*;
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use super::super::dtype_strategy::Int;
 

--- a/src/simd/simd_u16.rs
+++ b/src/simd/simd_u16.rs
@@ -13,22 +13,22 @@
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use super::config::SIMDInstructionSet;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
@@ -44,8 +44,8 @@ use std::arch::x86_64::*;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use super::super::dtype_strategy::Int;
 

--- a/src/simd/simd_u16.rs
+++ b/src/simd/simd_u16.rs
@@ -489,7 +489,7 @@ mod avx512 {
 
 #[cfg(any(
     all(target_arch = "arm", feature = "nightly_simd"),
-    target_arch = "aarch64"  // stable for AArch64
+    target_arch = "aarch64" // stable for AArch64
 ))]
 mod neon {
     use super::super::config::NEON;

--- a/src/simd/simd_u16.rs
+++ b/src/simd/simd_u16.rs
@@ -10,13 +10,28 @@
 /// the ordinal integer values and then transform the result back to the original u16
 /// values.
 ///
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use super::config::SIMDInstructionSet;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use crate::SCALAR;
-#[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
+#[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 #[cfg(all(target_arch = "arm", feature = "nightly_simd"))]
 use std::arch::arm::*;
@@ -26,7 +41,12 @@ use std::arch::x86::*;
 use std::arch::x86_64::*;
 
 /// The dtype-strategy for performing operations on u16 data: (default) Int
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use super::super::dtype_strategy::Int;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -41,8 +61,10 @@ fn _i16ord_to_u16(ord_i16: i16) -> u16 {
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 const MAX_INDEX: usize = i16::MAX as usize; // SIMD operations on signed ints
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-#[cfg(feature = "nightly_simd")]
+#[cfg(any(
+    all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64"
+))]
 const MAX_INDEX: usize = u8::MAX as usize; // SIMD operations on unsigned ints
 
 // --------------------------------------- AVX2 ----------------------------------------
@@ -465,8 +487,10 @@ mod avx512 {
 
 // --------------------------------------- NEON ----------------------------------------
 
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-#[cfg(feature = "nightly_simd")]
+#[cfg(any(
+    all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64"  // stable for AArch64
+))]
 mod neon {
     use super::super::config::NEON;
     use super::*;
@@ -586,7 +610,7 @@ mod neon {
     target_arch = "x86",
     target_arch = "x86_64",
     all(target_arch = "arm", feature = "nightly_simd"),
-    all(target_arch = "aarch64", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 #[cfg(test)]
 mod tests {

--- a/src/simd/simd_u32.rs
+++ b/src/simd/simd_u32.rs
@@ -14,21 +14,21 @@
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use super::config::SIMDInstructionSet;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
@@ -45,7 +45,7 @@ use std::arch::x86_64::*;
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use super::super::dtype_strategy::Int;
 

--- a/src/simd/simd_u32.rs
+++ b/src/simd/simd_u32.rs
@@ -13,22 +13,22 @@
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use super::config::SIMDInstructionSet;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
@@ -44,8 +44,8 @@ use std::arch::x86_64::*;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use super::super::dtype_strategy::Int;
 

--- a/src/simd/simd_u32.rs
+++ b/src/simd/simd_u32.rs
@@ -10,13 +10,28 @@
 /// the ordinal integer values and then transform the result back to the original u32
 /// values.
 ///
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use super::config::SIMDInstructionSet;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use crate::SCALAR;
-#[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
+#[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 #[cfg(all(target_arch = "arm", feature = "nightly_simd"))]
 use std::arch::arm::*;
@@ -26,7 +41,12 @@ use std::arch::x86::*;
 use std::arch::x86_64::*;
 
 /// The dtype-strategy for performing operations on u32 data: (default) Int
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use super::super::dtype_strategy::Int;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -44,8 +64,10 @@ fn _i32ord_to_u32(ord_i32: i32) -> u32 {
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 const MAX_INDEX: usize = i32::MAX as usize; // SIMD operations on signed ints
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-#[cfg(feature = "nightly_simd")]
+#[cfg(any(
+    all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64"
+))]
 const MAX_INDEX: usize = u8::MAX as usize; // SIMD operations on unsigned ints
 
 // --------------------------------------- AVX2 ----------------------------------------
@@ -330,8 +352,10 @@ mod avx512 {
 
 // --------------------------------------- NEON ----------------------------------------
 
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-#[cfg(feature = "nightly_simd")]
+#[cfg(any(
+    all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64"  // stable for AArch64
+))]
 mod neon {
     use super::super::config::NEON;
     use super::*;
@@ -394,7 +418,7 @@ mod neon {
     target_arch = "x86",
     target_arch = "x86_64",
     all(target_arch = "arm", feature = "nightly_simd"),
-    all(target_arch = "aarch64", feature = "nightly_simd"),
+    target_arch = "aarch64"
 ))]
 #[cfg(test)]
 mod tests {

--- a/src/simd/simd_u32.rs
+++ b/src/simd/simd_u32.rs
@@ -354,7 +354,7 @@ mod avx512 {
 
 #[cfg(any(
     all(target_arch = "arm", feature = "nightly_simd"),
-    target_arch = "aarch64"  // stable for AArch64
+    target_arch = "aarch64" // stable for AArch64
 ))]
 mod neon {
     use super::super::config::NEON;

--- a/src/simd/simd_u64.rs
+++ b/src/simd/simd_u64.rs
@@ -15,9 +15,19 @@
 use super::config::SIMDInstructionSet;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int};
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use super::generic::{SIMDArgMinMax, SIMDInit, SIMDOps};
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
@@ -27,7 +37,12 @@ use std::arch::x86::*;
 use std::arch::x86_64::*;
 
 /// The dtype-strategy for performing operations on u64 data: (default) Int
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use super::super::dtype_strategy::Int;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]

--- a/src/simd/simd_u64.rs
+++ b/src/simd/simd_u64.rs
@@ -18,15 +18,15 @@ use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int};
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use super::generic::{SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
@@ -40,8 +40,8 @@ use std::arch::x86_64::*;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use super::super::dtype_strategy::Int;
 

--- a/src/simd/simd_u64.rs
+++ b/src/simd/simd_u64.rs
@@ -345,7 +345,7 @@ mod neon {
     unimpl_SIMDArgMinMax!(u64, usize, SCALAR<Int>, NEON<Int>);
 }
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(target_arch = "aarch64")] // stable for AArch64
 mod neon {
     use super::super::config::NEON;
     use super::*;

--- a/src/simd/simd_u64.rs
+++ b/src/simd/simd_u64.rs
@@ -19,14 +19,14 @@ use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int};
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use super::generic::{SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
@@ -41,7 +41,7 @@ use std::arch::x86_64::*;
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use super::super::dtype_strategy::Int;
 

--- a/src/simd/simd_u64.rs
+++ b/src/simd/simd_u64.rs
@@ -11,23 +11,15 @@
 /// values.
 ///
 
-#[cfg(any(
-    target_arch = "x86",
-    target_arch = "x86_64",
-    all(target_arch = "aarch64", feature = "nightly_simd")
-))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
 use super::config::SIMDInstructionSet;
-#[cfg(any(
-    target_arch = "x86",
-    target_arch = "x86_64",
-    all(target_arch = "aarch64", feature = "nightly_simd")
-))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int};
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
 use super::generic::{SIMDArgMinMax, SIMDInit, SIMDOps};
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
 use crate::SCALAR;
-#[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
+#[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;
@@ -35,7 +27,7 @@ use std::arch::x86::*;
 use std::arch::x86_64::*;
 
 /// The dtype-strategy for performing operations on u64 data: (default) Int
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
 use super::super::dtype_strategy::Int;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -53,7 +45,7 @@ fn _i64ord_to_u64(ord_i64: i64) -> u64 {
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64",))]
 const MAX_INDEX: usize = i64::MAX as usize; // SIMD operations on signed ints
-#[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
+#[cfg(target_arch = "aarch64")]
 const MAX_INDEX: usize = u64::MAX as usize; // SIMD operations on unsigned ints
 
 // --------------------------------------- AVX2 ----------------------------------------
@@ -354,7 +346,6 @@ mod neon {
 }
 
 #[cfg(target_arch = "aarch64")]
-#[cfg(feature = "nightly_simd")]
 mod neon {
     use super::super::config::NEON;
     use super::*;
@@ -413,11 +404,7 @@ mod neon {
 
 // ======================================= TESTS =======================================
 
-#[cfg(any(
-    target_arch = "x86",
-    target_arch = "x86_64",
-    all(target_arch = "aarch64", feature = "nightly_simd"),
-))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
 #[cfg(test)]
 mod tests {
     use rstest::rstest;

--- a/src/simd/simd_u8.rs
+++ b/src/simd/simd_u8.rs
@@ -14,21 +14,21 @@
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use super::config::SIMDInstructionSet;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
@@ -45,7 +45,7 @@ use std::arch::x86_64::*;
     target_arch = "x86",
     target_arch = "x86_64",
     target_arch = "aarch64",
-    feature = "nightly_simd"
+    all(target_arch = "arm", feature = "nightly_simd"),
 ))]
 use super::super::dtype_strategy::Int;
 

--- a/src/simd/simd_u8.rs
+++ b/src/simd/simd_u8.rs
@@ -13,22 +13,22 @@
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use super::config::SIMDInstructionSet;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use crate::SCALAR;
 #[cfg(target_arch = "aarch64")]
@@ -44,8 +44,8 @@ use std::arch::x86_64::*;
 #[cfg(any(
     target_arch = "x86",
     target_arch = "x86_64",
-    target_arch = "aarch64",
     all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 use super::super::dtype_strategy::Int;
 

--- a/src/simd/simd_u8.rs
+++ b/src/simd/simd_u8.rs
@@ -508,7 +508,7 @@ mod avx512 {
 
 #[cfg(any(
     all(target_arch = "arm", feature = "nightly_simd"),
-    target_arch = "aarch64"  // stable for AArch64
+    target_arch = "aarch64" // stable for AArch64
 ))]
 mod neon {
     use super::super::config::NEON;

--- a/src/simd/simd_u8.rs
+++ b/src/simd/simd_u8.rs
@@ -10,13 +10,28 @@
 /// the ordinal integer values and then transform the result back to the original u8
 /// values.
 ///
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use super::config::SIMDInstructionSet;
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use super::generic::{impl_SIMDArgMinMax, impl_SIMDInit_Int, SIMDArgMinMax, SIMDInit, SIMDOps};
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use crate::SCALAR;
-#[cfg(all(target_arch = "aarch64", feature = "nightly_simd"))]
+#[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 #[cfg(all(target_arch = "arm", feature = "nightly_simd"))]
 use std::arch::arm::*;
@@ -26,7 +41,12 @@ use std::arch::x86::*;
 use std::arch::x86_64::*;
 
 /// The dtype-strategy for performing operations on u8 data: (default) Int
-#[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "nightly_simd"))]
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    feature = "nightly_simd"
+))]
 use super::super::dtype_strategy::Int;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -41,8 +61,10 @@ fn _i8ord_to_u8(ord_i8: i8) -> u8 {
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 const MAX_INDEX: usize = i8::MAX as usize; // SIMD operations on signed ints
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-#[cfg(feature = "nightly_simd")]
+#[cfg(any(
+    all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64"
+))]
 const MAX_INDEX: usize = u8::MAX as usize; // SIMD operations on unsigned ints
 
 // --------------------------------------- AVX2 ----------------------------------------
@@ -484,8 +506,10 @@ mod avx512 {
 
 // --------------------------------------- NEON ----------------------------------------
 
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-#[cfg(feature = "nightly_simd")]
+#[cfg(any(
+    all(target_arch = "arm", feature = "nightly_simd"),
+    target_arch = "aarch64"  // stable for AArch64
+))]
 mod neon {
     use super::super::config::NEON;
     use super::*;
@@ -613,7 +637,7 @@ mod neon {
     target_arch = "x86",
     target_arch = "x86_64",
     all(target_arch = "arm", feature = "nightly_simd"),
-    all(target_arch = "aarch64", feature = "nightly_simd"),
+    target_arch = "aarch64",
 ))]
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
:hourglass_flowing_sand: I'll work further on this once I get my hands on a rpi4 (because checking my code oon AArch64 with github ci-cd is not that convenient :upside_down_face: :upside_down_face:)